### PR TITLE
Changing the telescope names patterns

### DIFF
--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -21,6 +21,7 @@ import simtools.io_handler as io
 from simtools import visualize
 from simtools.util import names
 from simtools.util.general import collectArguments
+from simtools.util.model import getCameraName
 from simtools.model.telescope_model import TelescopeModel
 from simtools.model.model_parameters import CAMERA_RADIUS_CURV
 
@@ -197,13 +198,16 @@ class CameraEfficiency:
             )
             mirrorReflectivity = 'ref_astri_2017-06_T0.dat'
 
+        # Camera name
+        cameraName = getCameraName(self._telescopeModel.telescopeName)
+
         # cmd -> Command to be run at the shell
         cmd = str(self._simtelSourcePath.joinpath('sim_telarray/bin/testeff'))
         cmd += ' -nm -nsb-extra'
         cmd += ' -alt {}'.format(self._telescopeModel.getParameter('altitude'))
         cmd += ' -fatm {}'.format(self._telescopeModel.getParameter('atmospheric_transmission'))
         cmd += ' -flen {}'.format(focalLength * 0.01)  # focal lenght in meters
-        cmd += ' -fcur {}'.format(CAMERA_RADIUS_CURV[self._telescopeModel.telescopeName]) # fix it
+        cmd += ' -fcur {}'.format(CAMERA_RADIUS_CURV[cameraName])
         cmd += ' {} {}'.format(pixelShapeCmd, pixelDiameter)
         if mirrorClass == 1:
             cmd += ' -fmir {}'.format(self._telescopeModel.getParameter('mirror_list'))

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -119,21 +119,21 @@ class CameraEfficiency:
         ''' Define the variables for the file names, including the results, simtel and log file. '''
         # Results file
         fileNameResults = names.cameraEfficiencyResultsFileName(
-                self._telescopeModel.telescopeType,
+                self._telescopeModel.telescopeName,
                 self._zenithAngle,
                 self.label
         )
         self._fileResults = self._baseDirectory.joinpath(fileNameResults)
         # SimtelOutput file
         fileNameSimtel = names.cameraEfficiencySimtelFileName(
-                self._telescopeModel.telescopeType,
+                self._telescopeModel.telescopeName,
                 self._zenithAngle,
                 self.label
         )
         self._fileSimtel = self._baseDirectory.joinpath(fileNameSimtel)
         # Log file
         fileNameLog = names.cameraEfficiencyLogFileName(
-                self._telescopeModel.telescopeType,
+                self._telescopeModel.telescopeName,
                 self._zenithAngle,
                 self.label
         )
@@ -203,7 +203,7 @@ class CameraEfficiency:
         cmd += ' -alt {}'.format(self._telescopeModel.getParameter('altitude'))
         cmd += ' -fatm {}'.format(self._telescopeModel.getParameter('atmospheric_transmission'))
         cmd += ' -flen {}'.format(focalLength * 0.01)  # focal lenght in meters
-        cmd += ' -fcur {}'.format(CAMERA_RADIUS_CURV[self._telescopeModel.telescopeType])
+        cmd += ' -fcur {}'.format(CAMERA_RADIUS_CURV[self._telescopeModel.telescopeName]) # fix it
         cmd += ' {} {}'.format(pixelShapeCmd, pixelDiameter)
         if mirrorClass == 1:
             cmd += ' -fmir {}'.format(self._telescopeModel.getParameter('mirror_list'))
@@ -496,7 +496,7 @@ class CameraEfficiency:
         plt = visualize.plotTable(
             tableToPlot,
             yTitle='Cherenkov light efficiency',
-            title='{} response to Cherenkov light'.format(self._telescopeModel.telescopeType),
+            title='{} response to Cherenkov light'.format(self._telescopeModel.telescopeName),
             noMarkers=True
         )
 
@@ -529,7 +529,7 @@ class CameraEfficiency:
             tableToPlot,
             yTitle='Nightsky background light efficiency',
             title='{} response to nightsky background light'.format(
-                self._telescopeModel.telescopeType
+                self._telescopeModel.telescopeName
             ),
             noMarkers=True
         )

--- a/simtools/corsika_config.py
+++ b/simtools/corsika_config.py
@@ -140,8 +140,8 @@ class CorsikaConfig:
         self._label = label
         self._filesLocation = cfg.getConfigArg('outputLocation', filesLocation)
         self._databaseLocation = cfg.getConfigArg('databaseLocation', databaseLocation)
-        self._site = names.validateName(site, names.allSiteNames)
-        self._arrayName = names.validateName(arrayName, names.allArrayNames)
+        self._site = names.validateSiteName(site)
+        self._arrayName = names.validateArrayName(arrayName)
         self._array = getArray(self._arrayName, self._databaseLocation)
 
         self.setParameters(**kwargs)

--- a/simtools/corsika_parameters.py
+++ b/simtools/corsika_parameters.py
@@ -34,13 +34,13 @@ PRIMARIES = {
 }
 
 SITE_PARAMETERS = {
-    'Paranal': {
+    'South': {
         'OBSLEV': [2150.e2],
         'ATMOSPHERE': [26, 'Y'],
         'MAGNET': [20.925, -9.119],
         'ARRANG':  [-3.433]
     },
-    'LaPalma': {
+    'North': {
         'OBSLEV': [2158.e2],
         'ATMOSPHERE': [36, 'Y'],
         'MAGNET': [30.576, 23.571],

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -225,7 +225,7 @@ def getModelParametersYaml(telescopeType, version, onlyApplicable=False):
     '''
 
     _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
-    _versionValidated = names.validateName(version, names.allModelVersionNames)
+    _versionValidated = names.validateModelVersionName(version)
 
     if getTelescopeSize(_telTypeValidated) == 'MST':
         # MST-FlashCam or MST-NectarCam
@@ -286,7 +286,7 @@ def getModelParametersMongoDB(
 
     # TODO the naming is a mess at the moment, need to fix it everywhere consistently.
     _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
-    _versionValidated = names.validateName(version, names.allModelVersionNames)
+    _versionValidated = names.validateModelVersionName(version)
 
     site = _telTypeValidated.split('-')[0]
     if 'MST' in _telTypeValidated:

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -338,12 +338,7 @@ def getModelParametersMongoDB(
             _selectOnlyApplicable
         ))
 
-    # Removing all info but the value
-    _pars = dict()
-    for key, value in _parsInfo.items():
-        _pars[key] = value['Value']
-
-    return _pars
+    return _parsInfo
 
 
 def readMongoDB(

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -257,22 +257,6 @@ def getModelParametersYaml(telescopeName, version, onlyApplicable=False):
 
             _pars[parNameIn] = parInfo[_versionValidated]
 
-    # Site parameters are in separate yml files
-    def _getSiteParameter(site, parName):
-        ''' Get the value of parName for a given site '''
-        _yamlFile = cfg.findFile('parValues-Sites.yml', self._modelFilesLocations)
-        logger.info('Reading DB file {}'.format(_yamlFile))
-        with open(_yamlFile, 'r') as stream:
-            allPars = yaml.load(stream, Loader=yaml.FullLoader)
-            for par in allPars:
-                if parName in par and site.lower() in par:
-                    return allPars[par][_version]
-        logger.warning('Parameter {} not found for site {}'.format(parName, site))
-        return None
-
-    for siteParName in ['atmospheric_transmission', 'altitude']:
-        _pars[siteParName] = _getSiteParameter(_site, siteParName)
-
     return _pars
 
 
@@ -320,8 +304,9 @@ def getModelParametersMongoDB(
         _whichTelLabels = [_telNameValidated]
 
     # Selecting version and applicable (if on)
-    _parsInfo = dict()
+    _pars = dict()
     for _tel in _whichTelLabels:
+        print(_tel)
         # If tel is a struture, only applicable pars will be collected, always.
         # The default ones will be covered by the camera pars.
         _selectOnlyApplicable = onlyApplicable or (_tel in [
@@ -329,7 +314,7 @@ def getModelParametersMongoDB(
             '{}-SST-Structure-D'.format(_site)
         ])
 
-        _parsInfo.update(readMongoDB(
+        _pars.update(readMongoDB(
             dbClient,
             dbName,
             _tel,
@@ -338,7 +323,7 @@ def getModelParametersMongoDB(
             _selectOnlyApplicable
         ))
 
-    return _parsInfo
+    return _pars
 
 
 def readMongoDB(

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -29,7 +29,7 @@ def getArray(arrayName, databaseLocation):
 
     """
 
-    arrayName = names.validateName(arrayName, names.allArrayNames)
+    arrayName = names.validateArrayName(arrayName)
     allArrays = db.getArrayDB(databaseLocation)
     return allArrays[arrayName]
 

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -10,7 +10,7 @@ from matplotlib.collections import PatchCollection
 
 import simtools.util.legend_handlers as legH
 from simtools.model.model_parameters import CAMERA_ROTATE_ANGLE
-from simtools.util.model import getCameraName, isTwoMirrorTelescope
+from simtools.util.model import getCameraName, isTwoMirrorTelescope, getTelescopeClass
 
 __all__ = ['Camera']
 
@@ -185,7 +185,7 @@ class Camera:
         is saved in the const dictionary CAMERA_ROTATE_ANGLE.
         In the case of dual mirror telescopes, the axis is flipped in order to keep the same
         axis definition as for single mirror telescopes.
-        One can check if the telescope is a two mirror one with isTwoMirrorTelescope.    
+        One can check if the telescope is a two mirror one with isTwoMirrorTelescope.
         '''
 
         if isTwoMirrorTelescope(self._telescopeName):
@@ -737,7 +737,7 @@ class Camera:
 
             if self._pixels['pixID'][i_pix] < 51:
                 fontSize = 4
-                if self._telescopeName == 'SCT':  # fix it
+                if getTelescopeClass(self._telescopeName) == 'SCT':
                     fontSize = 2
                 plt.text(
                     xyPixPos[0],

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -79,7 +79,7 @@ class Camera:
             raise ValueError('The focal length must be larger than zero')
         self._pixels = self.readPixelList(cameraConfigFile)
 
-        self._pixels = self._rotatePixels(self._telescopeName, self._pixels)
+        self._pixels = self._rotatePixels(self._pixels)
 
         # Initialize an empty list of neighbours, to be calculated only when necessary.
         self._neighbours = None

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -9,8 +9,8 @@ from scipy.spatial import distance
 from matplotlib.collections import PatchCollection
 
 import simtools.util.legend_handlers as legH
-from simtools.model.model_parameters import TWO_MIRROR_TELS, CAMERA_ROTATE_ANGLE
-from simtools.util.model import getCameraName
+from simtools.model.model_parameters import CAMERA_ROTATE_ANGLE
+from simtools.util.model import getCameraName, isTwoMirrorTelescope
 
 __all__ = ['Camera']
 
@@ -185,10 +185,10 @@ class Camera:
         is saved in the const dictionary CAMERA_ROTATE_ANGLE.
         In the case of dual mirror telescopes, the axis is flipped in order to keep the same
         axis definition as for single mirror telescopes.
-        The list of dual mirror telescopes is given in the const dictionary TWO_MIRROR_TELS.
+        One can check if the telescope is a two mirror one with isTwoMirrorTelescope.    
         '''
 
-        if self._telescopeName not in TWO_MIRROR_TELS:
+        if isTwoMirrorTelescope(self._telescopeName):
             pixels['y'] = [(-1)*yVal for yVal in pixels['y']]
 
         rotateAngle = pixels['rotateAngle']  # So not to change the original angle
@@ -555,7 +555,7 @@ class Camera:
 
         invertYaxis = False
         xLeft = 0.7  # Position of the left most axis
-        if self._telescopeName not in TWO_MIRROR_TELS:
+        if not isTwoMirrorTelescope(self._telescopeName):
             invertYaxis = True
             xLeft = 0.8
 

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -51,15 +51,15 @@ class Camera:
     SIPM_NEIGHBOR_RADIUS_FACTOR = 1.4
     SIPM_ROW_COLUMN_DIST_FACTOR = 0.2
 
-    def __init__(self, telescopeType, cameraConfigFile, focalLength, logger=__name__):
+    def __init__(self, telescopeName, cameraConfigFile, focalLength, logger=__name__):
         '''
         Camera class, defining pixel layout including rotation, finding neighbour pixels,
         calculating FoV and plotting the camera.
 
         Parameters
         ----------
-        telescopeType: string
-                    As provided by the telescope model method "TelescopeModel".
+        telescopeName: string
+                    As provided by the telescope model method TelescopeModel (ex South-LST-1).
         cameraConfigFile: string
                     The sim_telarray file name.
         focalLength: float

--- a/simtools/model/model_parameters.py
+++ b/simtools/model/model_parameters.py
@@ -51,24 +51,22 @@ TWO_MIRROR_TELS = ['SCT', 'SST-2M-ASTRI', 'SST-2M-GCT-S', 'SST-Structure', 'SST-
 # and then actually rotate in the right direction.
 CAMERA_ROTATE_ANGLE = {
   'LST': 248.214,
-  'MST-FlashCam': 270,
-  'MST-NectarCam': 248.214,
+  'FlashCam': 270,
+  'NectarCam': 248.214,
   'SCT': 90,
-  'SST-2M-ASTRI': 90,
-  'SST-1M': 270,
-  'SST-2M-GCT-S': 90,
-  'SST-Structure': 90,
-  'SST-Camera': 90,
-  'SST': 90
+  'ASTRI': 90,
+  '1M': 270,
+  'GCT': 90,
+  'SST': 90,
 }
 
 CAMERA_RADIUS_CURV = {
     'SST': 4.566,
-    'SST-1M': 5.6,
-    'SST-2M-ASTRI': 4.3,
-    'SST-2M-GCT-S': 4.566,
-    'MST-FlashCam': 19.2,
-    'MST-NectarCam': 19.2,
-    'MST-SCT': 11.16,
+    '1M': 5.6,
+    'ASTRI': 4.3,
+    'GCT': 4.566,
+    'FlashCam': 19.2,
+    'NectarCam': 19.2,
+    'SCT': 11.16,
     'LST': 56
 }

--- a/simtools/model/model_parameters.py
+++ b/simtools/model/model_parameters.py
@@ -1,6 +1,6 @@
 ''' Parameters of telescope model. '''
 
-__all__ = ['MODEL_PARS', 'TWO_MIRROR_TELS', 'CAMERA_ROTATE_ANGLE']
+__all__ = ['MODEL_PARS', 'CAMERA_ROTATE_ANGLE']
 
 MODEL_PARS = {
     'focal_length': {'type': float, 'names': []},
@@ -41,8 +41,6 @@ MODEL_PARS = {
     'min_photoelectrons': {'type': int, 'names': []},
     'parabolic_dish': {'type': int, 'names': []}
 }
-
-TWO_MIRROR_TELS = ['SCT', 'SST-2M-ASTRI', 'SST-2M-GCT-S', 'SST-Structure', 'SST-Camera', 'SST']
 
 # The coordinate system is aligned with Alt (x) and Az(y), so need to rotate the camera.
 # The angle depends on what coordinate system was provided by the instrument team.

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -13,7 +13,7 @@ import simtools.config as cfg
 import simtools.io_handler as io
 import simtools.db_handler as db
 from simtools.util import names
-from simtools.util.model import getTelescopeSize, validateModelParameter
+from simtools.util.model import validateModelParameter
 from simtools.model.mirrors import Mirrors
 from simtools.model.camera import Camera
 from simtools.model.model_parameters import MODEL_PARS

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -97,7 +97,7 @@ class TelescopeModel:
         '''
         logger.debug('Init TelescopeModel')
 
-        self.version = names.validateName(version, names.allModelVersionNames)
+        self.version = names.validateModelVersionName(version)
         self.telescopeType = names.validateName(telescopeType, names.allTelescopeTypeNames)
         self.site = names.validateName(site, names.allSiteNames)
         self.label = label

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -217,7 +217,7 @@ class TelescopeModel:
         ''' Read parameters from DB and store them in _parameters. '''
 
         self._parameters = db.getModelParameters(
-            self.telescopeType,
+            self.telescopeName,
             self.version,
             onlyApplicable=True
         )
@@ -481,7 +481,7 @@ class TelescopeModel:
             logger.warning('Using focal_length because effective_focal_length is 0.')
             focalLength = self._parameters['focal_length']
         self._camera = Camera(
-            telescopeType=self.telescopeType,
+            telescopeName=self.telescopeName,
             cameraConfigFile=cfg.findFile(cameraConfigFile),
             focalLength=focalLength,
             logger=logger.name
@@ -490,14 +490,14 @@ class TelescopeModel:
 
     def isASTRI(self):
         '''
-        Check if telescope type is an ASTRI type.
+        Check if telescope is an ASTRI type.
 
         Returns
         ----------
         bool:
-            True if telescope type is a ASTRI, False otherwise.
+            True if telescope  is a ASTRI, False otherwise.
         '''
-        return self.telescopeType in ['SST-2M-ASTRI', 'SST']
+        return self.telescopeName in ['SST-2M-ASTRI', 'SST']
 
     def isFile2D(self, par):
         '''

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -238,6 +238,7 @@ class TelescopeModel:
         logger.debug('Reading site parameters from DB')
 
         site = names.getSiteFromTelescopeName(self.telescopeName)
+        site = 'Paranal' if site == 'South' else 'LaPalma'
 
         def _getSiteParameter(parName):
             ''' Get the value of parName for a given site '''
@@ -483,7 +484,10 @@ class TelescopeModel:
 
     def _loadMirrors(self):
         mirrorListFileName = self._parameters['mirror_list']
-        mirrorListFile = cfg.findFile(mirrorListFileName, self._configFileDirectory)
+        try:
+            mirrorListFile = cfg.findFile(mirrorListFileName, self._configFileDirectory)
+        except:
+            mirrorListFile = cfg.findFile(mirrorListFileName, self._modelFilesLocations)
         self._mirrors = Mirrors(mirrorListFile)
         return
 
@@ -493,9 +497,14 @@ class TelescopeModel:
         if focalLength == 0.:
             logger.warning('Using focal_length because effective_focal_length is 0.')
             focalLength = self._parameters['focal_length']
+        try:
+            cameraConfigFilePath = cfg.findFile(cameraConfigFile, self._configFileDirectory)
+        except:
+            cameraConfigFilePath = cfg.findFile(cameraConfigFile, self._modelFilesLocations)
+
         self._camera = Camera(
             telescopeName=self.telescopeName,
-            cameraConfigFile=cfg.findFile(cameraConfigFile, self._configFileDirectory),
+            cameraConfigFile=cameraConfigFilePath,
             focalLength=focalLength,
             logger=logger.name
         )

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -31,10 +31,8 @@ class TelescopeModel:
 
     Attributes
     ----------
-    telescopeType: str
-        Telescope type for the base set of parameters (ex. SST-2M-ASTRI, LST, ...).
-    site: str
-        Paranal or LaPalma.
+    telescopeName: str
+        Telescope name for the base set of parameters (ex. North-LST-1, ...).
     version: str
         Version of the model (ex. prod4).
     label: str
@@ -47,7 +45,7 @@ class TelescopeModel:
     Methods
     -------
     @classmethod
-    fromConfigFile(configFileName, telescopeType, site, label=None, filesLocation=None)
+    fromConfigFile(configFileName, telescopeName, label=None, filesLocation=None)
         Create a TelescopeModel from a sim_telarray cfg file.
     hasParameter(parName):
         Verify if parameter is in the model.
@@ -66,8 +64,7 @@ class TelescopeModel:
     '''
     def __init__(
         self,
-        telescopeType,
-        site,
+        telescopeName,
         version='default',
         label=None,
         modelFilesLocations=None,
@@ -79,10 +76,8 @@ class TelescopeModel:
 
         Parameters
         ----------
-        telescopeType: str
-            Telescope type for the base set of parameters (ex. SST-2M-ASTRI, LST, ...).
-        site: str
-            Paranal or LaPalma.
+        telescopeName: str
+            Telescope name for the base set of parameters (ex. North-LST-1, ...).
         version: str, optional
             Version of the model (ex. prod4) (Default = default).
         label: str, optional
@@ -98,8 +93,7 @@ class TelescopeModel:
         logger.debug('Init TelescopeModel')
 
         self.version = names.validateModelVersionName(version)
-        self.telescopeType = names.validateName(telescopeType, names.allTelescopeTypeNames)
-        self.site = names.validateName(site, names.allSiteNames)
+        self.telescopeName = names.validateTelescopeName(telescopeName)
         self.label = label
 
         self._modelFilesLocations = cfg.getConfigArg('modelFilesLocations', modelFilesLocations)
@@ -129,8 +123,7 @@ class TelescopeModel:
     def fromConfigFile(
         cls,
         configFileName,
-        telescopeType,
-        site,
+        telescopeName,
         label=None,
         modelFilesLocations=None,
         filesLocation=None
@@ -147,10 +140,8 @@ class TelescopeModel:
         ----------
         configFileName: str or Path
             Path to the input config file.
-        telescopeType: str
-            Telescope type for the base set of parameters (ex. SST-2M-ASTRI, LST, ...).
-        site: str
-            Paranal or LaPalma.
+        telescopeName: str
+            Telescope name for the base set of parameters (ex. North-LST-1, ...).
         label: str, optional
             Instance label. Important for output file naming.
         modelFilesLocation: str (or Path), optional
@@ -165,8 +156,7 @@ class TelescopeModel:
         '''
         parameters = dict()
         tel = cls(
-            telescopeType=telescopeType,
-            site=site,
+            telescopeName=telescopeName,
             label=label,
             modelFilesLocations=modelFilesLocations,
             filesLocation=filesLocation,
@@ -232,23 +222,24 @@ class TelescopeModel:
             onlyApplicable=True
         )
 
-        # Site: Two site parameters need to be read: atmospheric_transmission and altitude
-        logger.debug('Reading site parameters from DB')
+        # CHECK THIS
+        # # Site: Two site parameters need to be read: atmospheric_transmission and altitude
+        # logger.debug('Reading site parameters from DB')
 
-        def _getSiteParameter(site, parName):
-            ''' Get the value of parName for a given site '''
-            yamlFile = cfg.findFile('parValues-Sites.yml', self._modelFilesLocations)
-            logger.info('Reading DB file {}'.format(yamlFile))
-            with open(yamlFile, 'r') as stream:
-                allPars = yaml.load(stream, Loader=yaml.FullLoader)
-                for par in allPars:
-                    if parName in par and self.site.lower() in par:
-                        return allPars[par][self.version]
-            logger.warning('Parameter {} not found for site {}'.format(parName, site))
-            return None
+        # def _getSiteParameter(site, parName):
+        #     ''' Get the value of parName for a given site '''
+        #     yamlFile = cfg.findFile('parValues-Sites.yml', self._modelFilesLocations)
+        #     logger.info('Reading DB file {}'.format(yamlFile))
+        #     with open(yamlFile, 'r') as stream:
+        #         allPars = yaml.load(stream, Loader=yaml.FullLoader)
+        #         for par in allPars:
+        #             if parName in par and self.site.lower() in par:
+        #                 return allPars[par][self.version]
+        #     logger.warning('Parameter {} not found for site {}'.format(parName, site))
+        #     return None
 
-        for siteParName in ['atmospheric_transmission', 'altitude']:
-            self._parameters[siteParName] = _getSiteParameter(self.site, siteParName)
+        # for siteParName in ['atmospheric_transmission', 'altitude']:
+        #     self._parameters[siteParName] = _getSiteParameter(self.site, siteParName)
     # END _loadParametersFromDB
 
     def hasParameter(self, parName):
@@ -370,8 +361,7 @@ class TelescopeModel:
         # Setting file name and the location
         configFileName = names.simtelConfigFileName(
             self.version,
-            self.site,
-            self.telescopeType,
+            self.telescopeName,
             self.label
         )
         self._configFilePath = self._configFileDirectory.joinpath(configFileName)
@@ -382,8 +372,7 @@ class TelescopeModel:
             header = (
                 '%{}\n'.format(99 * '=')
                 + '% Configuration file for:\n'
-                + '% TelescopeType: {}\n'.format(self.telescopeType)
-                + '% Site: {}\n'.format(self.site)
+                + '% TelescopeName: {}\n'.format(self.telescopeName)
                 + '% Label: {}\n'.format(self.label) if self.label is not None else ''
                 + '%{}\n'.format(99 * '=')
             )
@@ -441,8 +430,7 @@ class TelescopeModel:
 
         fileName = names.simtelSingleMirrorListFileName(
             self.version,
-            self.site,
-            self.telescopeType,
+            self.telescopeName,
             mirrorNumber,
             self.label
         )

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -216,11 +216,15 @@ class TelescopeModel:
     def _loadParametersFromDB(self):
         ''' Read parameters from DB and store them in _parameters. '''
 
+        self._setConfigFileDirectory()
         self._parameters = db.getModelParameters(
             self.telescopeName,
             self.version,
+            self._configFileDirectory,
             onlyApplicable=True
         )
+
+        print(self._parameters)
 
         # CHECK THIS
         # # Site: Two site parameters need to be read: atmospheric_transmission and altitude
@@ -470,7 +474,7 @@ class TelescopeModel:
 
     def _loadMirrors(self):
         mirrorListFileName = self._parameters['mirror_list']
-        mirrorListFile = cfg.findFile(mirrorListFileName, self._modelFilesLocations)
+        mirrorListFile = cfg.findFile(mirrorListFileName, self._configFileDirectory)
         self._mirrors = Mirrors(mirrorListFile)
         return
 
@@ -482,7 +486,7 @@ class TelescopeModel:
             focalLength = self._parameters['focal_length']
         self._camera = Camera(
             telescopeName=self.telescopeName,
-            cameraConfigFile=cfg.findFile(cameraConfigFile),
+            cameraConfigFile=cfg.findFile(cameraConfigFile, self._configFileDirectory),
             focalLength=focalLength,
             logger=logger.name
         )

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -154,7 +154,7 @@ class RayTracing:
 
         # Results file
         fileNameResults = names.rayTracingResultsFileName(
-                self._telescopeModel.telescopeType,
+                self._telescopeModel.telescopeName,
                 self._sourceDistance,
                 self._zenithAngle,
                 self.label
@@ -252,7 +252,7 @@ class RayTracing:
                     self._logger.debug('mirrorNumber={}'.format(thisMirror))
 
                 photonsFileName = names.rayTracingFileName(
-                    self._telescopeModel.telescopeType,
+                    self._telescopeModel.telescopeName,
                     self._sourceDistance,
                     self._zenithAngle,
                     thisOffAxis,
@@ -374,7 +374,7 @@ class RayTracing:
 
         plotFileName = names.rayTracingPlotFileName(
             key,
-            self._telescopeModel.telescopeType,
+            self._telescopeModel.telescopeName,
             self._sourceDistance,
             self._zenithAngle,
             self.label

--- a/simtools/simtel_runner.py
+++ b/simtools/simtel_runner.py
@@ -88,7 +88,7 @@ class SimtelRunner:
         self._logger.debug('Init SimtelRunner')
 
         self._simtelSourcePath = Path(cfg.getConfigArg('simtelPath', simtelSourcePath))
-        self.mode = names.validateName(mode, names.allSimtelModeNames)
+        self.mode = names.validateSimtelModeName(mode)
         self.telescopeModel = self._validateTelescopeModel(telescopeModel)
         self.label = label if label is not None else self.telescopeModel.label
 

--- a/simtools/simtel_runner.py
+++ b/simtools/simtel_runner.py
@@ -224,7 +224,7 @@ class SimtelRunner:
         ''' Tells if simulations should be run again based on the existence of output files. '''
         if self._isRayTracingMode():
             photonsFileName = names.rayTracingFileName(
-                self.telescopeModel.telescopeType,
+                self.telescopeModel.telescopeName,
                 self._sourceDistance,
                 self._zenithAngle,
                 self._offAxisAngle,
@@ -251,7 +251,7 @@ class SimtelRunner:
             # Files will be named _baseFileName = self.__dict__['_' + base + 'FileName']
             for baseName in ['stars', 'photons', 'log']:
                 fileName = names.rayTracingFileName(
-                    self.telescopeModel.telescopeType,
+                    self.telescopeModel.telescopeName,
                     self._sourceDistance,
                     self._zenithAngle,
                     self._offAxisAngle,

--- a/simtools/tests/test_camera_efficiency.py
+++ b/simtools/tests/test_camera_efficiency.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 def test_main():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
+        telescopeName='north-lst-1',
         version='p3',
         label='test_camera_eff'
     )

--- a/simtools/tests/test_camera_efficiency.py
+++ b/simtools/tests/test_camera_efficiency.py
@@ -13,8 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 def test_main():
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopeName='south-lst-1',
         version='p3',
         label='test_camera_eff'
     )

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -31,7 +31,7 @@ def test_reading_db_lst():
 def test_reading_db_mst_nc():
 
     logger.info('----Testing reading MST-NectarCam-----')
-    pars = db.getModelParameters('north-mst-nectarcam-d', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('north-mst-NectarCam-D', 'prod4', testDataDirectory)
     assert(pars['camera_pixels']['Value'] == 1855)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
@@ -46,7 +46,7 @@ def test_reading_db_mst_nc():
 def test_reading_db_mst_fc():
 
     logger.info('----Testing reading MST-FlashCam-----')
-    pars = db.getModelParameters('north-mst-flashcam-d', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('north-mst-FlashCam-D', 'prod4', testDataDirectory)
     assert(pars['camera_pixels']['Value'] == 1764)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
@@ -61,7 +61,7 @@ def test_reading_db_mst_fc():
 def test_reading_db_sst():
 
     logger.info('----Testing reading SST-----')
-    pars = db.getModelParameters('south-sst-d', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('south-sst-D', 'prod4', testDataDirectory)
     assert(pars['camera_pixels']['Value'] == 2048)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
@@ -118,29 +118,6 @@ def test_modify_db():
     db.closeSSHTunnel([tunnel])
 
     return
-
-
-# def test_get_model_file():
-
-#     tel = TelescopeModel(
-#         telescopeType='lst',
-#         site='south',
-#         version='prod4',
-#         label='test-lst'
-#     )
-
-#     fileName = tel.getParameter('camera_config_file')
-
-#     logger.info('FileName = {}'.format(fileName))
-
-#     file = db.getModelFile(fileName)
-
-#     logger.info('FilePath = {}'.format(file))
-
-#     destDir = Path.cwd()
-#     db.writeModelFile(fileName, destDir)
-
-#     return
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_names.py
+++ b/simtools/tests/test_names.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+import logging
+from simtools.util import names
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+def test_validate_telescope_names():
+    newName = names.validateTelescopeName('north-sst-D')
+    print(newName) 
+
+
+def test_validate_other_names():
+    modelVersion = names.validateModelVersionName('p4')
+    print(modelVersion) 
+
+if __name__ == '__main__':
+
+    test_validate_telescope_names()
+    test_validate_other_names()
+    pass

--- a/simtools/tests/test_names.py
+++ b/simtools/tests/test_names.py
@@ -8,12 +8,13 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 def test_validate_telescope_names():
     newName = names.validateTelescopeName('north-sst-D')
-    print(newName) 
+    print(newName)
 
 
 def test_validate_other_names():
     modelVersion = names.validateModelVersionName('p4')
-    print(modelVersion) 
+    print(modelVersion)
+
 
 if __name__ == '__main__':
 

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -28,8 +28,7 @@ def test_ssts(show=False):
     rayTracing = list()
     for t in telTypes:
         tel = TelescopeModel(
-            telescopeName='south-' + t,
-            site=site,
+            telescopeName='north-' + t,
             version=version,
             label='test-sst'
         )
@@ -67,8 +66,7 @@ def test_rx():
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
-        site=site,
+        telescopeName='north-lst-1',
         version=version,
         label=label
     )
@@ -120,8 +118,7 @@ def test_plot_image():
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeName='south-sst-D',
-        site=site,
+        telescopeName='north-sst-D',
         version=version,
         label=label
     )
@@ -154,8 +151,7 @@ def test_single_mirror(plot=False):
     version = 'prod3'
 
     tel = TelescopeModel(
-        telescopeName='south-mst-FlashCam-D',
-        site=site,
+        telescopeName='north-mst-FlashCam-D',
         version=version,
         label='test-mst'
     )
@@ -187,8 +183,7 @@ def test_integral_curve():
     show = True
 
     tel = TelescopeModel(
-        telescopeName='south-mst-FlashCam-D',
-        site=site,
+        telescopeName='north-mst-FlashCam-D',
         version=version,
         label=label
     )
@@ -216,8 +211,8 @@ def test_integral_curve():
 
 if __name__ == '__main__':
 
-    test_ssts()
-    # test_rx()
+    # test_ssts()
+    test_rx()
     # test_single_mirror()
     # test_plot_image()
     # test_integral_curve()

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -19,17 +19,16 @@ logger.setLevel(logging.DEBUG)
 def test_ssts(show=False):
     # Test with 3 SSTs
     sourceDistance = 10 * u.km
-    site = 'south'
     version = 'prod3'
     zenithAngle = 20 * u.deg
     offAxisAngle = [0, 1.0, 2.0, 3.0, 4.0] * u.deg
 
-    telTypes = ['sst-1m', 'sst-astri', 'sst-gct']
+    telTypes = ['sst-1M', 'sst-ASTRI', 'sst-GCT']
     telModels = list()
     rayTracing = list()
     for t in telTypes:
         tel = TelescopeModel(
-            telescopeType=t,
+            telescopeName='south-' + t,
             site=site,
             version=version,
             label='test-sst'
@@ -62,14 +61,13 @@ def test_ssts(show=False):
 
 def test_rx():
     sourceDistance = 10 * u.km
-    site = 'south'
     version = 'prod3'
     label = 'test-lst'
     zenithAngle = 20 * u.deg
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeType='lst',
+        telescopeName='south-lst-1',
         site=site,
         version=version,
         label=label
@@ -116,14 +114,13 @@ def test_rx():
 
 def test_plot_image():
     sourceDistance = 10 * u.km
-    site = 'south'
     version = 'prod3'
     label = 'test-astri'
     zenithAngle = 20 * u.deg
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeType='astri',
+        telescopeName='south-sst-D',
         site=site,
         version=version,
         label=label
@@ -154,11 +151,10 @@ def test_plot_image():
 def test_single_mirror(plot=False):
 
     # Test MST, single mirror PSF simulation
-    site = 'south'
     version = 'prod3'
 
     tel = TelescopeModel(
-        telescopeType='mst-flashcam',
+        telescopeName='south-mst-FlashCam-D',
         site=site,
         version=version,
         label='test-mst'
@@ -184,7 +180,6 @@ def test_single_mirror(plot=False):
 
 def test_integral_curve():
     sourceDistance = 10 * u.km
-    site = 'south'
     version = 'prod4'
     label = 'lst_integral'
     zenithAngle = 20 * u.deg
@@ -192,7 +187,7 @@ def test_integral_curve():
     show = True
 
     tel = TelescopeModel(
-        telescopeType='mst-flashcam',
+        telescopeName='south-mst-FlashCam-D',
         site=site,
         version=version,
         label=label

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -13,8 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 def test_ray_tracing_mode():
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopeName='south-lst-1',
         version='prod4',
         label='test-simtel'
     )
@@ -33,7 +32,7 @@ def test_ray_tracing_mode():
 
 def test_catching_model_error():
     tel = TelescopeModel(
-        telescopeType='lst',
+        telescopeName='south-lst-1',
         site='south',
         version='prod4',
         label='test-simtel'

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -13,7 +13,7 @@ logger.setLevel(logging.DEBUG)
 
 def test_ray_tracing_mode():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
+        telescopeName='north-lst-1',
         version='prod4',
         label='test-simtel'
     )
@@ -32,8 +32,7 @@ def test_ray_tracing_mode():
 
 def test_catching_model_error():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
-        site='south',
+        telescopeName='north-lst-1',
         version='prod4',
         label='test-simtel'
     )

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -10,27 +10,22 @@ logger.setLevel(logging.DEBUG)
 
 
 def test_input_validation():
-    telType = 'lst'
-    site = 'south'
-    logger.info('Input telType: {}'.format(telType))
-    logger.info('Input site: {}'.format(site))
+    telName = 'south-lst-1'
+    logger.info('Input telName: {}'.format(telName))
 
     tel = TelescopeModel(
-        telescopeType=telType,
-        site=site,
+        telescopeName=telName,
         version='prod4',
         label='test-lst'
     )
 
-    logger.info('Validated telType: {}'.format(tel.telescopeType))
-    logger.info('Validated site: {}'.format(tel.site))
+    logger.info('Validated telName: {}'.format(tel.telescopeName))
     return
 
 
 def test_handling_parameters():
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopeName='south-lst-1',
         version='prod4',
         label='test-lst'
     )
@@ -54,8 +49,7 @@ def test_handling_parameters():
 
 def test_flen_type():
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopeName='south-lst-1',
         version='prod4',
         label='test-lst'
     )
@@ -68,10 +62,9 @@ def test_flen_type():
 def test_cfg_file():
     # Exporting
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopeName='south-sst-d',
         version='prod4',
-        label='test-lst'
+        label='test-sst'
     )
     # tel.exportConfigFile(loc='/home/prado/Work/Projects/CTA_MC/MCLib')
     tel.exportConfigFile()
@@ -81,9 +74,8 @@ def test_cfg_file():
     # Importing
     cfgFile = tel.getConfigFile()
     tel = TelescopeModel.fromConfigFile(
-        telescopeType='astri',
-        site='south',
-        label='test-astri',
+        telescopeName='south-sst-d',
+        label='test-sst',
         configFileName=cfgFile
     )
     tel.exportConfigFile()
@@ -92,10 +84,9 @@ def test_cfg_file():
 
 def test_cfg_input():
     tel = TelescopeModel(
-        telescopeType='lst',
-        site='south',
+        telescopename='south-lst-1',
         version='prod4',
-        label='test-input'
+        label='test-sst-2'
     )
     return
 

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -84,7 +84,7 @@ def test_cfg_file():
 
 def test_cfg_input():
     tel = TelescopeModel(
-        telescopename='south-lst-1',
+        telescopeName='south-lst-1',
         version='prod4',
         label='test-sst-2'
     )

--- a/simtools/util/model.py
+++ b/simtools/util/model.py
@@ -4,6 +4,7 @@ import logging
 import math
 
 from simtools.model.model_parameters import MODEL_PARS
+from simtools.util import names
 
 
 __all__ = ['computeTelescopeTransmission', 'getTelescopeSize']
@@ -83,3 +84,44 @@ def validateModelParameter(parNameIn, parValueIn):
             parType = MODEL_PARS[parNameModel]['type']
             return parNameModel, parType(parValueIn)
     return parNameIn, parValueIn
+
+
+def getCameraName(telescopeName):
+    '''
+    Get camera name from the telescope name.
+
+    Parameters
+    ----------
+    telescopeName: str
+        Telescope name (ex. South-LST-1)
+
+    Returns
+    -------
+    str
+        Camera name (validated by util.names)
+    '''
+    cameraName = ''
+    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    if telClass == 'LST':
+        cameraName = 'LST'
+    elif telClass == 'MST':
+        if 'FlashCam' in telType:
+            cameraName = 'FlashCam'
+        elif 'NectarCam' in telType:
+            cameraName = 'NectarCam'
+        else:
+            logger.error('Camera not found for MST class telescope')
+    elif telClass == 'SCT':
+        cameraName = 'SCT'
+    elif telClass == 'SST':
+        if 'ASTRI' in telType:
+            cameraName = 'ASTRI'
+        elif 'GCT' in telType:
+            cameraName = 'GCT'
+        else:
+            cameraName = 'SST'
+    else:
+        logger.error('Invalid telescope name - please validate it first')
+
+    cameraName = names.validateCameraName(cameraName)
+    return cameraName

--- a/simtools/util/model.py
+++ b/simtools/util/model.py
@@ -118,10 +118,13 @@ def getCameraName(telescopeName):
             cameraName = 'ASTRI'
         elif 'GCT' in telType:
             cameraName = 'GCT'
+        elif '1M' in telType:
+            cameraName = '1M'
         else:
             cameraName = 'SST'
     else:
         logger.error('Invalid telescope name - please validate it first')
 
     cameraName = names.validateCameraName(cameraName)
+    logger.debug('Camera name - {}'.format(cameraName))
     return cameraName

--- a/simtools/util/model.py
+++ b/simtools/util/model.py
@@ -7,7 +7,12 @@ from simtools.model.model_parameters import MODEL_PARS
 from simtools.util import names
 
 
-__all__ = ['computeTelescopeTransmission', 'getTelescopeSize']
+__all__ = [
+    'computeTelescopeTransmission',
+    'getTelescopeClass',
+    'getCameraName',
+    'isTwoMirrorTelescope'
+]
 
 logger = logging.getLogger(__name__)
 
@@ -35,31 +40,6 @@ def computeTelescopeTransmission(pars, offAxis):
     else:
         t = math.sin(offAxis*_degToRad) / (pars[3]*_degToRad)
         return pars[0] / (1. + pars[2] * t**pars[4])
-
-
-def getTelescopeSize(telescopeType):
-    '''
-    Provide the telescope size (SST, MST or LST) for a given telescopeType.
-
-    Parameters
-    ----------
-    telescopeType: str
-        Ex. SST-2M-ASTRI, LST, ...
-
-    Returns
-    -------
-    str
-        'SST', 'MST' or 'LST'
-    '''
-    if 'SST' in telescopeType:
-        return 'SST'
-    elif 'MST' in telescopeType:
-        return 'MST'
-    elif 'LST' in telescopeType:
-        return 'LST'
-    else:
-        logger.warning('Invalid telescopeType {}'.format(telescopeType))
-        return None
 
 
 def validateModelParameter(parNameIn, parValueIn):
@@ -128,3 +108,44 @@ def getCameraName(telescopeName):
     cameraName = names.validateCameraName(cameraName)
     logger.debug('Camera name - {}'.format(cameraName))
     return cameraName
+
+
+def getTelescopeClass(telescopeName):
+    '''
+    Get telescope class from telescope name.
+
+    Parameters
+    ----------
+    telescopeName: str
+        Telescope name (ex. South-LST-1)
+
+    Returns
+    -------
+    str
+        Telescope class (SST, MST, ...)
+    '''
+    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    return telClass
+
+
+def isTwoMirrorTelescope(telescopeName):
+    '''
+    Check if the telescope is a two mirror design.
+
+    Parameters
+    ----------
+    telescopeName: str
+        Telescope name (ex. South-LST-1)
+
+    Returns
+    -------
+    bool
+        True if the telescope is a two mirror one.
+    '''
+    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    if telClass == 'SST':
+        return False if '1M' in telType else True
+    elif telClass == 'SCT':
+        return True
+    else:
+        return False

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -173,7 +173,7 @@ def validateTelescopeName(name):
     telClass = validateName(nameParts[1], allTelescopeClassNames)
     telType = ''
     for ii in range(2, len(nameParts)):
-        telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-') 
+        telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-')
     return thisSite + '-' + telClass + '-' + telType
 
 
@@ -234,7 +234,7 @@ allArrayNames = {
 }
 
 
-def simtelConfigFileName(version, site, telescopeType, label):
+def simtelConfigFileName(version, telescopeName, label):
     '''
     sim_telarray config file name.
 
@@ -242,10 +242,8 @@ def simtelConfigFileName(version, site, telescopeType, label):
     ----------
     version: str
         Version of the model.
-    site: str
-        Paranal or LaPalma
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        North-LST-1, South-MST-FlashCam, ...
     label: str
         Instance label.
 
@@ -254,13 +252,13 @@ def simtelConfigFileName(version, site, telescopeType, label):
     str
         File name.
     '''
-    name = 'CTA-{}-{}-{}'.format(version, site, telescopeType)
+    name = 'CTA-{}-{}'.format(version, telescopeName)
     name += '_{}'.format(label) if label is not None else ''
     name += '.cfg'
     return name
 
 
-def simtelSingleMirrorListFileName(version, site, telescopeType, mirrorNumber, label):
+def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
     '''
     sim_telarray mirror list file with a single mirror.
 

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -9,6 +9,7 @@ __all__ = [
     'validateArrayName',
     'validateTelescopeName',
     'validateCameraName',
+    'convertTelescopeNameToYaml'
     'splitTelescopeName',
     'getSiteFromTelescopeName',
     'rayTracingFileName',
@@ -246,23 +247,42 @@ def getSiteFromTelescopeName(name):
     return thisSite
 
 
-# allTelescopeTypeNames = {
-#     'SST': ['sst'],
-#     'SST-1M': ['1m'],
-#     'SST-2M-ASTRI': ['sst-astri', 'astri'],
-#     'SST-2M-GCT-S': ['sst-gct', 'gct', 'sst-gct-s'],
-#     'MST-FlashCam': ['flashcam', 'mst-fc'],
-#     'MST-NectarCam': ['nectarcam', 'mst-nc'],
-#     'SCT': ['mst-sct', 'sct'],
-#     'LST': [],
-#     'North-LST-1': ['north-lst-1'],
-#     'North-LST-D234': ['north-lst-d234'],
-#     'North-MST-FlashCam-D': ['north-flashcam-d', 'north-mst-fc-d'],
-#     'North-MST-NectarCam-D': ['north-nectarcam-d', 'north-mst-nc-d'],
-#     'North-SCT-D': ['north-mst-sct-d', 'north-sct-d'],
-#     'South-SST-D': ['south-sst-d'],
-#     'North-LST-Test': ['north-lst-test']
-# }
+def convertTelescopeNameToYaml(name):
+    '''
+    Get telescope name following the old convention (yaml files) from the current telescope name.
+
+    Parameters
+    ----------
+    name: str
+        Telescope name.
+
+    Returns
+    -------
+    str
+        Telescope name (old convention).
+    '''
+    telSite, telClass, telType = splitTelescopeName(name)
+    newName = telClass + '-' + telType
+    if newName == 'SST-D':
+        return 'SST'
+    elif newName == 'SST-1M':
+        return 'SST-1M'
+    elif newName == 'SST-ASTRI':
+        return 'SST-2M-ASTRI'
+    elif newName == 'SST-GCT':
+        return 'SST-2M-GCT-S'
+    elif newName == 'MST-FlashCam-D':
+        return 'MST-FlashCam'
+    elif newName == 'MST-Nectar-D':
+        return 'MST-NectarCam'
+    elif newName == 'SCT-D':
+        return 'SCT'
+    elif newName in 'LST-D234':
+        return 'LST'
+    else:
+        logger.error('Telescope name {} could not be converted to yml names'.format(name))
+        return None
+
 
 allTelescopeClassNames = {
     'SST': ['sst'],

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -36,6 +36,27 @@ def validateModelVersionName(name):
     return validateName(name, allModelVersionNames)
 
 
+def validateSimtelModeName(name):
+    '''
+    Validate a sim_telarray mode name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
+    return validateName(name, allSimtelModeNames)
+
+
 def validateName(name, allNames):
     '''
     Validate a name given the allNames options. For each key in allNames, a list of options is
@@ -88,13 +109,30 @@ def isValidName(name, allNames):
 
 
 def validateTelescopeName(name):
+    '''
+    Validate a telescope name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
     nameParts = name.split('-')
-    site = validateName(nameParts[0], allSiteNames)
+    thisSite = validateName(nameParts[0], allSiteNames)
     telClass = validateName(nameParts[1], allTelescopeClassNames)
     telType = ''
     for ii in range(2, len(nameParts)):
         telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-') 
-    return site + '-' + telClass + '-' + telType
+    return thisSite + '-' + telClass + '-' + telType
 
 
 allTelescopeTypeNames = {

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -66,6 +66,18 @@ def isValidName(name, allNames):
     return False
 
 
+def validateTelescopeName(name):
+    nameParts = name.split('-')
+    print(nameParts)
+    site = validateName(nameParts[0], allSiteNames)
+    telClass = validateName(nameParts[1], allTelescopeClassNames)
+    telType = ''
+    for ii in range(2, len(nameParts)):
+        print(ii)
+        telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-') 
+    return site + '-' + telClass + '-' + telType
+
+
 allTelescopeTypeNames = {
     'SST': ['sst'],
     'SST-1M': ['1m'],
@@ -84,9 +96,17 @@ allTelescopeTypeNames = {
     'North-LST-Test': ['north-lst-test']
 }
 
+allTelescopeClassNames = {
+    'SST': ['sst'],
+    'MST-FlashCam': ['mst'],
+    'SCT': ['sct'],
+    'LST': ['lst']
+}
+
+
 allSiteNames = {
-    'Paranal': ['south'],
-    'LaPalma': ['north']
+    'South': ['paranal', 'south'],
+    'North': ['lapalma', 'north']
 }
 
 allModelVersionNames = {

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -246,23 +246,23 @@ def getSiteFromTelescopeName(name):
     return thisSite
 
 
-allTelescopeTypeNames = {
-    'SST': ['sst'],
-    'SST-1M': ['1m'],
-    'SST-2M-ASTRI': ['sst-astri', 'astri'],
-    'SST-2M-GCT-S': ['sst-gct', 'gct', 'sst-gct-s'],
-    'MST-FlashCam': ['flashcam', 'mst-fc'],
-    'MST-NectarCam': ['nectarcam', 'mst-nc'],
-    'SCT': ['mst-sct', 'sct'],
-    'LST': [],
-    'North-LST-1': ['north-lst-1'],
-    'North-LST-D234': ['north-lst-d234'],
-    'North-MST-FlashCam-D': ['north-flashcam-d', 'north-mst-fc-d'],
-    'North-MST-NectarCam-D': ['north-nectarcam-d', 'north-mst-nc-d'],
-    'North-SCT-D': ['north-mst-sct-d', 'north-sct-d'],
-    'South-SST-D': ['south-sst-d'],
-    'North-LST-Test': ['north-lst-test']
-}
+# allTelescopeTypeNames = {
+#     'SST': ['sst'],
+#     'SST-1M': ['1m'],
+#     'SST-2M-ASTRI': ['sst-astri', 'astri'],
+#     'SST-2M-GCT-S': ['sst-gct', 'gct', 'sst-gct-s'],
+#     'MST-FlashCam': ['flashcam', 'mst-fc'],
+#     'MST-NectarCam': ['nectarcam', 'mst-nc'],
+#     'SCT': ['mst-sct', 'sct'],
+#     'LST': [],
+#     'North-LST-1': ['north-lst-1'],
+#     'North-LST-D234': ['north-lst-d234'],
+#     'North-MST-FlashCam-D': ['north-flashcam-d', 'north-mst-fc-d'],
+#     'North-MST-NectarCam-D': ['north-nectarcam-d', 'north-mst-nc-d'],
+#     'North-SCT-D': ['north-mst-sct-d', 'north-sct-d'],
+#     'South-SST-D': ['south-sst-d'],
+#     'North-LST-Test': ['north-lst-test']
+# }
 
 allTelescopeClassNames = {
     'SST': ['sst'],
@@ -275,6 +275,7 @@ allCameraNames = {
     'SST': ['sst'],
     'ASTRI': ['astri'],
     'GCT': ['gct', 'gct-s'],
+    '1M': ['1m'],
     'FlashCam': ['flashcam', 'flash-cam'],
     'NectarCam': ['nectarcam', 'nectar-cam'],
     'SCT': ['sct'],

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -172,13 +172,36 @@ def validateTelescopeName(name):
     str
         Validated name.
     '''
+    telSite, telClass, telType = splitTelescopeName(name)
+    return telSite + '-' + telClass + '-' + telType
+
+
+def splitTelescopeName(name):
+    '''
+    Split a telescope name into site, class and type.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+        Telescope name.
+
+    Returns
+    -------
+    str, str, str
+        Site (South or North), class (LST, MST, SST ...) and type (any complement).
+    '''
     nameParts = name.split('-')
     thisSite = validateSiteName(nameParts[0])
     telClass = validateName(nameParts[1], allTelescopeClassNames)
     telType = ''
     for ii in range(2, len(nameParts)):
         telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-')
-    return thisSite + '-' + telClass + '-' + telType
+    return thisSite, telClass, telType
 
 
 def getSiteFromTelescopeName(name):

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -309,7 +309,7 @@ def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
 
 
 def rayTracingFileName(
-    telescopeType,
+    telescopeName,
     sourceDistance,
     zenithAngle,
     offAxisAngle,
@@ -322,8 +322,8 @@ def rayTracingFileName(
 
     Parameters
     ----------
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        North-LST-1, South-MST-FlashCam, ...
     sourceDistance: float
         Source distance (km).
     zenithAngle: float
@@ -344,7 +344,7 @@ def rayTracingFileName(
     '''
     name = '{}-{}-d{:.1f}-za{:.1f}-off{:.3f}'.format(
         base,
-        telescopeType,
+        telescopeName,
         sourceDistance,
         zenithAngle,
         offAxisAngle
@@ -355,14 +355,14 @@ def rayTracingFileName(
     return name
 
 
-def rayTracingResultsFileName(telescopeType, sourceDistance, zenithAngle, label):
+def rayTracingResultsFileName(telescopeName, sourceDistance, zenithAngle, label):
     '''
     Ray tracing results file name.
 
     Parameters
     ----------
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        North-LST-1, South-MST-FlashCam, ...
     sourceDistance: float
         Source distance (km).
     zenithAngle: float
@@ -375,12 +375,13 @@ def rayTracingResultsFileName(telescopeType, sourceDistance, zenithAngle, label)
     str
         File name.
     '''
-    name = 'ray-tracing-{}-d{:.1f}-za{:.1f}'.format(telescopeType, sourceDistance, zenithAngle)
+    name = 'ray-tracing-{}-d{:.1f}-za{:.1f}'.format(telescopeName, sourceDistance, zenithAngle)
     name += '_{}'.format(label) if label is not None else ''
     name += '.cvs'
     return name
 
-def rayTracingPlotFileName(key, telescopeType, sourceDistance, zenithAngle, label):
+
+def rayTracingPlotFileName(key, telescopeName, sourceDistance, zenithAngle, label):
     '''
     Ray tracing plot file name.
 
@@ -388,8 +389,8 @@ def rayTracingPlotFileName(key, telescopeType, sourceDistance, zenithAngle, labe
     ----------
     key: str
         Quantity to be plotted (d80_cm, d80_deg, eff_area or eff_flen)
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        South-LST-1, North-MST-FlashCam, ...
     sourceDistance: float
         Source distance (km).
     zenithAngle: float
@@ -402,19 +403,25 @@ def rayTracingPlotFileName(key, telescopeType, sourceDistance, zenithAngle, labe
     str
         File name.
     '''
-    name = 'ray-tracing-{}-{}-d{:.1f}-za{:.1f}'.format(telescopeType, key, sourceDistance, zenithAngle)
+    name = 'ray-tracing-{}-{}-d{:.1f}-za{:.1f}'.format(
+        telescopeName,
+        key,
+        sourceDistance,
+        zenithAngle
+    )
     name += '_{}'.format(label) if label is not None else ''
     name += '.pdf'
     return name
 
-def cameraEfficiencyResultsFileName(telescopeType, zenithAngle, label):
+
+def cameraEfficiencyResultsFileName(telescopeName, zenithAngle, label):
     '''
     Camera efficiency results file name.
 
     Parameters
     ----------
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        South-LST-1, North-MST-FlashCam, ...
     zenithAngle: float
         Zenith angle (deg).
     label: str
@@ -425,20 +432,20 @@ def cameraEfficiencyResultsFileName(telescopeType, zenithAngle, label):
     str
         File name.
     '''
-    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeType, zenithAngle)
+    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeName, zenithAngle)
     name += '_{}'.format(label) if label is not None else ''
     name += '.csv'
     return name
 
 
-def cameraEfficiencySimtelFileName(telescopeType, zenithAngle, label):
+def cameraEfficiencySimtelFileName(telescopeName, zenithAngle, label):
     '''
     Camera efficiency simtel output file name.
 
     Parameters
     ----------
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        North-LST-1, South-MST-FlashCam, ...
     zenithAngle: float
         Zenith angle (deg).
     label: str
@@ -449,20 +456,20 @@ def cameraEfficiencySimtelFileName(telescopeType, zenithAngle, label):
     str
         File name.
     '''
-    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeType, zenithAngle)
+    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeName, zenithAngle)
     name += '_{}'.format(label) if label is not None else ''
     name += '.dat'
     return name
 
 
-def cameraEfficiencyLogFileName(telescopeType, zenithAngle, label):
+def cameraEfficiencyLogFileName(telescopeName, zenithAngle, label):
     '''
     Camera efficiency log file name.
 
     Parameters
     ----------
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        South-LST-1, North-MST-FlashCam, ...
     zenithAngle: float
         Zenith angle (deg).
     label: str
@@ -473,7 +480,7 @@ def cameraEfficiencyLogFileName(telescopeType, zenithAngle, label):
     str
         File name.
     '''
-    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeType, zenithAngle)
+    name = 'camera-efficiency-{}-za{:.1f}'.format(telescopeName, zenithAngle)
     name += '_{}'.format(label) if label is not None else ''
     name += '.log'
     return name

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -57,6 +57,48 @@ def validateSimtelModeName(name):
     return validateName(name, allSimtelModeNames)
 
 
+def validateSiteName(name):
+    '''
+    Validate a site name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
+    return validateName(name, allSiteNames)
+
+
+def validateArrayName(name):
+    '''
+    Validate a array name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
+    return validateName(name, allArrayNames)
+
+
 def validateName(name, allNames):
     '''
     Validate a name given the allNames options. For each key in allNames, a list of options is
@@ -127,7 +169,7 @@ def validateTelescopeName(name):
         Validated name.
     '''
     nameParts = name.split('-')
-    thisSite = validateName(nameParts[0], allSiteNames)
+    thisSite = validateSiteName(nameParts[0])
     telClass = validateName(nameParts[1], allTelescopeClassNames)
     telType = ''
     for ii in range(2, len(nameParts)):

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -279,6 +279,8 @@ def convertTelescopeNameToYaml(name):
         return 'SCT'
     elif newName in 'LST-D234':
         return 'LST'
+    elif newName in 'LST-1':
+        return 'LST'
     else:
         logger.error('Telescope name {} could not be converted to yml names'.format(name))
         return None

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -8,7 +8,9 @@ __all__ = [
     'validateSiteName',
     'validateArrayName',
     'validateTelescopeName',
-    'getSiteFromTelescopeName'
+    'validateCameraName',
+    'splitTelescopeName',
+    'getSiteFromTelescopeName',
     'rayTracingFileName',
     'simtelConfigFileName',
     'simtelSingleMirrorListFileName',
@@ -17,6 +19,27 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def validateCameraName(name):
+    '''
+    Validate a camera name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
+    return validateName(name, allCameraNames)
 
 
 def validateModelVersionName(name):
@@ -243,7 +266,17 @@ allTelescopeTypeNames = {
 
 allTelescopeClassNames = {
     'SST': ['sst'],
-    'MST-FlashCam': ['mst'],
+    'MST': ['mst'],
+    'SCT': ['sct'],
+    'LST': ['lst']
+}
+
+allCameraNames = {
+    'SST': ['sst'],
+    'ASTRI': ['astri'],
+    'GCT': ['gct', 'gct-s'],
+    'FlashCam': ['flashcam', 'flash-cam'],
+    'NectarCam': ['nectarcam', 'nectar-cam'],
     'SCT': ['sct'],
     'LST': ['lst']
 }

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -3,8 +3,12 @@
 import logging
 
 __all__ = [
-    'validateName',
-    'isValidName',
+    'validateModelVersionName',
+    'validateSimtelModeName',
+    'validateSiteName',
+    'validateArrayName',
+    'validateTelescopeName',
+    'getSiteFromTelescopeName'
     'rayTracingFileName',
     'simtelConfigFileName',
     'simtelSingleMirrorListFileName',
@@ -177,6 +181,25 @@ def validateTelescopeName(name):
     return thisSite + '-' + telClass + '-' + telType
 
 
+def getSiteFromTelescopeName(name):
+    '''
+    Get site name (South or North) from the (validated) telescope name.
+
+    Parameters
+    ----------
+    name: str
+        Telescope name.
+
+    Returns
+    -------
+    str
+        Site name (South or North).
+    '''
+    nameParts = name.split('-')
+    thisSite = validateSiteName(nameParts[0])
+    return thisSite
+
+
 allTelescopeTypeNames = {
     'SST': ['sst'],
     'SST-1M': ['1m'],
@@ -266,10 +289,8 @@ def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
     ----------
     version: str
         Version of the model.
-    site: str
-        Paranal or LaPalma
-    telescopeType: str
-        LST, MST-FlashCam, ...
+    telescopeName: str
+        North-LST-1, South-MST-FlashCam, ...
     mirrorNumber: int
         Mirror number.
     label: str
@@ -280,7 +301,7 @@ def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
     str
         File name.
     '''
-    name = 'CTA-single-mirror-list-{}-{}-{}'.format(version, site, telescopeType)
+    name = 'CTA-single-mirror-list-{}-{}'.format(version, telescopeName)
     name += '-mirror{}'.format(mirrorNumber)
     name += '_{}'.format(label) if label is not None else ''
     name += '.dat'

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -15,6 +15,27 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+def validateModelVersionName(name):
+    '''
+    Validate a model version name.
+
+    Raises
+    ------
+    ValueError
+        If name is not valid.
+
+    Parameters
+    ----------
+    name: str
+
+    Returns
+    -------
+    str
+        Validated name.
+    '''
+    return validateName(name, allModelVersionNames)
+
+
 def validateName(name, allNames):
     '''
     Validate a name given the allNames options. For each key in allNames, a list of options is
@@ -68,12 +89,10 @@ def isValidName(name, allNames):
 
 def validateTelescopeName(name):
     nameParts = name.split('-')
-    print(nameParts)
     site = validateName(nameParts[0], allSiteNames)
     telClass = validateName(nameParts[1], allTelescopeClassNames)
     telType = ''
     for ii in range(2, len(nameParts)):
-        print(ii)
         telType += nameParts[ii] + ('' if ii == len(nameParts) - 1 else '-') 
     return site + '-' + telClass + '-' + telType
 


### PR DESCRIPTION
This is a big PR, many small changes in many modules.
Few items to be aware of:

- TelescopeNames follow the pattern "Site-Class-Type", where Site can be South or North, Class can be SST, MST, SCT or LST and Type can be anything. (The terms Class and Type are only relevant internally to util.names. For all the other modules, only telescopeName is meaningful.)
- The Type with single numbers should be reserved for real, on-site, telescopes. A letter D can be used to indicate telescopes designs.
- The Type can contain dashes itself, e.g South-MST-FlashCam-D (Type = FlashCam-D)
- The function util.names.validateTelescopeName checks if the site and class are valid (and convert it to the right form if necessary) but it does not check the Type. The Type validation will be better done by the db_handler, by checking if that telescopeName exists in the DB. I created an issue for that (https://github.com/gammasim/gammasim-tools/issues/52).
- All telescopeType variables were replaced by telescopeName. In all the cases where both telescopeType and site were passed, only telescopeName is passed now. When the site is needed, the function util.model.getSiteFromTelescopeName can be used.
- I introduced cameraNames, which are defined by the function util.model.getCameraName. This was necessary to deal with the camera-dependent parameters CAMERA_ROTATE_ANGLE and CAMERA_RADIUS_CURV. Instead of using the telescopeName as keys, I use now the cameraNames, that can be obtained by getCameraName(telescopeName). This is a good solution since the same camera will be part of many different telescopes.
- The TWO_MIRROR_TELESCOPE parameter was replaced by the function util.model.isTwoMirrorTelescope(telescopeName).
- The previously used telescope names can be obtained from a modern one with util.names.convertTelescopeNameToYaml. This is used whenever useMongoDB is set to False. At the moment, both LST-D234 and LST-1 are being converted to the same LST. @orelgueta , please have a look and fix it.
- The new names for the old unused telescopes are Site-SST-ASTRI, Site-SST-1M, Site-SST-GCT.
- IMPORTANT: The site parameters are being collected from the yml files in the TelescopeModel method _loadModelParameters. This is a temporary hack.
- BUG LEFT BEHIND: Some pytest's failed because sim_telarray complaint about the new parameters that we added to the model. We have to remove these parameters when exporting the config file (https://github.com/gammasim/gammasim-tools/issues/53). 



