### PR TITLE
Add "Current" and "Latest" labels of the model

### DIFF
--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -157,7 +157,7 @@ class DatabaseHandler:
         '''
 
         tunnelCmd = (
-            'ssh -N -L {localport}:{mongodbServer}:{remoteport} {user}@{tunnelServer}'.format(
+            'ssh -4 -N -L {localport}:{mongodbServer}:{remoteport} {user}@{tunnelServer}'.format(
                 localport=localport,
                 remoteport=remoteport,
                 user=user,

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -64,7 +64,7 @@ class TelescopeModel:
     def __init__(
         self,
         telescopeName,
-        version='default',
+        version='Current',
         label=None,
         modelFilesLocations=None,
         filesLocation=None,
@@ -79,7 +79,7 @@ class TelescopeModel:
         telescopeName: str
             Telescope name for the base set of parameters (ex. North-LST-1, ...).
         version: str, optional
-            Version of the model (ex. prod4) (Default = default).
+            Version of the model (ex. prod4) (default: "Current").
         label: str, optional
             Instance label. Important for output file naming.
         modelFilesLocation: str (or Path), optional

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -19,7 +19,7 @@ def test_reading_db_lst():
 
     logger.info('----Testing reading LST-----')
     db = db_handler.DatabaseHandler(logger.name)
-    pars = db.getModelParameters('north-lst-1', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('north-lst-1', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['parabolic_dish']['Value'] == 1)
         assert(pars['camera_pixels']['Value'] == 1855)
@@ -37,7 +37,7 @@ def test_reading_db_mst_nc():
 
     logger.info('----Testing reading MST-NectarCam-----')
     db = db_handler.DatabaseHandler(logger.name)
-    pars = db.getModelParameters('north-mst-NectarCam-D', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('north-mst-NectarCam-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 1855)
     else:
@@ -56,7 +56,7 @@ def test_reading_db_mst_fc():
 
     logger.info('----Testing reading MST-FlashCam-----')
     db = db_handler.DatabaseHandler(logger.name)
-    pars = db.getModelParameters('north-mst-FlashCam-D', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('north-mst-FlashCam-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 1764)
     else:
@@ -75,7 +75,7 @@ def test_reading_db_sst():
 
     logger.info('----Testing reading SST-----')
     db = db_handler.DatabaseHandler(logger.name)
-    pars = db.getModelParameters('south-sst-D', 'prod4', testDataDirectory)
+    pars = db.getModelParameters('south-sst-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 2048)
     else:
@@ -101,11 +101,17 @@ def test_modify_db():
     db.copyTelescope(
         DB_CTA_SIMULATION_MODEL,
         'North-LST-1',
-        'prod4',
+        'Current',
         'North-LST-Test',
         'sandbox'
     )
-    pars = db.readMongoDB('sandbox', 'North-LST-Test', 'prod4', testDataDirectory, False)
+    db.copyDocuments(
+        DB_CTA_SIMULATION_MODEL,
+        'metadata', 
+        {'Entry': 'Simulation-Model-Tags'},
+        'sandbox'
+    )
+    pars = db.readMongoDB('sandbox', 'North-LST-Test', 'Current', testDataDirectory, False)
     assert(pars['camera_pixels']['Value'] == 1855)
 
     logger.info('----Testing adding a parameter-----')
@@ -141,9 +147,11 @@ def test_modify_db():
     pars = db.readMongoDB('sandbox', 'North-LST-Test', 'test', testDataDirectory, False)
     assert(pars['camera_config_version_test']['Value'] == 999)
 
-    logger.info('----Testing deleting a query (a whole telescope in this case)-----')
+    logger.info('----Testing deleting a query (a whole telescope in this case and metadata)-----')
     query = {'Telescope': 'North-LST-Test'}
-    db.deleteQuery('sandbox', query)
+    db.deleteQuery('sandbox', 'telescopes', query)
+    query = {'Entry': 'Simulation-Model-Tags'}
+    db.deleteQuery('sandbox', 'metadata', query)
 
     return
 
@@ -156,11 +164,11 @@ def test_reading_db_sites():
 
     db = db_handler.DatabaseHandler(logger.name)
     logger.info('----Testing reading La Palma parameters-----')
-    pars = db.getSiteParameters('North', 'prod4', testDataDirectory)
+    pars = db.getSiteParameters('North', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
-        assert(pars['altitude']['Value'] == 2147)
+        assert(pars['altitude']['Value'] == 2158)
     else:
-        assert(pars['altitude'] == 2147)
+        assert(pars['altitude'] == 2158)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
@@ -169,11 +177,11 @@ def test_reading_db_sites():
     subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
 
     logger.info('----Testing reading Paranal parameters-----')
-    pars = db.getSiteParameters('South', 'prod4', testDataDirectory)
+    pars = db.getSiteParameters('South', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
-        assert(pars['altitude']['Value'] == 2150)
+        assert(pars['altitude']['Value'] == 2147)
     else:
-        assert(pars['altitude'] == 2150)
+        assert(pars['altitude'] == 2147)
 
     logger.info('Listing files written in {}'.format(testDataDirectory))
     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -14,7 +14,7 @@ logger.setLevel(logging.DEBUG)
 def test_ray_tracing_mode():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='current',
+        version='Current',
         label='test-simtel',
         logger=logger.name
     )
@@ -34,7 +34,7 @@ def test_ray_tracing_mode():
 def test_catching_model_error():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='current',
+        version='Current',
         label='test-simtel',
         logger=logger.name
     )

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -14,7 +14,7 @@ logger.setLevel(logging.DEBUG)
 def test_ray_tracing_mode():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='prod4',
+        version='current',
         label='test-simtel',
         logger=logger.name
     )
@@ -34,7 +34,7 @@ def test_ray_tracing_mode():
 def test_catching_model_error():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='prod4',
+        version='current',
         label='test-simtel',
         logger=logger.name
     )

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -15,7 +15,7 @@ def test_input_validation():
 
     tel = TelescopeModel(
         telescopeName=telName,
-        version='prod4',
+        version='current',
         label='test-lst',
         logger=logger.name
     )
@@ -27,7 +27,7 @@ def test_input_validation():
 def test_handling_parameters():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='prod4',
+        version='current',
         label='test-lst',
         logger=logger.name
     )
@@ -52,7 +52,7 @@ def test_handling_parameters():
 def test_flen_type():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='prod4',
+        version='current',
         label='test-lst',
         logger=logger.name
     )
@@ -66,7 +66,7 @@ def test_cfg_file():
     # Exporting
     tel = TelescopeModel(
         telescopeName='south-sst-d',
-        version='prod4',
+        version='current',
         label='test-sst',
         logger=logger.name
     )
@@ -90,7 +90,7 @@ def test_cfg_file():
 def test_cfg_input():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='prod4',
+        version='current',
         label='test-sst-2',
         logger=logger.name
     )

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -15,7 +15,7 @@ def test_input_validation():
 
     tel = TelescopeModel(
         telescopeName=telName,
-        version='current',
+        version='Current',
         label='test-lst',
         logger=logger.name
     )
@@ -27,7 +27,7 @@ def test_input_validation():
 def test_handling_parameters():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='current',
+        version='Current',
         label='test-lst',
         logger=logger.name
     )
@@ -52,7 +52,7 @@ def test_handling_parameters():
 def test_flen_type():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='current',
+        version='Current',
         label='test-lst',
         logger=logger.name
     )
@@ -66,7 +66,7 @@ def test_cfg_file():
     # Exporting
     tel = TelescopeModel(
         telescopeName='south-sst-d',
-        version='current',
+        version='Current',
         label='test-sst',
         logger=logger.name
     )
@@ -90,7 +90,7 @@ def test_cfg_file():
 def test_cfg_input():
     tel = TelescopeModel(
         telescopeName='north-lst-1',
-        version='current',
+        version='Current',
         label='test-sst-2',
         logger=logger.name
     )

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -321,7 +321,18 @@ allSiteNames = {
 allModelVersionNames = {
     'prod3_compatible': ['p3', 'prod3', 'prod3b'],
     'prod4': ['p4'],
-    'default': []
+    'post_prod3_updates': [''],
+    '2018-11-07': [''],
+    '2019-02-22': [''],
+    '2019-05-13': [''],
+    '2019-11-20': [''],
+    '2019-12-30': [''],
+    '2020-02-26': [''],
+    '2020-06-28': ['prod5'],
+    'prod4-prototype': [''],
+    'default': [],
+    'Current': [],
+    'Latest': []
 }
 
 allSimtelModeNames = {


### PR DESCRIPTION
This PR should answer #66. I essentially added a metadata collection to our DB to keep the information of what is the "Current" and what is the "Latest" Telescope Model tag. Currently the two are the same (Prod5), but in the future I expect the "latest" to include the latest changes, while the "Current" should be actual productions. Once construction is over, this will be replaced by a more sophisticated system of course.
I suggest that the default from now on is "Current". This is what I set it in "TelescopeModel".