### PR TITLE
Replacing few key words in telType by its right form

### DIFF
--- a/simtools/tests/test_names.py
+++ b/simtools/tests/test_names.py
@@ -7,8 +7,14 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 
 def test_validate_telescope_names():
-    newName = names.validateTelescopeName('north-sst-D')
-    print(newName)
+
+    def validate(name):
+        print('Validating {}'.format(name))
+        newName = names.validateTelescopeName(name)
+        print('New name {}'.format(newName))
+
+    for n in ['north-sst-d', 'south-mst-flashcam-d', 'north-sct-d']:
+        validate(n)
 
 
 def test_validate_other_names():

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -197,6 +197,21 @@ def validateTelescopeName(name):
         Validated name.
     '''
     telSite, telClass, telType = splitTelescopeName(name)
+    telSite = validateSiteName(telSite)
+    telClass = validateName(telClass, allTelescopeClassNames)
+    if 'flashcam' in telType:
+        telType = telType.replace('flashcam', 'FlashCam')
+    if 'nectarcam' in telType:
+        telType = telType.replace('nectarcam', 'NectarCam')
+    if '1m' in telType:
+        telType = telType.replace('1m', '1M')
+    if 'gct' in telType:
+        telType = telType.replace('gct', 'GCT')
+    if 'astri' in telType:
+        telType = telType.replace('astri', 'ASTRI')
+    if '-d' in '-' + telType:
+        telType = telType.replace('d', 'D')
+
     return telSite + '-' + telClass + '-' + telType
 
 
@@ -220,8 +235,8 @@ def splitTelescopeName(name):
         Site (South or North), class (LST, MST, SST ...) and type (any complement).
     '''
     nameParts = name.split('-')
-    thisSite = validateSiteName(nameParts[0])
-    telClass = validateName(nameParts[1], allTelescopeClassNames)
+    thisSite = nameParts[0]
+    telClass = nameParts[1]
     telType = '-'.join(nameParts[2:])
     return thisSite, telClass, telType
 


### PR DESCRIPTION
Now the telescope name validation will work fine for all current cases (flashcam, astri ...). We might need a better solution if the number of telescope types increases too much.