### PR TITLE
Turn db_handler to a class (and other small things)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytest-cov
   - scipy
   - pymongo
+  - bson
 
 # cheatsheet
 

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -9,7 +9,7 @@ import time
 import atexit
 import getpass
 from pathlib import Path
-from bson import ObjectId
+from bson.objectid import ObjectId
 from threading import Lock
 
 import pymongo

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -10,6 +10,7 @@ import atexit
 import getpass
 from pathlib import Path
 from bson import ObjectId
+from threading import Lock
 
 import pymongo
 import gridfs
@@ -21,695 +22,725 @@ import simtools.config as cfg
 from simtools.util import names
 from simtools.util.model import validateModelParameter, getTelescopeSize
 
-__all__ = ['getArrayDB']
+__all__ = [
+    'getArrayDB',
+    'getModelParameters',
+    'readMongoDB',
+    'writeModelFile',
+    'getModelFile',
+    'getFileMongoDB',
+    'writeFileFromMongoToDisk',
+    'copyTelescope',
+    'deleteQuery',
+    'updateParameter',
+    'addParameter',
+    'addNewParameter'
+]
 
 
-logger = logging.getLogger(__name__)
-
-# TODO move into config file?
-DB_TABULATED_DATA = 'CTA-Simulation-Model'
-DB_CTA_SIMULATION_MODEL = 'CTA-Simulation-Model'
-DB_CTA_SIMULATION_MODEL_DESCRIPTIONS = 'CTA-Simulation-Model-Descriptions'
-
-
-def createTunnel(localport, remoteport, user, mongodbServer, tunnelServer):
+class DatabaseHandler:
     '''
-    Create SSH Tunnels for database connection.
+    DatabaseHandler provides the interface to the DB.
 
-    Parameters
+    Attributes
     ----------
-    localport: int
-        The local port to connect to the DB through (for MongoDB, usually 27018)
-    remoteport: int
-        The port on the server to connect to the DB through (for MongoDB, usually 27017)
-    user: str
-        User name to connect with.
-    tunnelServer: str
-        The server to run the tunnel through (should be warp).
+    mode: str
+        Yaml or MongoDB, only these two options are allowed.
 
-    Returns
+    Methods
     -------
-    Tunnel process handle.
+    getModelParameters()
+        Get the model parameters of a specific telescope with a specific version.
+    copyTelescope()
+        Copy a full telescope configuration of a specific version to a new telescope name.
+    deleteQuery()
+        Delete all entries from the DB which correspond to the provided query.
+    updateParameter()
+        Update a parameter value for a specific telescope/version.
+    addParameter()
+        Add a parameter value for a specific telescope.
+    addNewParamete()
+        Add a new parameter for a specific telescope.
     '''
 
-    tunnelCmd = 'ssh -N -L {localport}:{mongodbServer}:{remoteport} {user}@{tunnelServer}'.format(
-        localport=localport,
-        remoteport=remoteport,
-        user=user,
-        mongodbServer=mongodbServer,
-        tunnelServer=tunnelServer
-    )
+    # TODO move into config file?
+    DB_TABULATED_DATA = 'CTA-Simulation-Model'
+    DB_CTA_SIMULATION_MODEL = 'CTA-Simulation-Model'
+    DB_CTA_SIMULATION_MODEL_DESCRIPTIONS = 'CTA-Simulation-Model-Descriptions'
 
-    args = shlex.split(tunnelCmd)
-    tunnel = subprocess.Popen(args)
+    dbClient = None
+    tunnel = None
 
-    time.sleep(2)  # Give it a couple seconds to finish setting up
+    def __init__(
+        self,
+        logger=__name__
+    ):
+        '''
+        Initialize the DatabaseHandler class.
 
-    # return the tunnel so you can kill it before you stop
-    # the program - else the connection will persist
-    # after the script ends
-    return tunnel
+        Parameters
+        ----------
+        logger: str
+            Logger name to use in this instance
+        '''
+        self._logger = logging.getLogger(logger)
+        self._logger.debug('Initialize DatabaseHandler')
 
+        if cfg.get('useMongoDB'):
+            if DatabaseHandler.dbClient is None or DatabaseHandler.tunnel is None:
+                with Lock():
+                    self.dbDetails = self._readDetailsMongoDB()
+                    DatabaseHandler.dbClient, DatabaseHandler.tunnel = self._openMongoDB()
 
-def closeSSHTunnel(tunnels):
-    '''
-    Close SSH tunnels given in the process handles "tunnels"
+    # END of _init_
 
-    Parameters
-    ----------
-    tunnels: a tunnel process handle (or a list of those)
-    '''
+    def _readDetailsMongoDB(self):
+        '''
+        Read the MongoDB details (server, user, pass, etc.) from an external file.
 
-    logger.info('Closing SSH tunnel(s)')
-    if not isinstance(tunnels, list):
-        tunnels = [tunnels]
+        Returns
+        -------
+        dbDetails: dict
+            Dictionary containing the DB details.
+        '''
 
-    for tunnel in tunnels:
-        tunnel.kill()
+        dbDetails = dict()
+        dbDetailsFile = cfg.get('mongoDBConfigFile')
+        with open(dbDetailsFile, 'r') as stream:
+            dbDetails = yaml.load(stream, Loader=yaml.FullLoader)
 
-    return
+        return dbDetails
 
+    def _openMongoDB(self):
+        '''
+        Open a connection to MongoDB and return the client to read/write to the DB with.
 
-def openMongoDB():
-    '''
-    Open a connection to MongoDB and return the client to read/write to the DB with.
+        Returns
+        -------
+        A PyMongo DB client and the tunnel process handle
+        '''
 
-    Returns
-    -------
-    A PyMongo DB client and the tunnel process handle
-    '''
+        user = getpass.getuser()
 
-    dbDetailsFile = cfg.get('mongoDBConfigFile')
-    dbDetails = readDetailsDB(dbDetailsFile)
-
-    user = getpass.getuser()
-
-    # Start tunnel
-    tunnel = createTunnel(
-        localport=dbDetails['localport'],
-        remoteport=dbDetails['remoteport'],
-        user=user,
-        mongodbServer=dbDetails['mongodbServer'],
-        tunnelServer=dbDetails['tunnelServer']
-    )
-    atexit.register(closeSSHTunnel, [tunnel])
-
-    userDB = dbDetails['userDB']
-    dbServer = 'localhost'
-    dbClient = MongoClient(
-        dbServer,
-        port=dbDetails['dbPort'],
-        username=userDB,
-        password=dbDetails['passDB'],
-        authSource=dbDetails['authenticationDatabase'],
-        ssl=True,
-        tlsallowinvalidhostnames=True,
-        tlsallowinvalidcertificates=True
-    )
-
-    return dbClient, tunnel
-
-
-def getArrayDB(databaseLocation):
-    '''
-    Get array db info as a dict.
-
-    Parameters
-    ----------
-    databaseLocation: str or Path
-
-    Returns
-    -------
-    dict
-    '''
-
-    file = Path(databaseLocation).joinpath('arrays').joinpath('arrays.yml')
-    out = dict()
-    with open(file, 'r') as stream:
-        out = yaml.load(stream, Loader=yaml.FullLoader)
-    return out
-
-
-def readDetailsDB(dbDetailsFile):
-    '''
-    Get a dict with db details (name, ports, password).
-
-    Parameters
-    ----------
-    dbDetailsFile: str or Path
-
-    Returns
-    -------
-    dict
-    '''
-
-    dbDetails = dict()
-    with open(dbDetailsFile, 'r') as stream:
-        dbDetails = yaml.load(stream, Loader=yaml.FullLoader)
-    return dbDetails
-
-
-def getModelParameters(telescopeType, version, onlyApplicable=False, runPath='./play/datFiles/'):
-    '''
-    Get parameters from either MongoDB or Yaml DB for a specific telescope.
-
-    Parameters
-    ----------
-    telescopeType: str
-    version: str
-        Version of the model.
-    onlyApplicable: bool
-        If True, only applicable parameters will be read.
-    runPath: Path or str
-        The sim_telarray run location to write the tabulated data files into.
-
-    Returns
-    -------
-    dict containing the parameters
-    '''
-
-    if cfg.get('useMongoDB'):
-        # TODO - This is probably not efficient to open a new connection
-        # every time we want to read the parameters of a single telescope.
-        # Change this to keep the connection open.
-        # Probably would be easier to do if db_handler is a class.
-        dbClient, tunnel = openMongoDB()
-        _pars = getModelParametersMongoDB(
-            dbClient,
-            DB_CTA_SIMULATION_MODEL,
-            telescopeType,
-            version,
-            onlyApplicable
+        # Start tunnel
+        _tunnel = self._createTunnel(
+            localport=self.dbDetails['localport'],
+            remoteport=self.dbDetails['remoteport'],
+            user=user,
+            mongodbServer=self.dbDetails['mongodbServer'],
+            tunnelServer=self.dbDetails['tunnelServer']
         )
-        atexit.unregister(closeSSHTunnel)
-        closeSSHTunnel([tunnel])
+        atexit.register(self._closeSSHTunnel, [_tunnel])
+
+        userDB = self.dbDetails['userDB']
+        dbServer = 'localhost'
+        _dbClient = MongoClient(
+            dbServer,
+            port=self.dbDetails['dbPort'],
+            username=userDB,
+            password=self.dbDetails['passDB'],
+            authSource=self.dbDetails['authenticationDatabase'],
+            ssl=True,
+            tlsallowinvalidhostnames=True,
+            tlsallowinvalidcertificates=True
+        )
+
+        return _dbClient, _tunnel
+
+    def _createTunnel(self, localport, remoteport, user, mongodbServer, tunnelServer):
+        '''
+        Create SSH Tunnels for database connection.
+
+        Parameters
+        ----------
+        localport: int
+            The local port to connect to the DB through (for MongoDB, usually 27018)
+        remoteport: int
+            The port on the server to connect to the DB through (for MongoDB, usually 27017)
+        user: str
+            User name to connect with.
+        tunnelServer: str
+            The server to run the tunnel through (should be warp).
+
+        Returns
+        -------
+        Tunnel process handle.
+        '''
+
+        tunnelCmd = 'ssh -N -L {localport}:{mongodbServer}:{remoteport} {user}@{tunnelServer}'.format(
+            localport=localport,
+            remoteport=remoteport,
+            user=user,
+            mongodbServer=mongodbServer,
+            tunnelServer=tunnelServer
+        )
+
+        args = shlex.split(tunnelCmd)
+        _tunnel = subprocess.Popen(args)
+
+        time.sleep(2)  # Give it a couple seconds to finish setting up
+
+        # return the tunnel so you can kill it before you stop
+        # the program - else the connection will persist
+        # after the script ends
+        return _tunnel
+
+    def _closeSSHTunnel(self, tunnels):
+        '''
+        Close SSH tunnels given in the process handles "tunnels"
+
+        Parameters
+        ----------
+        tunnels: a tunnel process handle (or a list of those)
+        '''
+
+        self._logger.info('Closing SSH tunnel(s)')
+        if not isinstance(tunnels, list):
+            tunnels = [tunnels]
+
+        for _tunnel in tunnels:
+            _tunnel.kill()
+
+        return
+
+    def getArrayDB(self, databaseLocation):
+        '''
+        Get array db info as a dict.
+
+        Parameters
+        ----------
+        databaseLocation: str or Path
+
+        Returns
+        -------
+        dict
+        '''
+
+        file = Path(databaseLocation).joinpath('arrays').joinpath('arrays.yml')
+        out = dict()
+        with open(file, 'r') as stream:
+            out = yaml.load(stream, Loader=yaml.FullLoader)
+        return out
+
+    def getModelParameters(
+        self,
+        telescopeType,
+        version,
+        onlyApplicable=False,
+        runPath='./play/datFiles/'
+    ):
+        '''
+        Get parameters from either MongoDB or Yaml DB for a specific telescope.
+
+        Parameters
+        ----------
+        telescopeType: str
+        version: str
+            Version of the model.
+        onlyApplicable: bool
+            If True, only applicable parameters will be read.
+        runPath: Path or str
+            The sim_telarray run location to write the tabulated data files into.
+
+        Returns
+        -------
+        dict containing the parameters
+        '''
+
+        if cfg.get('useMongoDB'):
+            _pars = self._getModelParametersMongoDB(
+                DatabaseHandler.DB_CTA_SIMULATION_MODEL,
+                telescopeType,
+                version,
+                onlyApplicable
+            )
+            return _pars
+        else:
+            return self._getModelParametersYaml(telescopeType, version, onlyApplicable)
+
+    def _getModelParametersYaml(self, telescopeType, version, onlyApplicable=False):
+        '''
+        Get parameters from DB for one specific type.
+
+        Parameters
+        ----------
+        telescopeType: str
+        version: str
+            Version of the model.
+        onlyApplicable: bool
+            If True, only applicable parameters will be read.
+
+        Returns
+        -------
+        dict containing the parameters
+        '''
+
+        _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
+        _versionValidated = names.validateName(version, names.allModelVersionNames)
+
+        if getTelescopeSize(_telTypeValidated) == 'MST':
+            # MST-FlashCam or MST-NectarCam
+            _whichTelLabels = [_telTypeValidated, 'MST-optics']
+        elif _telTypeValidated == 'SST':
+            # SST = SST-Camera + SST-Structure
+            _whichTelLabels = ['SST-Camera', 'SST-Structure']
+        else:
+            _whichTelLabels = [_telTypeValidated]
+
+        # Selecting version and applicable (if on)
+        _pars = dict()
+        for _tel in _whichTelLabels:
+            _allPars = self._getAllModelParametersYaml(_tel, _versionValidated)
+
+            # If tel is a struture, only applicable pars will be collected, always.
+            # The default ones will be covered by the camera pars.
+            _selectOnlyApplicable = onlyApplicable or (_tel in ['MST-optics', 'SST-Structure'])
+
+            for parNameIn, parInfo in _allPars.items():
+
+                if not parInfo['Applicable'] and _selectOnlyApplicable:
+                    continue
+
+                _pars[parNameIn] = parInfo[_versionValidated]
+
         return _pars
-    else:
-        return getModelParametersYaml(telescopeType, version, onlyApplicable)
 
+    def _getModelParametersMongoDB(
+        self,
+        dbName,
+        telescopeType,
+        version,
+        runLocation,
+        onlyApplicable=False
+    ):
+        '''
+        Get parameters from MongoDB for a specific telescope.
 
-def getModelParametersYaml(telescopeType, version, onlyApplicable=False):
-    '''
-    Get parameters from DB for one specific type.
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB
+        telescopeType: str
+        version: str
+            Version of the model.
+        runLocation: Path or str
+            The sim_telarray run location to write the tabulated data files into.
+        onlyApplicable: bool
+            If True, only applicable parameters will be read.
 
-    Parameters
-    ----------
-    telescopeType: str
-    version: str
-        Version of the model.
-    onlyApplicable: bool
-        If True, only applicable parameters will be read.
+        Returns
+        -------
+        dict containing the parameters
+        '''
 
-    Returns
-    -------
-    dict containing the parameters
-    '''
+        # TODO the naming is a mess at the moment, need to fix it everywhere consistently.
+        _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
+        _versionValidated = names.validateName(version, names.allModelVersionNames)
 
-    _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
-    _versionValidated = names.validateName(version, names.allModelVersionNames)
+        site = _telTypeValidated.split('-')[0]
+        if 'MST' in _telTypeValidated:
+            # MST-FlashCam or MST-NectarCam
+            _whichTelLabels = [_telTypeValidated, '{}-MST-Structure-D'.format(site)]
+        elif 'SST' in _telTypeValidated:
+            # SST = SST-Camera + SST-Structure
+            _whichTelLabels = ['{}-SST-Camera-D'.format(site), '{}-SST-Structure'.format(site)]
+        else:
+            _whichTelLabels = [_telTypeValidated]
 
-    if getTelescopeSize(_telTypeValidated) == 'MST':
-        # MST-FlashCam or MST-NectarCam
-        _whichTelLabels = [_telTypeValidated, 'MST-optics']
-    elif _telTypeValidated == 'SST':
-        # SST = SST-Camera + SST-Structure
-        _whichTelLabels = ['SST-Camera', 'SST-Structure']
-    else:
-        _whichTelLabels = [_telTypeValidated]
+        # Selecting version and applicable (if on)
+        _pars = dict()
+        for _tel in _whichTelLabels:
 
-    # Selecting version and applicable (if on)
-    _pars = dict()
-    for _tel in _whichTelLabels:
-        _allPars = getAllModelParametersYaml(_tel, _versionValidated)
+            # If tel is a struture, only applicable pars will be collected, always.
+            # The default ones will be covered by the camera pars.
+            _selectOnlyApplicable = onlyApplicable or (_tel in [
+                '{}-MST-Structure-D'.format(site),
+                '{}-SST-Structure-D'.format(site)
+            ])
 
-        # If tel is a struture, only applicable pars will be collected, always.
-        # The default ones will be covered by the camera pars.
-        _selectOnlyApplicable = onlyApplicable or (_tel in ['MST-optics', 'SST-Structure'])
+            _pars.update(self.readMongoDB(
+                dbName,
+                _tel,
+                _versionValidated,
+                runLocation,
+                True,
+                _selectOnlyApplicable
+            ))
 
-        for parNameIn, parInfo in _allPars.items():
+        return _pars
 
-            if not parInfo['Applicable'] and _selectOnlyApplicable:
-                continue
+    def readMongoDB(
+        self,
+        dbName,
+        telescopeType,
+        version,
+        runLocation,
+        writeFiles=True,
+        onlyApplicable=False
+    ):
+        '''
+        Build and execute query to Read the MongoDB for a specific telescope.
+        Also writes the files listed in the parameter values into the sim_telarray run location
 
-            _pars[parNameIn] = parInfo[_versionValidated]
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB
+        telescopeType: str
+        version: str
+            Version of the model.
+        runLocation: Path or str
+            The sim_telarray run location to write the tabulated data files into.
+        writeFiles: bool
+            If true, write the files to the runLocation.
+        onlyApplicable: bool
+            If True, only applicable parameters will be read.
 
-    return _pars
+        Returns
+        -------
+        dict containing the parameters
+        '''
 
+        posts = DatabaseHandler.dbClient[dbName].posts
+        _parameters = dict()
 
-def getModelParametersMongoDB(
-    dbClient,
-    dbName,
-    telescopeType,
-    version,
-    runLocation,
-    onlyApplicable=False
-):
-    '''
-    Get parameters from MongoDB for a specific telescope.
+        query = {
+            'Telescope': telescopeType,
+            'Version': version,
+        }
+        if onlyApplicable:
+            query['Applicable'] = onlyApplicable
+        for post in posts.find(query):
+            parNow = post['Parameter']
+            _parameters[parNow] = post
+            _parameters[parNow].pop('Parameter', None)
+            _parameters[parNow].pop('Telescope', None)
+            _parameters[parNow]['entryDate'] = ObjectId(post['_id']).generation_time
+            if _parameters[parNow]['File'] and writeFiles:
+                file = self.getFileMongoDB(
+                    dbName,
+                    _parameters[parNow]['Value']
+                )
 
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB
-    telescopeType: str
-    version: str
-        Version of the model.
-    runLocation: Path or str
-        The sim_telarray run location to write the tabulated data files into.
-    onlyApplicable: bool
-        If True, only applicable parameters will be read.
+                self.writeFileFromMongoToDisk(dbName, runLocation, file)
 
-    Returns
-    -------
-    dict containing the parameters
-    '''
+        return _parameters
 
-    # TODO the naming is a mess at the moment, need to fix it everywhere consistently.
-    _telTypeValidated = names.validateName(telescopeType, names.allTelescopeTypeNames)
-    _versionValidated = names.validateName(version, names.allModelVersionNames)
+    def _getAllModelParametersYaml(self, telescopeType, version):
+        '''
+        Get all parameters from Yaml DB for one specific type.
+        No selection is applied.
 
-    site = _telTypeValidated.split('-')[0]
-    if 'MST' in _telTypeValidated:
-        # MST-FlashCam or MST-NectarCam
-        _whichTelLabels = [_telTypeValidated, '{}-MST-Structure-D'.format(site)]
-    elif 'SST' in _telTypeValidated:
-        # SST = SST-Camera + SST-Structure
-        _whichTelLabels = ['{}-SST-Camera-D'.format(site), '{}-SST-Structure'.format(site)]
-    else:
-        _whichTelLabels = [_telTypeValidated]
+        Parameters
+        ----------
+        telescopeType: str
+        version: str
+            Version of the model.
 
-    # Selecting version and applicable (if on)
-    _pars = dict()
-    for _tel in _whichTelLabels:
+        Returns
+        -------
+        dict containing the parameters
+        '''
 
-        # If tel is a struture, only applicable pars will be collected, always.
-        # The default ones will be covered by the camera pars.
-        _selectOnlyApplicable = onlyApplicable or (_tel in [
-            '{}-MST-Structure-D'.format(site),
-            '{}-SST-Structure-D'.format(site)
-        ])
+        _fileNameDB = 'parValues-{}.yml'.format(telescopeType)
+        _yamlFile = cfg.findFile(
+            _fileNameDB,
+            cfg.get('modelFilesLocations')
+        )
+        self._logger.debug('Reading DB file {}'.format(_yamlFile))
+        with open(_yamlFile, 'r') as stream:
+            _allPars = yaml.load(stream, Loader=yaml.FullLoader)
+        return _allPars
 
-        _pars.update(readMongoDB(
-            dbClient,
-            dbName,
-            _tel,
-            _versionValidated,
-            runLocation,
-            _selectOnlyApplicable
-        ))
+    def writeModelFile(self, fileName, destDir):
+        '''
+        Find the fileName in the model files location and write a copy
+        at the destDir directory.
 
-    return _pars
+        Parameters
+        ----------
+        fileName: str or Path
+            File name to be found and copied.
+        destDir: str or Path
+            Path of the directory where the file will be written.
+        '''
 
+        destFile = Path(destDir).joinpath(fileName)
+        file = Path(self.getModelFile(fileName))
+        destFile.write_text(file.read_text())
 
-def readMongoDB(
-    dbClient,
-    dbName,
-    telescopeType,
-    version,
-    runLocation,
-    onlyApplicable=False
-):
-    '''
-    Build and execute query to Read the MongoDB for a specific telescope.
-    Also writes the files listed in the parameter values into the sim_telarray run location
+    def getModelFile(self, fileName):
+        '''
+        Find file in model files locations and return its full path.
 
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB
-    telescopeType: str
-    version: str
-        Version of the model.
-    runLocation: Path or str
-        The sim_telarray run location to write the tabulated data files into.
-    onlyApplicable: bool
-        If True, only applicable parameters will be read.
+        Parameters
+        ----------
+        fileName: str
+            File name to be found.
 
-    Returns
-    -------
-    dict containing the parameters
-    '''
+        Returns
+        -------
+        Path
+            Full path of the file.
+        '''
 
-    posts = dbClient[dbName].posts
-    _parameters = dict()
+        file = cfg.findFile(fileName, cfg.get('modelFilesLocations'))
+        return file
 
-    query = {
-        'Telescope': telescopeType,
-        'Version': version,
-    }
-    if onlyApplicable:
-        query['Applicable'] = onlyApplicable
-    for i_entry, post in enumerate(posts.find(query)):
-        parNow = post['Parameter']
-        _parameters[parNow] = post
-        _parameters[parNow].pop('Parameter', None)
-        _parameters[parNow].pop('Telescope', None)
-        _parameters[parNow]['entryDate'] = ObjectId(post['_id']).generation_time
-        if _parameters[parNow]['File']:
-            file = getFileMongoDB(
-                dbClient,
-                DB_TABULATED_DATA,
-                _parameters[parNow]['Value']
+    def getFileMongoDB(self, dbName, fileName):
+        '''
+        Extract a file from MongoDB and write it to disk
+
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB with files of tabulated data
+        fileName: str
+            The name of the file requested
+
+        Returns
+        -------
+        GridOut
+            A file instance returned by GridFS find_one
+        '''
+
+        db = DatabaseHandler.dbClient[dbName]
+        fileSystem = gridfs.GridFS(db)
+        if fileSystem.exists({'filename': fileName}):
+            return fileSystem.find_one({'filename': fileName})
+        else:
+            raise FileNotFoundError(
+                'The file {} does not exist in the database {}'.format(fileName, dbName)
             )
 
-            writeFileFromMongoToDisk(dbClient, DB_TABULATED_DATA, runLocation, file)
+    def writeFileFromMongoToDisk(self, dbName, path, file):
+        '''
+        Extract a file from MongoDB and write it to disk
 
-    return _parameters
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB with files of tabulated data
+        path: str or Path
+            The path to write the file to
+        file: GridOut
+            A file instance returned by GridFS find_one
+        '''
 
+        db = DatabaseHandler.dbClient[dbName]
+        fsOutput = gridfs.GridFSBucket(db)
+        with open(Path(path).joinpath(file.filename), 'wb') as outputFile:
+            fsOutput.download_to_stream_by_name(file.filename, outputFile)
 
-def getAllModelParametersYaml(telescopeType, version):
-    '''
-    Get all parameters from Yaml DB for one specific type.
-    No selection is applied.
+        return
 
-    Parameters
-    ----------
-    telescopeType: str
-    version: str
-        Version of the model.
+    def copyTelescope(self, dbName, telToCopy, versionToCopy, newTelName, dbToCopyTo=None):
+        '''
+        Copy a full telescope configuration to a new telescope name.
+        Only a specific version is copied.
+        (This function should be rarely used, probably only during "construction".)
 
-    Returns
-    -------
-    dict containing the parameters
-    '''
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB to copy from
+        telToCopy: str
+            The telescope to copy
+        versionToCopy: str
+            The version of the configuration to copy
+        newTelName: str
+            The name of the new telescope
+        dbToCopyTo: str
+            The name of the DB to copy to (default is the same as dbName)
+        '''
 
-    _fileNameDB = 'parValues-{}.yml'.format(telescopeType)
-    _yamlFile = cfg.findFile(
-        _fileNameDB,
-        cfg.get('modelFilesLocations')
-    )
-    logger.debug('Reading DB file {}'.format(_yamlFile))
-    with open(_yamlFile, 'r') as stream:
-        _allPars = yaml.load(stream, Loader=yaml.FullLoader)
-    return _allPars
+        if dbToCopyTo is None:
+            dbToCopyTo = dbName
 
+        self._logger.info('Copying version {} of {} to the new telescope {} in the {} DB'.format(
+            versionToCopy,
+            telToCopy,
+            newTelName,
+            dbToCopyTo
+        ))
 
-def writeModelFile(fileName, destDir):
-    '''
-    Find the fileName in the model files location and write a copy
-    at the destDir directory.
+        collection = DatabaseHandler.dbClient[dbName].posts
+        _parameters = dict()
+        dbEntries = list()
 
-    Parameters
-    ----------
-    fileName: str or Path
-        File name to be found and copied.
-    destDir: str or Path
-        Path of the directory where the file will be written.
-    '''
-
-    destFile = Path(destDir).joinpath(fileName)
-    file = Path(getModelFile(fileName))
-    destFile.write_text(file.read_text())
-
-
-def getModelFile(fileName):
-    '''
-    Find file in model files locations and return its full path.
-
-    Parameters
-    ----------
-    fileName: str
-        File name to be found.
-
-    Returns
-    -------
-    Path
-        Full path of the file.
-    '''
-
-    file = cfg.findFile(fileName, cfg.get('modelFilesLocations'))
-    return file
-
-
-def getFileMongoDB(dbClient, dbName, fileName):
-    '''
-    Extract a file from MongoDB and write it to disk
-
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB with files of tabulated data
-    fileName: str
-        The name of the file requested
-
-    Returns
-    -------
-    GridOut
-        A file instance returned by GridFS find_one
-    '''
-
-    db = dbClient[dbName]
-    fileSystem = gridfs.GridFS(db)
-    if fileSystem.exists({'filename': fileName}):
-        return fileSystem.find_one({'filename': fileName})
-    else:
-        raise FileNotFoundError(
-            'The file {} does not exist in the database {}'.format(fileName, dbName)
-        )
-
-
-def writeFileFromMongoToDisk(dbClient, dbName, path, file):
-    '''
-    Extract a file from MongoDB and write it to disk
-
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB with files of tabulated data
-    path: str or Path
-        The path to write the file to
-    file: GridOut
-        A file instance returned by GridFS find_one
-    '''
-
-    db = dbClient[dbName]
-    fsOutput = gridfs.GridFSBucket(db)
-    with open(Path(path).joinpath(file.filename), 'wb') as outputFile:
-        fsOutput.download_to_stream_by_name(file.filename, outputFile)
-
-    return
-
-
-def copyTelescope(dbClient, dbName, telToCopy, versionToCopy, newTelName, dbToCopyTo=None):
-    '''
-    Copy a full telescope configuration to a new telescope name.
-    Only a specific version is copied.
-    (This function should be rarely used, probably only during "construction".)
-
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB to copy from
-    telToCopy: str
-        The telescope to copy
-    versionToCopy: str
-        The version of the configuration to copy
-    newTelName: str
-        The name of the new telescope
-    dbToCopyTo: str
-        The name of the DB to copy to (default is the same as dbName)
-    '''
-
-    if dbToCopyTo is None:
-        dbToCopyTo = dbName
-
-    logger.info('Copying version {} of {} to the new telescope {} in the {} DB'.format(
-        versionToCopy,
-        telToCopy,
-        newTelName,
-        dbToCopyTo
-    ))
-
-    collection = dbClient[dbName].posts
-    _parameters = dict()
-    dbEntries = list()
-
-    query = {
-        'Telescope': telToCopy,
-        'Version': versionToCopy,
-    }
-    for i_entry, post in enumerate(collection.find(query)):
-        post['Telescope'] = newTelName
-        post.pop('_id', None)
-        dbEntries.append(post)
-
-    logger.info('Creating new telescope {}'.format(newTelName))
-    db = dbClient[dbToCopyTo]
-    posts = db.posts
-    try:
-        posts.insert_many(dbEntries)
-    except BulkWriteError as exc:
-        raise exc(exc.details)
-
-    return
-
-
-def deleteQuery(dbClient, dbName, query):
-    '''
-    Delete all entries from the DB which correspond to the provided query.
-    (This function should be rarely used, if at all.)
-
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the DB
-    query: dict
-        A dictionary listing the fields/values to delete.
-        For example,
         query = {
-            'Telescope': 'North-LST-1',
-            'Version': 'prod4',
+            'Telescope': telToCopy,
+            'Version': versionToCopy,
         }
-        would delete the entire prod4 version from telescope North-LST-1.
-    '''
+        for post in collection.find(query):
+            post['Telescope'] = newTelName
+            post.pop('_id', None)
+            dbEntries.append(post)
 
-    collection = dbClient[dbName].posts
+        self._logger.info('Creating new telescope {}'.format(newTelName))
+        db = DatabaseHandler.dbClient[dbToCopyTo]
+        posts = db.posts
+        try:
+            posts.insert_many(dbEntries)
+        except BulkWriteError as exc:
+            raise exc(exc.details)
 
-    logger.info('Deleting {} entries from {}'.format(
-        collection.count_documents(query),
-        dbName,
-    ))
+        return
 
-    collection.delete_many(query)
+    def deleteQuery(self, dbName, query):
+        '''
+        Delete all entries from the DB which correspond to the provided query.
+        (This function should be rarely used, if at all.)
 
-    return
+        Parameters
+        ----------
+        dbName: str
+            the name of the DB
+        query: dict
+            A dictionary listing the fields/values to delete.
+            For example,
+            query = {
+                'Telescope': 'North-LST-1',
+                'Version': 'prod4',
+            }
+            would delete the entire prod4 version from telescope North-LST-1.
+        '''
 
+        collection = DatabaseHandler.dbClient[dbName].posts
 
-def updateParameter(dbClient, dbName, telescope, version, parameter, newValue):
-    '''
-    Update a parameter value for a specific telescope/version.
-    (This function should be rarely used, since new values should ideally have their own version.)
+        self._logger.info('Deleting {} entries from {}'.format(
+            collection.count_documents(query),
+            dbName,
+        ))
 
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the file DB
-    telescope: str
-        Which telescope to update
-    version: str
-        Which version to update
-    parameter: str
-        Which parameter to update
-    newValue: type identical to the original parameter type
-        The new value to set for the parameter
-    '''
+        collection.delete_many(query)
 
-    collection = dbClient[dbName].posts
+        return
 
-    query = {
-        'Telescope': telescope,
-        'Version': version,
-        'Parameter': parameter,
-    }
+    def updateParameter(self, dbName, telescope, version, parameter, newValue):
+        '''
+        Update a parameter value for a specific telescope/version.
+        (This function should be rarely used since new values
+         should ideally have their own version.)
 
-    parEntry = collection.find_one(query)
-    oldValue = parEntry['Value']
+        Parameters
+        ----------
+        dbName: str
+            the name of the file DB
+        telescope: str
+            Which telescope to update
+        version: str
+            Which version to update
+        parameter: str
+            Which parameter to update
+        newValue: type identical to the original parameter type
+            The new value to set for the parameter
+        '''
 
-    logger.info('For telescope {}, version {}\nreplacing {} value from {} to {}'.format(
-        telescope,
-        version,
-        parameter,
-        oldValue,
-        newValue
-    ))
+        collection = DatabaseHandler.dbClient[dbName].posts
 
-    queryUpdate = {'$set': {'Value': newValue}}
+        query = {
+            'Telescope': telescope,
+            'Version': version,
+            'Parameter': parameter,
+        }
 
-    collection.update_one(query, queryUpdate)
+        parEntry = collection.find_one(query)
+        oldValue = parEntry['Value']
 
-    return
+        self._logger.info('For telescope {}, version {}\nreplacing {} value from {} to {}'.format(
+            telescope,
+            version,
+            parameter,
+            oldValue,
+            newValue
+        ))
 
+        queryUpdate = {'$set': {'Value': newValue}}
 
-def addParameter(dbClient, dbName, telescope, parameter, newVersion, newValue):
-    '''
-    Add a parameter value for a specific telescope.
-    A new document will be added to the DB,
-    with all fields taken from the last entry of this parameter to this telescope,
-    except the ones changed.
+        collection.update_one(query, queryUpdate)
 
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the file DB
-    telescope: str
-        Which telescope to update
-    parameter: str
-        Which parameter to add
-    newVersion: str
-        The version of the new parameter value
-    newValue: type identical to the original parameter type
-        The new value to set for the parameter
-    '''
+        return
 
-    collection = dbClient[dbName].posts
+    def addParameter(self, dbName, telescope, parameter, newVersion, newValue):
+        '''
+        Add a parameter value for a specific telescope.
+        A new document will be added to the DB,
+        with all fields taken from the last entry of this parameter to this telescope,
+        except the ones changed.
 
-    query = {
-        'Telescope': telescope,
-        'Parameter': parameter,
-    }
+        Parameters
+        ----------
+        dbName: str
+            the name of the file DB
+        telescope: str
+            Which telescope to update
+        parameter: str
+            Which parameter to add
+        newVersion: str
+            The version of the new parameter value
+        newValue: type identical to the original parameter type
+            The new value to set for the parameter
+        '''
 
-    parEntry = collection.find(query).sort('_id', pymongo.DESCENDING)[0]
-    parEntry['Value'] = newValue
-    parEntry['Version'] = newVersion
-    parEntry.pop('_id', None)
+        collection = DatabaseHandler.dbClient[dbName].posts
 
-    logger.info('Will add the following entry to DB\n', parEntry)
+        query = {
+            'Telescope': telescope,
+            'Parameter': parameter,
+        }
 
-    collection.insert_one(parEntry)
+        parEntry = collection.find(query).sort('_id', pymongo.DESCENDING)[0]
+        parEntry['Value'] = newValue
+        parEntry['Version'] = newVersion
+        parEntry.pop('_id', None)
 
-    return
+        self._logger.info('Will add the following entry to DB\n', parEntry)
 
+        collection.insert_one(parEntry)
 
-def addNewParameter(dbClient, dbName, telescope, version, parameter, value, **kwargs):
-    '''
-    Add a parameter value for a specific telescope.
-    A new document will be added to the DB,
-    with all fields taken from the last entry of this parameter to this telescope,
-    except the ones changed.
+        return
 
-    Parameters
-    ----------
-    dbClient: a MongoDB client provided by openMongoDB
-    dbName: str
-        the name of the file DB
-    telescope: str
-        The name of the telescope to add a parameter to.
-        Assumed to be a valid name!
-    parameter: str
-        Which parameter to add
-    version: str
-        The version of the new parameter value
-    value: can be any type, preferably given in kwargs
-        The value to set for the new parameter
-    kwargs: dict
-        Any additional fields to add to the parameter
-    '''
+    def addNewParameter(self, dbName, telescope, version, parameter, value, **kwargs):
+        '''
+        Add a parameter value for a specific telescope.
+        A new document will be added to the DB,
+        with all fields taken from the input parameters.
 
-    collection = dbClient[dbName].posts
+        Parameters
+        ----------
+        dbName: str
+            the name of the file DB
+        telescope: str
+            The name of the telescope to add a parameter to.
+            Assumed to be a valid name!
+        parameter: str
+            Which parameter to add
+        version: str
+            The version of the new parameter value
+        value: can be any type, preferably given in kwargs
+            The value to set for the new parameter
+        kwargs: dict
+            Any additional fields to add to the parameter
+        '''
 
-    dbEntry = dict()
-    dbEntry['Telescope'] = telescope
-    dbEntry['Version'] = version
-    dbEntry['Parameter'] = parameter
-    dbEntry['Value'] = value
-    dbEntry['Type'] = kwargs['Type'] if 'Type' in kwargs else str(type(value))
-    dbEntry['File'] = False
-    if '.dat' in str(value) or '.txt' in str(value):
-        dbEntry['File'] = True
+        collection = DatabaseHandler.dbClient[dbName].posts
 
-    kwargs.pop('Type', None)
-    dbEntry.update(kwargs)
+        dbEntry = dict()
+        dbEntry['Telescope'] = telescope
+        dbEntry['Version'] = version
+        dbEntry['Parameter'] = parameter
+        dbEntry['Value'] = value
+        dbEntry['Type'] = kwargs['Type'] if 'Type' in kwargs else str(type(value))
+        dbEntry['File'] = False
+        if '.dat' in str(value) or '.txt' in str(value):
+            dbEntry['File'] = True
 
-    logger.info('Will add the following entry to DB\n', dbEntry)
+        kwargs.pop('Type', None)
+        dbEntry.update(kwargs)
 
-    collection.insert_one(dbEntry)
+        self._logger.info('Will add the following entry to DB\n', dbEntry)
 
-    return
+        collection.insert_one(dbEntry)
+
+        return

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -51,6 +51,8 @@ class DatabaseHandler:
     -------
     getModelParameters()
         Get the model parameters of a specific telescope with a specific version.
+    getSiteParameters()
+        Get the site parameters of a specific version of a site.
     copyTelescope()
         Copy a full telescope configuration of a specific version to a new telescope name.
     deleteQuery()

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -22,20 +22,7 @@ import simtools.config as cfg
 from simtools.util import names
 from simtools.util.model import getTelescopeClass
 
-__all__ = [
-    'getArrayDB',
-    'getModelParameters',
-    'readMongoDB',
-    'writeModelFile',
-    'getModelFile',
-    'getFileMongoDB',
-    'writeFileFromMongoToDisk',
-    'copyTelescope',
-    'deleteQuery',
-    'updateParameter',
-    'addParameter',
-    'addNewParameter'
-]
+__all__ = ['DatabaseHandler']
 
 
 class DatabaseHandler:

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -11,7 +11,7 @@ import yaml
 from pathlib import Path
 
 from simtools.util import names
-import simtools.db_handler as db
+from simtools import db_handler
 
 __all__ = ['getArray', 'ArrayModel']
 
@@ -30,6 +30,7 @@ def getArray(arrayName, databaseLocation):
     """
 
     arrayName = names.validateArrayName(arrayName)
+    db = db_handler.DatabaseHandler(logger.name)
     allArrays = db.getArrayDB(databaseLocation)
     return allArrays[arrayName]
 

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -30,7 +30,7 @@ def getArray(arrayName, databaseLocation):
     """
 
     arrayName = names.validateArrayName(arrayName)
-    db = db_handler.DatabaseHandler(logger.name)
+    db = db_handler.DatabaseHandler()
     allArrays = db.getArrayDB(databaseLocation)
     return allArrays[arrayName]
 

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import simtools.config as cfg
 import simtools.io_handler as io
-import simtools.db_handler as db
+from simtools import db_handler
 from simtools.util import names
 from simtools.util.model import validateModelParameter
 from simtools.model.mirrors import Mirrors
@@ -218,6 +218,7 @@ class TelescopeModel:
         ''' Read parameters from DB and store them in _parameters. '''
 
         self._setConfigFileDirectory()
+        db = db_handler.DatabaseHandler(logger.name)
         self._parameters = db.getModelParameters(
             self.telescopeName,
             self.version,

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -150,6 +150,10 @@ def test_modify_db():
 
 def test_reading_db_sites():
 
+    # This test is only relevant for the MongoDB
+    if not cfg.get('useMongoDB'):
+        return
+
     db = db_handler.DatabaseHandler(logger.name)
     logger.info('----Testing reading La Palma parameters-----')
     pars = db.getSiteParameters('North', 'prod4', testDataDirectory)

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -75,7 +75,7 @@ def test_reading_db_sst():
 
 def test_modify_db():
 
-    logger.info('----Testing copying a whole telescope-----')
+    # logger.info('----Testing copying a whole telescope-----')
     dbClient, tunnel = db.openMongoDB()
     db.copyTelescope(
         dbClient,
@@ -111,6 +111,18 @@ def test_modify_db():
     )
     pars = db.readMongoDB(dbClient, 'sandbox', 'North-LST-Test', 'test', testDataDirectory)
     assert(pars['camera_config_version']['Value'] == 999)
+
+    logger.info('----Testing adding a new parameter-----')
+    db.addNewParameter(
+        dbClient,
+        'sandbox',
+        'North-LST-Test',
+        'test',
+        'camera_config_version_test',
+        999
+    )
+    pars = db.readMongoDB(dbClient, 'sandbox', 'North-LST-Test', 'test', testDataDirectory)
+    assert(pars['camera_config_version_test']['Value'] == 999)
 
     logger.info('----Testing deleting a query (a whole telescope in this case)-----')
     query = {'Telescope': 'North-LST-Test'}

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -20,8 +20,12 @@ def test_reading_db_lst():
     logger.info('----Testing reading LST-----')
     db = db_handler.DatabaseHandler(logger.name)
     pars = db.getModelParameters('north-lst-1', 'prod4', testDataDirectory)
-    assert(pars['parabolic_dish']['Value'] == 1)
-    assert(pars['camera_pixels']['Value'] == 1855)
+    if cfg.get('useMongoDB'):
+        assert(pars['parabolic_dish']['Value'] == 1)
+        assert(pars['camera_pixels']['Value'] == 1855)
+    else:
+        assert(pars['parabolic_dish'] == 1)
+        assert(pars['camera_pixels'] == 1855)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
@@ -34,7 +38,10 @@ def test_reading_db_mst_nc():
     logger.info('----Testing reading MST-NectarCam-----')
     db = db_handler.DatabaseHandler(logger.name)
     pars = db.getModelParameters('north-mst-NectarCam-D', 'prod4', testDataDirectory)
-    assert(pars['camera_pixels']['Value'] == 1855)
+    if cfg.get('useMongoDB'):
+        assert(pars['camera_pixels']['Value'] == 1855)
+    else:
+        assert(pars['camera_pixels'] == 1855)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
@@ -50,7 +57,10 @@ def test_reading_db_mst_fc():
     logger.info('----Testing reading MST-FlashCam-----')
     db = db_handler.DatabaseHandler(logger.name)
     pars = db.getModelParameters('north-mst-FlashCam-D', 'prod4', testDataDirectory)
-    assert(pars['camera_pixels']['Value'] == 1764)
+    if cfg.get('useMongoDB'):
+        assert(pars['camera_pixels']['Value'] == 1764)
+    else:
+        assert(pars['camera_pixels'] == 1764)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
@@ -66,7 +76,10 @@ def test_reading_db_sst():
     logger.info('----Testing reading SST-----')
     db = db_handler.DatabaseHandler(logger.name)
     pars = db.getModelParameters('south-sst-D', 'prod4', testDataDirectory)
-    assert(pars['camera_pixels']['Value'] == 2048)
+    if cfg.get('useMongoDB'):
+        assert(pars['camera_pixels']['Value'] == 2048)
+    else:
+        assert(pars['camera_pixels'] == 2048)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
@@ -78,6 +91,10 @@ def test_reading_db_sst():
 
 
 def test_modify_db():
+
+    # This test is only relevant for the MongoDB
+    if not cfg.get('useMongoDB'):
+        return
 
     logger.info('----Testing copying a whole telescope-----')
     db = db_handler.DatabaseHandler(logger.name)
@@ -131,6 +148,38 @@ def test_modify_db():
     return
 
 
+def test_reading_db_sites():
+
+    db = db_handler.DatabaseHandler(logger.name)
+    logger.info('----Testing reading La Palma parameters-----')
+    pars = db.getSiteParameters('North', 'prod4', testDataDirectory)
+    if cfg.get('useMongoDB'):
+        assert(pars['altitude']['Value'] == 2147)
+    else:
+        assert(pars['altitude'] == 2147)
+
+    logger.info('Listing files written in {}'.format(testDataDirectory))
+    subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
+
+    logger.info('Removing the files written in {}'.format(testDataDirectory))
+    subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
+
+    logger.info('----Testing reading Paranal parameters-----')
+    pars = db.getSiteParameters('South', 'prod4', testDataDirectory)
+    if cfg.get('useMongoDB'):
+        assert(pars['altitude']['Value'] == 2150)
+    else:
+        assert(pars['altitude'] == 2150)
+
+    logger.info('Listing files written in {}'.format(testDataDirectory))
+    subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
+
+    logger.info('Removing the files written in {}'.format(testDataDirectory))
+    subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
+
+    return
+
+
 if __name__ == '__main__':
 
     # test_get_model_file()
@@ -139,4 +188,5 @@ if __name__ == '__main__':
     test_reading_db_mst_fc()
     test_reading_db_sst()
     test_modify_db()
+    test_reading_db_sites()
     pass

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -28,7 +28,7 @@ def test_ssts(show=False):
     rayTracing = list()
     for t in telTypes:
         tel = TelescopeModel(
-            telescopeName='north-' + t,
+            telescopeName='south-' + t,
             version=version,
             label='test-sst'
         )
@@ -118,7 +118,7 @@ def test_plot_image():
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeName='north-sst-D',
+        telescopeName='south-sst-D',
         version=version,
         label=label
     )

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -10,7 +10,7 @@ logger.setLevel(logging.DEBUG)
 
 
 def test_input_validation():
-    telName = 'south-lst-1'
+    telName = 'north-lst-1'
     logger.info('Input telName: {}'.format(telName))
 
     tel = TelescopeModel(
@@ -25,7 +25,7 @@ def test_input_validation():
 
 def test_handling_parameters():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
+        telescopeName='north-lst-1',
         version='prod4',
         label='test-lst'
     )
@@ -49,7 +49,7 @@ def test_handling_parameters():
 
 def test_flen_type():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
+        telescopeName='north-lst-1',
         version='prod4',
         label='test-lst'
     )
@@ -84,7 +84,7 @@ def test_cfg_file():
 
 def test_cfg_input():
     tel = TelescopeModel(
-        telescopeName='south-lst-1',
+        telescopeName='north-lst-1',
         version='prod4',
         label='test-sst-2'
     )

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -282,17 +282,16 @@ def convertTelescopeNameToYaml(name):
         'SST-ASTRI': 'SST-2M-ASTRI',
         'SST-GCT': 'SST-2M-GCT-S',
         'MST-FlashCam-D': 'MST-FlashCam',
-        'MST-Nectar-D': 'MST-NectarCam',
+        'MST-NectarCam-D': 'MST-NectarCam',
         'SCT-D': 'SCT',
         'LST-D234': 'LST',
         'LST-1': 'LST'
     }
 
     if newName not in oldNames.keys():
-        logger.error('Telescope name {} could not be converted to yml names'.format(name))
-        return None
+        raise ValueError('Telescope name {} could not be converted to yml names'.format(name))
     else:
-        return oldNames[newNames]
+        return oldNames[newName]
 
 
 allTelescopeClassNames = {


### PR DESCRIPTION
The main difference is the db_handler is now a class. Had to make some changes to the telescope model as well, but they were quite small.
The problem, as usual, is that I can't test those changes. The db_handler tests pass (both Yaml and MongoDB), but I can't run the telescope model part. I am trying to do it on the wgs, but that turned out to be a nightmare (ran out of quota in the middle of creating the conda environment and now my conda is completely screwed up). 
@RaulRPrado, can you please run the other tests before you approve the merge?