### PR TITLE
Making telescope model names consistent all over the modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ telarray_rand.conf.used
 
 # Files produced tests
 data/test-plots/*
+data/test-output/*
 
 # Compiled files
 *.py[co]

--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -25,8 +25,10 @@
 
     Command line arguments
     ----------------------
-    tel_name (str, required)
-        Telescope name (e.g. North-LST-1, South-SST-D, ...).
+    site (str, required)
+        North or South.
+    telescope (str, required)
+        Telescope model name (e.g. LST-1, SST-D, ...).
     model_version (str, optional)
         Model version (default=prod4).
     src_distance (float, optional)
@@ -106,9 +108,16 @@ if __name__ == '__main__':
         )
     )
     parser.add_argument(
+        '-s',
+        '--site',
+        help='North or South',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
         '-t',
-        '--tel_name',
-        help='Telescope name (e.g. North-MST-FlashCam-D, North-LST-1)',
+        '--telescope',
+        help='Telescope model name (e.g. MST-FlashCam-D, LST-1)',
         type=str,
         required=True
     )
@@ -165,7 +174,8 @@ if __name__ == '__main__':
     outputDir = io.getApplicationOutputDirectory(cfg.get('outputLocation'), label)
 
     telModel = TelescopeModel(
-        telescopeName=args.tel_name,
+        site=args.site,
+        telescopeModelName=args.telescope,
         version=args.model_version,
         label=label
     )

--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -62,8 +62,7 @@
 
     .. code-block:: console
 
-        python applications/compare_cumulative_psf.py --tel_name North-LST-1 \
-        --model_version prod4 --pars lst_pars.yml --data PSFcurve_data_v2.txt
+        python applications/compare_cumulative_psf.py --site North --telescope LST-1 --model_version prod4 --pars lst_pars.yml --data PSFcurve_data_v2.txt
 
     .. todo::
 

--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
     plt = visualize.plot1D(dataToPlot)
     plt.gca().set_ylim(0, 1.05)
 
-    plotFileName = label + '_' + telModel.telescopeName + '_cumulativePSF'
+    plotFileName = label + '_' + telModel.name + '_cumulativePSF'
     plotFile = outputDir.joinpath(plotFileName)
     for f in ['pdf', 'png']:
         plt.savefig(str(plotFile) + '.' + f, format=f, bbox_inches='tight')
@@ -221,7 +221,7 @@ if __name__ == '__main__':
     circle = plt.Circle((0, 0), im.getPSF(0.8) / 2, color='k', fill=False, lw=2, ls='--')
     plt.gca().add_artist(circle)
 
-    plotFileName = label + '_' + telModel.telescopeName + '_image'
+    plotFileName = label + '_' + telModel.name + '_image'
     plotFile = outputDir.joinpath(plotFileName)
     for f in ['pdf', 'png']:
         plt.savefig(str(plotFile) + '.' + f, format=f, bbox_inches='tight')

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -77,9 +77,7 @@
 
     .. code-block:: console
 
-        python applications/derive_mirror_rnda.py --tel_name North-MST-FlashCam-D --mean_d80 1.4 \
-        --sig_d80 0.16 --mirror_list mirror_MST_focal_lengths.dat --d80_list mirror_MST_D80.dat \
-        --rnda 0.0075
+        python applications/derive_mirror_rnda.py --site North --telescope MST-FlashCam-D --mean_d80 1.4 --sig_d80 0.16 --mirror_list mirror_MST_focal_lengths.dat --d80_list mirror_MST_D80.dat --rnda 0.0075
 
 
     Expected output:
@@ -131,9 +129,16 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        '-s',
+        '--site',
+        help='North or South',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
         '-t',
-        '--tel_name',
-        help='Telescope name (e.g. North-LST-1, South-SST-D, ...)',
+        '--telescope',
+        help='Telescope model name (e.g. LST-1, SST-D, ...)',
         type=str,
         required=True
     )
@@ -223,7 +228,8 @@ if __name__ == '__main__':
     outputDir = io.getApplicationOutputDirectory(cfg.get('outputLocation'), label)
 
     tel = TelescopeModel(
-        telescopeName=args.tel_name,
+        site=args.site,
+        telescopeModelName=args.telescope,
         version=args.model_version,
         label=label
     )

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
                 )
 
             ax.legend(frameon=False)
-            plotFileName = label + '_' + tel.telescopeName + '_' + 'D80-distributions'
+            plotFileName = label + '_' + tel.name + '_' + 'D80-distributions'
             plotFile = outputDir.joinpath(plotFileName)
             plt.savefig(str(plotFile) + '.pdf', format='pdf', bbox_inches='tight')
             plt.savefig(str(plotFile) + '.png', format='png', bbox_inches='tight')
@@ -389,7 +389,7 @@ if __name__ == '__main__':
 
     ax.legend(frameon=False, loc='upper left')
 
-    plotFileName = label + '_' + tel.telescopeName
+    plotFileName = label + '_' + tel.name
     plotFile = outputDir.joinpath(plotFileName)
     plt.savefig(str(plotFile) + '.pdf', format='pdf', bbox_inches='tight')
     plt.savefig(str(plotFile) + '.png', format='png', bbox_inches='tight')

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
     tel = TelescopeModel(
         site=args.site,
         telescopeModelName=args.telescope,
-        version=args.model_version,
+        modelVersion=args.model_version,
         label=label
     )
     if args.mirror_list is not None:

--- a/applications/get_parameter.py
+++ b/applications/get_parameter.py
@@ -19,9 +19,16 @@ if __name__ == '__main__':
         )
     )
     parser.add_argument(
+        '-s',
+        '--site',
+        help='Site (North or South)',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
         '-t',
         '--tel_type',
-        help='Telescope type (e.g. north-lst-1, south-sst-d)',
+        help='Telescope type (e.g. LST-1, SST-D)',
         type=str,
         required=True
     )
@@ -65,7 +72,7 @@ if __name__ == '__main__':
         raise NotImplemented('Printing last 5 versions is not implemented yet.')
     else:
         version = args.version
-    pars = db.getModelParameters(args.tel_type, version)
+    pars = db.getModelParameters(args.site, args.tel_type, version)
     print()
     pprint(pars[args.parameter])
     print()

--- a/applications/get_parameter.py
+++ b/applications/get_parameter.py
@@ -66,6 +66,8 @@ if __name__ == '__main__':
     if not cfg.get('useMongoDB'):
         raise ValueError('This application works only with MongoDB and you asked not to use it')
 
+    logger.info('TEST')
+
     db = db_handler.DatabaseHandler()
 
     if args.version == 'all':

--- a/applications/make_regular_arrays.py
+++ b/applications/make_regular_arrays.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
     siteParsDB = dict()
     sitePars = dict()
     for site in ['North', 'South']:
-        siteParsDB[site] = db.getSiteParameters(site=site, version='prod3_compatible')
+        siteParsDB[site] = db.getSiteParameters(site=site, modelVersion='prod3_compatible')
 
         sitePars[site] = dict()
         sitePars[site]['centerLatitude'] = float(siteParsDB[site]['ref_lat']['Value']) * u.deg

--- a/applications/validate_camera_efficiency.py
+++ b/applications/validate_camera_efficiency.py
@@ -17,8 +17,10 @@
 
     Command line arguments
     ----------------------
-    tel_name (str, required)
-        Telescope name (e.g. North-LST-1, South-SST-D, ...)
+    site (str, required)
+        North or South.
+    telescope (str, required)
+        Telescope model name (e.g. LST-1, SST-D, ...)
     model_version (str, optional)
         Model version (default=prod4)
     verbosity (str, optional)
@@ -32,8 +34,7 @@
 
     .. code-block:: console
 
-        python applications/validate_camera_efficiency.py --tel_name North-MST-NectarCam-D \
-        --model_version prod4
+        python applications/validate_camera_efficiency.py --site North --telescope MST-NectarCam-D --model_version prod4
 
     .. todo::
 
@@ -61,9 +62,16 @@ if __name__ == '__main__':
         )
     )
     parser.add_argument(
+        '-s',
+        '--site',
+        help='North or South',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
         '-t',
-        '--tel_name',
-        help='Telescope name (e.g. North-LST-1, South-SST-D)',
+        '--telescope',
+        help='Telescope model name (e.g. LST-1, SST-D)',
         type=str,
         required=True
     )
@@ -93,7 +101,8 @@ if __name__ == '__main__':
     outputDir = io.getApplicationOutputDirectory(cfg.get('outputLocation'), label)
 
     telModel = TelescopeModel(
-        telescopeName=args.tel_name,
+        site=args.site,
+        telescopeModelName=args.telescope,
         version=args.model_version,
         label=label
     )
@@ -101,15 +110,15 @@ if __name__ == '__main__':
     # For debugging purposes
     telModel.exportConfigFile()
 
-    logger.info('Validating the camera efficiency of {}'.format(telModel.telescopeName))
+    logger.info('Validating the camera efficiency of {}'.format(telModel.name))
 
-    ce = CameraEfficiency(telescopeModel=telModel, logger=logger.name)
+    ce = CameraEfficiency(telescopeModel=telModel)
     ce.simulate(force=False)
     ce.analyze(force=True)
 
     # Plotting the camera efficiency for Cherenkov light
     plt = ce.plotCherenkovEfficiency()
-    cherenkovPlotFileName = label + '_' + telModel.telescopeName + '_cherenkov'
+    cherenkovPlotFileName = label + '_' + telModel.name + '_cherenkov'
     cherenkovPlotFile = outputDir.joinpath(cherenkovPlotFileName)
     for f in ['pdf', 'png']:
         plt.savefig(str(cherenkovPlotFile) + '.' + f, format=f, bbox_inches='tight')
@@ -118,7 +127,7 @@ if __name__ == '__main__':
 
     # Plotting the camera efficiency for NSB light
     plt = ce.plotNSBEfficiency()
-    nsbPlotFileName = label + '_' + telModel.telescopeName + '_nsb'
+    nsbPlotFileName = label + '_' + telModel.name + '_nsb'
     nsbPlotFile = outputDir.joinpath(nsbPlotFileName)
     for f in ['pdf', 'png']:
         plt.savefig(str(nsbPlotFile) + '.' + f, format=f, bbox_inches='tight')

--- a/applications/validate_camera_efficiency.py
+++ b/applications/validate_camera_efficiency.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     telModel = TelescopeModel(
         site=args.site,
         telescopeModelName=args.telescope,
-        version=args.model_version,
+        modelVersion=args.model_version,
         label=label
     )
 

--- a/applications/validate_camera_fov.py
+++ b/applications/validate_camera_fov.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
     cameraConfigFile = telModel.getParameter('camera_config_file')
     focalLength = float(telModel.getParameter('effective_focal_length'))
     camera = Camera(
-        telescopeName=telModel.name,
+        telescopeModelName=telModel.name,
         cameraConfigFile=cfg.findFile(cameraConfigFile),
         focalLength=focalLength
     )

--- a/applications/validate_camera_fov.py
+++ b/applications/validate_camera_fov.py
@@ -15,8 +15,10 @@
 
     Command line arguments
     ----------------------
-    tel_name (str, required)
-        Telescope name (e.g. North-LST-1, South-SST-D, ...)
+    site (str, required)
+        North or South.
+    telescope (str, required)
+        Telescope model name (e.g. LST-1, SST-D, ...)
     model_version (str, optional)
         Model version (default=prod4)
     verbosity (str, optional)
@@ -30,7 +32,7 @@
 
     .. code-block:: console
 
-        python applications/validate_camera_fov.py --tel_name North-LST-1 --model_version prod4
+        python applications/validate_camera_fov.py --site North --telescope LST-1 --model_version prod4
 
     .. todo::
 
@@ -58,8 +60,16 @@ if __name__ == '__main__':
         )
     )
     parser.add_argument(
-        '--tel_name',
-        help='Telescope name (e.g. North-LST-1, South-SST-D)',
+        '-s',
+        '--site',
+        help='North or South',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
+        't',
+        '--telescope',
+        help='Telescope model name (e.g. LST-1, SST-D)',
         type=str,
         required=True
     )
@@ -88,17 +98,18 @@ if __name__ == '__main__':
     outputDir = io.getApplicationOutputDirectory(cfg.get('outputLocation'), label)
 
     telModel = TelescopeModel(
-        telescopeName=args.tel_name,
-        version=args.model_version,
+        site=args.site,
+        telescopeModelName=args.telescope,
+        modelVersion=args.model_version,
         label=label
     )
 
-    print('\nValidating the camera FoV of {}\n'.format(telModel.telescopeName))
+    print('\nValidating the camera FoV of {}\n'.format(telModel.name))
 
     cameraConfigFile = telModel.getParameter('camera_config_file')
     focalLength = float(telModel.getParameter('effective_focal_length'))
     camera = Camera(
-        telescopeName=telModel.telescopeName,
+        telescopeName=telModel.name,
         cameraConfigFile=cfg.findFile(cameraConfigFile),
         focalLength=focalLength
     )
@@ -106,12 +117,12 @@ if __name__ == '__main__':
     fov, rEdgeAvg = camera.calcFOV()
 
     print('\nEffective focal length = ' + '{0:.3f} cm'.format(focalLength))
-    print('{0} FoV = {1:.3f} deg'.format(telModel.telescopeName, fov))
+    print('{0} FoV = {1:.3f} deg'.format(telModel.name, fov))
     print('Avg. edge radius = {0:.3f} cm\n'.format(rEdgeAvg))
 
     # Now plot the camera as well
     plt = camera.plotPixelLayout()
-    plotFileName = label + '_' + telModel.telescopeName + '_pixelLayout'
+    plotFileName = label + '_' + telModel.name + '_pixelLayout'
     plotFile = outputDir.joinpath(plotFileName)
     for f in ['pdf', 'png']:
         plt.savefig(str(plotFile) + '.' + f, format=f, bbox_inches='tight')

--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -156,7 +156,7 @@ if __name__ == '__main__':
 
     print(
         '\nValidating telescope optics with ray tracing simulations'
-        ' for {}\n'.format(telModel.telescopeName)
+        ' for {}\n'.format(telModel.name)
     )
 
     ray = RayTracing(

--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -27,8 +27,10 @@
 
     Command line arguments
     ----------------------
-    tel_name (str, required)
-        Telescope name (e.g. North-LST-1, South-SST-D, ...).
+    site (str, required)
+        North or South.
+    telescope (str, required)
+        Telescope model name (e.g. LST-1, SST-D, ...).
     model_version (str, optional)
         Model version (default=prod4).
     src_distance (float, optional)
@@ -50,7 +52,7 @@
 
     .. code-block:: console
 
-        python applications/validate_optics.py --tel_name North-LST-1 --max_offset 5.0
+        python applications/validate_optics.py --site North --telescope LST-1 --max_offset 5.0
 
     .. todo::
 
@@ -83,9 +85,16 @@ if __name__ == '__main__':
         )
     )
     parser.add_argument(
+        '-s',
+        '--site',
+        help='North or South',
+        type=str,
+        required=True
+    )
+    parser.add_argument(
         '-t',
-        '--tel_name',
-        help='Telescope name (e.g. North-MST-FlashCam-D, North-LST-1)',
+        '--telescope',
+        help='Telescope model name (e.g. MST-FlashCam-D, LST-1)',
         type=str,
         required=True
     )
@@ -138,8 +147,9 @@ if __name__ == '__main__':
     outputDir = io.getApplicationOutputDirectory(cfg.get('outputLocation'), label)
 
     telModel = TelescopeModel(
-        telescopeName=args.tel_name,
-        version=args.model_version,
+        site=args.site,
+        telescopeModelName=args.telescope,
+        modelVersion=args.model_version,
         label=label,
         readFromDB=True
     )
@@ -164,7 +174,7 @@ if __name__ == '__main__':
 
         ray.plot(key, marker='o', linestyle=':', color='k')
 
-        plotFileName = label + '_' + telModel.telescopeName + '_' + key
+        plotFileName = label + '_' + telModel.name + '_' + key
         plotFile = outputDir.joinpath(plotFileName)
         plt.savefig(str(plotFile) + '.pdf', format='pdf', bbox_inches='tight')
         plt.savefig(str(plotFile) + '.png', format='png', bbox_inches='tight')

--- a/simtools/__init__.py
+++ b/simtools/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.basicConfig(format='%(levelname)s::%(module)s(l%(lineno)s)::%(funcName)s::%(message)s')

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -111,6 +111,7 @@ class CameraEfficiency:
         ''' Define the variables for the file names, including the results, simtel and log file. '''
         # Results file
         fileNameResults = names.cameraEfficiencyResultsFileName(
+            self._telescopeModel.site,
             self._telescopeModel.name,
             self._zenithAngle,
             self.label
@@ -118,6 +119,7 @@ class CameraEfficiency:
         self._fileResults = self._baseDirectory.joinpath(fileNameResults)
         # SimtelOutput file
         fileNameSimtel = names.cameraEfficiencySimtelFileName(
+            self._telescopeModel.site,
             self._telescopeModel.name,
             self._zenithAngle,
             self.label
@@ -125,6 +127,7 @@ class CameraEfficiency:
         self._fileSimtel = self._baseDirectory.joinpath(fileNameSimtel)
         # Log file
         fileNameLog = names.cameraEfficiencyLogFileName(
+            self._telescopeModel.site,
             self._telescopeModel.name,
             self._zenithAngle,
             self.label

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -111,21 +111,21 @@ class CameraEfficiency:
         ''' Define the variables for the file names, including the results, simtel and log file. '''
         # Results file
         fileNameResults = names.cameraEfficiencyResultsFileName(
-            self._telescopeModel.telescopeName,
+            self._telescopeModel.name,
             self._zenithAngle,
             self.label
         )
         self._fileResults = self._baseDirectory.joinpath(fileNameResults)
         # SimtelOutput file
         fileNameSimtel = names.cameraEfficiencySimtelFileName(
-            self._telescopeModel.telescopeName,
+            self._telescopeModel.name,
             self._zenithAngle,
             self.label
         )
         self._fileSimtel = self._baseDirectory.joinpath(fileNameSimtel)
         # Log file
         fileNameLog = names.cameraEfficiencyLogFileName(
-            self._telescopeModel.telescopeName,
+            self._telescopeModel.name,
             self._zenithAngle,
             self.label
         )
@@ -190,7 +190,7 @@ class CameraEfficiency:
             mirrorReflectivity = 'ref_astri_2017-06_T0.dat'
 
         # Camera name
-        cameraName = getCameraName(self._telescopeModel.telescopeName)
+        cameraName = getCameraName(self._telescopeModel.name)
 
         # cmd -> Command to be run at the shell
         cmd = str(self._simtelSourcePath.joinpath('sim_telarray/bin/testeff'))
@@ -493,7 +493,7 @@ class CameraEfficiency:
         plt = visualize.plotTable(
             tableToPlot,
             yTitle='Cherenkov light efficiency',
-            title='{} response to Cherenkov light'.format(self._telescopeModel.telescopeName),
+            title='{} response to Cherenkov light'.format(self._telescopeModel.name),
             noMarkers=True
         )
 
@@ -526,7 +526,7 @@ class CameraEfficiency:
             tableToPlot,
             yTitle='Nightsky background light efficiency',
             title='{} response to nightsky background light'.format(
-                self._telescopeModel.telescopeName
+                self._telescopeModel.name
             ),
             noMarkers=True
         )

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -388,7 +388,7 @@ class DatabaseHandler:
             the name of the DB
         site: str
             South or North.
-        telescopeName: str
+        telescopeModelName: str
             Name of the telescope model (e.g. MST-FlashCam-D ...)
         modelVersion: str
             Version of the model.

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -333,7 +333,10 @@ class DatabaseHandler:
         '''
 
         _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
-        _telClass = getTelescopeClass(_telNameDB)
+        _telClass = getTelescopeClass(telescopeModelName)
+
+        self._logger.debug('TelNameDB: {}'.format(_telNameDB))
+        self._logger.debug('TelClass: {}'.format(_telClass))
 
         if _telClass == 'MST':
             # MST-FlashCam or MST-NectarCam

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -186,7 +186,7 @@ class DatabaseHandler:
 
         return
 
-    def _getTelescopeModelNameForDB(site, telescopeModelName):
+    def _getTelescopeModelNameForDB(self, site, telescopeModelName):
         ''' Make telescope name as the DB needs from site and telescopeModelName. '''
         return site + '-' + telescopeModelName
 
@@ -369,8 +369,7 @@ class DatabaseHandler:
     def readMongoDB(
         self,
         dbName,
-        site,
-        telescopeModelName,
+        telescopeModelNameDB,
         modelVersion,
         runLocation,
         writeFiles=True,
@@ -386,7 +385,7 @@ class DatabaseHandler:
             the name of the DB
         site: str
             South or North.
-        telescopeModelName: str
+        telescopeModelNameDB: str
             Name of the telescope model (e.g. MST-FlashCam-D ...)
         modelVersion: str
             Version of the model.
@@ -405,11 +404,10 @@ class DatabaseHandler:
         collection = DatabaseHandler.dbClient[dbName]['telescopes']
         _parameters = dict()
 
-        _modelVersion = self._convertTaggedVersion(modelVersion, dbName)
-        _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
+        _modelVersion = self._convertVersionToTagged(modelVersion, dbName)
 
         query = {
-            'Telescope': _telNameDB,
+            'Telescope': telescopeModelNameDB,
             'Version': _modelVersion,
         }
         if onlyApplicable:

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -227,7 +227,7 @@ class DatabaseHandler:
 
         _siteValidated = names.validateSiteName(site)
         _versionValidated = names.validateModelVersionName(_version)
-        _telModelNameValidated = names.validateTelescopeName(telescopeModelName)
+        _telModelNameValidated = names.validateTelescopeModelName(telescopeModelName)
 
         if cfg.get('useMongoDB'):
             _pars = self._getModelParametersMongoDB(

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -240,7 +240,7 @@ class DatabaseHandler:
             return _pars
         else:
             return self._getModelParametersYaml(
-                site,
+                _siteValidated,
                 _telModelNameValidated,
                 _versionValidated,
                 onlyApplicable

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -410,6 +410,8 @@ class DatabaseHandler:
             'Telescope': telescopeModelNameDB,
             'Version': _modelVersion,
         }
+
+        self._logger.debug('Trying the following query: {}'.format(query))
         if onlyApplicable:
             query['Applicable'] = onlyApplicable
         if collection.count_documents(query) < 1:

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -267,10 +267,8 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
-        _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
-
-        _telClass = getTelescopeClass(_telNameDB)
-        _telNameConverted = names.convertTelescopeNameToYaml(_telNameDB)
+        _telClass = getTelescopeClass(telescopeModelName)
+        _telNameConverted = names.convertTelescopeModelNameToYaml(telescopeModelName)
 
         if _telClass == 'MST':
             # MST-FlashCam or MST-NectarCam

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -186,10 +186,15 @@ class DatabaseHandler:
 
         return
 
+    def _getTelescopeModelNameForDB(site, telescopeModelName):
+        ''' Make telescope name as the DB needs from site and telescopeModelName. '''
+        return site + '-' + telescopeModelName
+
     def getModelParameters(
         self,
-        telescopeName,
-        version,
+        site,
+        telescopeModelName,
+        modelVersion,
         runLocation=None,
         onlyApplicable=False,
     ):
@@ -198,8 +203,11 @@ class DatabaseHandler:
 
         Parameters
         ----------
-        telescopeName: str
-        version: str
+        site: str
+            South or North.
+        telescopeModelName: str
+            Name of the telescope model (e.g. LST-1, MST-FlashCam-D)
+        modelVersion: str
             Version of the model.
         runLocation: Path or str
             The sim_telarray run location to write the tabulated data files into.
@@ -211,30 +219,45 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
-        _version = version
-        if version in ['Current', 'Latest']:
-            _version = self._getTaggedVersion(DatabaseHandler.DB_CTA_SIMULATION_MODEL, version)
+        _version = modelVersion
+        if modelVersion in ['Current', 'Latest']:
+            _version = self._getTaggedVersion(DatabaseHandler.DB_CTA_SIMULATION_MODEL, modelVersion)
+
+        # _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
+
+        _siteValidated = names.validateSiteName(site)
+        _versionValidated = names.validateModelVersionName(_version)
+        _telModelNameValidated = names.validateTelescopeName(telescopeModelName)
 
         if cfg.get('useMongoDB'):
             _pars = self._getModelParametersMongoDB(
                 DatabaseHandler.DB_CTA_SIMULATION_MODEL,
-                telescopeName,
-                _version,
+                _siteValidated,
+                _telModelNameValidated,
+                _versionValidated,
                 runLocation,
                 onlyApplicable
             )
             return _pars
         else:
-            return self._getModelParametersYaml(telescopeName, version, onlyApplicable)
+            return self._getModelParametersYaml(
+                site,
+                _telModelNameValidated,
+                _versionValidated,
+                onlyApplicable
+            )
 
-    def _getModelParametersYaml(self, telescopeName, version, onlyApplicable=False):
+    def _getModelParametersYaml(self, site, telescopeModelName, modelVersion, onlyApplicable=False):
         '''
         Get parameters from DB for one specific type.
 
         Parameters
         ----------
-        telescopeName: str
-        version: str
+        site: str
+            North or South.
+        telescopeModelName: str
+            Telescope model name (e.g MST-FlashCam-D ...).
+        modelVersion: str
             Version of the model.
         onlyApplicable: bool
             If True, only applicable parameters will be read.
@@ -244,12 +267,10 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
-        _telNameValidated = names.validateTelescopeName(telescopeName)
-        _versionValidated = names.validateModelVersionName(version)
+        _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
 
-        _site = names.getSiteFromTelescopeName(_telNameValidated)
-        _telClass = getTelescopeClass(_telNameValidated)
-        _telNameConverted = names.convertTelescopeNameToYaml(_telNameValidated)
+        _telClass = getTelescopeClass(_telNameDB)
+        _telNameConverted = names.convertTelescopeNameToYaml(_telNameDB)
 
         if _telClass == 'MST':
             # MST-FlashCam or MST-NectarCam
@@ -263,7 +284,7 @@ class DatabaseHandler:
         # Selecting version and applicable (if on)
         _pars = dict()
         for _tel in _whichTelLabels:
-            _allPars = self._getAllModelParametersYaml(_tel, _versionValidated)
+            _allPars = self._getAllModelParametersYaml(_tel, modelVersion)
 
             # If _tel is a structure, only the applicable parameters will be collected, always.
             # The default ones will be covered by the camera parameters.
@@ -274,18 +295,19 @@ class DatabaseHandler:
                 if not parInfo['Applicable'] and _selectOnlyApplicable:
                     continue
 
-                if _versionValidated not in parInfo:
+                if modelVersion not in parInfo:
                     continue
 
-                _pars[parNameIn] = parInfo[_versionValidated]
+                _pars[parNameIn] = parInfo[modelVersion]
 
         return _pars
 
     def _getModelParametersMongoDB(
         self,
         dbName,
-        telescopeName,
-        version,
+        site,
+        telescopeModelName,
+        modelVersion,
         runLocation=None,
         onlyApplicable=False
     ):
@@ -296,8 +318,11 @@ class DatabaseHandler:
         ----------
         dbName: str
             the name of the DB
-        telescopeName: str
-        version: str
+        site: str
+            South or North.
+        telescopeModelName: str
+            Name of the telescope model (e.g. MST-FlashCam-D ...)
+        modelVersion: str
             Version of the model.
         runLocation: Path or str
             The sim_telarray run location to write the tabulated data files into.
@@ -309,19 +334,17 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
-        _telNameValidated = names.validateTelescopeName(telescopeName)
-        _telClass = getTelescopeClass(_telNameValidated)
-        _site = names.getSiteFromTelescopeName(_telNameValidated)
-        _versionValidated = names.validateModelVersionName(version)
+        _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
+        _telClass = getTelescopeClass(_telNameDB)
 
         if _telClass == 'MST':
             # MST-FlashCam or MST-NectarCam
-            _whichTelLabels = [_telNameValidated, '{}-MST-Structure-D'.format(_site)]
+            _whichTelLabels = [_telNameDB, '{}-MST-Structure-D'.format(site)]
         elif _telClass == 'SST':
             # SST = SST-Camera + SST-Structure
-            _whichTelLabels = ['{}-SST-Camera-D'.format(_site), '{}-SST-Structure-D'.format(_site)]
+            _whichTelLabels = ['{}-SST-Camera-D'.format(site), '{}-SST-Structure-D'.format(site)]
         else:
-            _whichTelLabels = [_telNameValidated]
+            _whichTelLabels = [_telNameDB]
 
         # Selecting version and applicable (if on)
         _pars = dict()
@@ -330,14 +353,14 @@ class DatabaseHandler:
             # If tel is a struture, only applicable pars will be collected, always.
             # The default ones will be covered by the camera pars.
             _selectOnlyApplicable = onlyApplicable or (_tel in [
-                '{}-MST-Structure-D'.format(_site),
-                '{}-SST-Structure-D'.format(_site)
+                '{}-MST-Structure-D'.format(site),
+                '{}-SST-Structure-D'.format(site)
             ])
 
             _pars.update(self.readMongoDB(
                 dbName,
                 _tel,
-                _versionValidated,
+                modelVersion,
                 runLocation,
                 (runLocation is not None),
                 _selectOnlyApplicable
@@ -348,8 +371,9 @@ class DatabaseHandler:
     def readMongoDB(
         self,
         dbName,
-        telescopeName,
-        version,
+        site,
+        telescopeModelName,
+        modelVersion,
         runLocation,
         writeFiles=True,
         onlyApplicable=False
@@ -362,8 +386,11 @@ class DatabaseHandler:
         ----------
         dbName: str
             the name of the DB
+        site: str
+            South or North.
         telescopeName: str
-        version: str
+            Name of the telescope model (e.g. MST-FlashCam-D ...)
+        modelVersion: str
             Version of the model.
         runLocation: Path or str
             The sim_telarray run location to write the tabulated data files into.
@@ -380,13 +407,12 @@ class DatabaseHandler:
         collection = DatabaseHandler.dbClient[dbName]['telescopes']
         _parameters = dict()
 
-        _version = version
-        if version in ['Current', 'Latest']:
-            _version = self._getTaggedVersion(dbName, version)
+        _modelVersion = self._convertTaggedVersion(modelVersion, dbName)
+        _telNameDB = self._getTelescopeModelNameForDB(site, telescopeModelName)
 
         query = {
-            'Telescope': telescopeName,
-            'Version': _version,
+            'Telescope': _telNameDB,
+            'Version': _modelVersion,
         }
         if onlyApplicable:
             query['Applicable'] = onlyApplicable
@@ -411,23 +437,22 @@ class DatabaseHandler:
 
         return _parameters
 
-    def _getAllModelParametersYaml(self, telescopeName, version):
+    def _getAllModelParametersYaml(self, telescopeNameYaml):
         '''
         Get all parameters from Yaml DB for one specific type.
         No selection is applied.
 
         Parameters
         ----------
-        telescopeName: str
-        version: str
-            Version of the model.
+        telescopeNameYaml: str
+            Telescope name as required by the yaml files.
 
         Returns
         -------
         dict containing the parameters
         '''
 
-        _fileNameDB = 'parValues-{}.yml'.format(telescopeName)
+        _fileNameDB = 'parValues-{}.yml'.format(telescopeNameYaml)
         _yamlFile = cfg.findFile(
             _fileNameDB,
             cfg.get('modelFilesLocations')
@@ -440,7 +465,7 @@ class DatabaseHandler:
     def getSiteParameters(
         self,
         site,
-        version,
+        modelVersion,
         runLocation=None,
         onlyApplicable=False,
     ):
@@ -450,7 +475,8 @@ class DatabaseHandler:
         Parameters
         ----------
         site: str
-        version: str
+            South or North.
+        modelVersion: str
             Version of the model.
         runLocation: Path or str
             The sim_telarray run location to write the tabulated data files into.
@@ -461,28 +487,30 @@ class DatabaseHandler:
         -------
         dict containing the parameters
         '''
+        _site = names.validateSiteName(site)
+        _version = names.validateModelVersionName(modelVersion)
 
         if cfg.get('useMongoDB'):
             _pars = self._getSiteParametersMongoDB(
                 DatabaseHandler.DB_CTA_SIMULATION_MODEL,
-                site,
-                version,
+                _site,
+                _version,
                 runLocation,
                 onlyApplicable
             )
             return _pars
         else:
-            return self._getSiteParametersYaml(site, version, onlyApplicable)
+            return self._getSiteParametersYaml(_site, _version, onlyApplicable)
 
-    def _getSiteParametersYaml(self, site, version, onlyApplicable=False):
+    def _getSiteParametersYaml(self, site, modelVersion, onlyApplicable=False):
         '''
         Get parameters from DB for a specific type.
 
         Parameters
         ----------
         site: str
-            Must be "North" or "South" (not case sensitive)
-        version: str
+            North or South.
+        modelVersion: str
             Version of the model.
         onlyApplicable: bool
             If True, only applicable parameters will be read.
@@ -491,10 +519,6 @@ class DatabaseHandler:
         -------
         dict containing the parameters
         '''
-
-        if site.lower() not in ['north', 'south']:
-            raise ValueError('Site must be "North" or "South" (not case sensitive)')
-        site = 'lapalma' if 'north' in site.lower() else 'paranal'
 
         yamlFile = cfg.findFile('parValues-Sites.yml', cfg.get('modelFilesLocations'))
         self._logger.info('Reading DB file {}'.format(yamlFile))
@@ -509,7 +533,7 @@ class DatabaseHandler:
             if site in parName:
                 parNameIn = '_'.join(parName.split('_')[1:])
 
-                _pars[parNameIn] = parInfo[version]
+                _pars[parNameIn] = parInfo[modelVersion]
 
         return _pars
 
@@ -517,7 +541,7 @@ class DatabaseHandler:
         self,
         dbName,
         site,
-        version,
+        modelVersion,
         runLocation=None,
         onlyApplicable=False
     ):
@@ -527,9 +551,10 @@ class DatabaseHandler:
         Parameters
         ----------
         dbName: str
-            the name of the DB
+            The name of the DB.
         site: str
-        version: str
+            South or North.
+        modelVersion: str
             Version of the model.
         runLocation: Path or str
             The sim_telarray run location to write the tabulated data files into.
@@ -541,15 +566,10 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
-        if site not in ['North', 'South']:
-            raise ValueError('Site must be "North" or "South" (case sensitive!)')
-
         collection = DatabaseHandler.dbClient[dbName].sites
         _parameters = dict()
 
-        _version = version
-        if version in ['Current', 'Latest']:
-            _version = self._getTaggedVersion(dbName, version)
+        _version = self._convertVersionToTagged(modelVersion, dbName)
 
         query = {
             'Site': site,
@@ -927,6 +947,13 @@ class DatabaseHandler:
         collection.insert_one(dbEntry)
 
         return
+
+    def _convertVersionToTagged(self, modelVersion, dbName):
+        ''' Convert to tagged version, if needed. '''
+        if modelVersion in ['Current', 'Latest']:
+            return self._getTaggedVersion(dbName, modelVersion)
+        else:
+            return modelVersion
 
     def _getTaggedVersion(self, dbName, version='Current'):
         '''

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -521,6 +521,8 @@ class DatabaseHandler:
         dict containing the parameters
         '''
 
+        siteYaml = 'lapalma' if site is 'North' else 'paranal'
+
         yamlFile = cfg.findFile('parValues-Sites.yml', cfg.get('modelFilesLocations'))
         self._logger.info('Reading DB file {}'.format(yamlFile))
         with open(yamlFile, 'r') as stream:
@@ -531,7 +533,7 @@ class DatabaseHandler:
 
             if not parInfo['Applicable'] and onlyApplicable:
                 continue
-            if site in parName:
+            if siteYaml in parName:
                 parNameIn = '_'.join(parName.split('_')[1:])
 
                 _pars[parNameIn] = parInfo[modelVersion]

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -207,6 +207,7 @@ class ArrayModel:
                 # First time a telescope name is built
                 _allTelescopeModelNames.append(telModelName)
                 telModel = TelescopeModel(
+                    site=self.site,
                     telescopeModelName=telModelName,
                     modelVersion=self.modelVersion,
                     label=self.label,
@@ -278,7 +279,7 @@ class ArrayModel:
                     msg = 'ArrayConfig has no name for a telescope'
                     self._logger.error(msg)
                     raise InvalidArrayConfigData(msg)
-                telName = self.site + '-' + telSize + '-' + data['name']
+                telName = telSize + '-' + data['name']
                 parsToChange = {k: v for (k, v) in data.items() if k != 'name'}
                 self._logger.debug(
                     'Grabbing tel data as dict - '
@@ -288,7 +289,7 @@ class ArrayModel:
                 return telName, parsToChange
             elif isinstance(data, str):
                 # Case 1: data is string (only name)
-                telName = self.site + '-' + telSize + '-' + data
+                telName = telSize + '-' + data
                 return telName, dict()
             else:
                 # Case 2: data has a wrong type

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -207,7 +207,7 @@ class ArrayModel:
                 # First time a telescope name is built
                 _allTelescopeModelNames.append(telModelName)
                 telModel = TelescopeModel(
-                    telescopeName=telModelName,
+                    telescopeModelName=telModelName,
                     modelVersion=self.modelVersion,
                     label=self.label,
                     modelFilesLocations=self._modelFilesLocations,
@@ -217,10 +217,10 @@ class ArrayModel:
                 # Telescope name already exists.
                 # Finding the TelescopeModel and copying it.
                 for tel in self._telescopeModel:
-                    if tel.telescopeName != telModelName:
+                    if tel.name != telModelName:
                         continue
                     self._logger.debug(
-                        'Copying tel model {} already loaded from DB'.format(tel.telescopeName)
+                        'Copying tel model {} already loaded from DB'.format(tel.name)
                     )
                     telModel = copy(tel)
                     break
@@ -322,7 +322,7 @@ class ArrayModel:
     def printTelescopeList(self):
         ''' Print out the list of telescopes for quick inspection. '''
         for telData, telModel in zip(self.layout, self._telescopeModel):
-            print('Name: {}\t Model: {}'.format(telData.name, telModel.telescopeName))
+            print('Name: {}\t Model: {}'.format(telData.name, telModel.name))
 
     def exportSimtelTelescopeConfigFiles(self):
         '''
@@ -332,7 +332,7 @@ class ArrayModel:
         exportedModels = list()
         for telModel in self._telescopeModel:
             name = (
-                telModel.telescopeName
+                telModel.name
                 + ('_' + telModel.extraLabel if telModel.extraLabel != '' else '')
             )
             if name not in exportedModels:

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -52,14 +52,14 @@ class Camera:
     SIPM_NEIGHBOR_RADIUS_FACTOR = 1.4
     SIPM_ROW_COLUMN_DIST_FACTOR = 0.2
 
-    def __init__(self, telescopeName, cameraConfigFile, focalLength):
+    def __init__(self, telescopeModelName, cameraConfigFile, focalLength):
         '''
         Camera class, defining pixel layout including rotation, finding neighbour pixels,
         calculating FoV and plotting the camera.
 
         Parameters
         ----------
-        telescopeName: string
+        telescopeModelName: string
                     As provided by the telescope model method TelescopeModel (ex South-LST-1).
         cameraConfigFile: string
                     The sim_telarray file name.
@@ -70,8 +70,8 @@ class Camera:
 
         self._logger = logging.getLogger(__name__)
 
-        self._telescopeName = telescopeName
-        self._cameraName = getCameraName(self._telescopeName)
+        self._telescopeModelName = telescopeModelName
+        self._cameraName = getCameraName(self._telescopeModelName)
         self._cameraConfigFile = cameraConfigFile
         self._focalLength = focalLength
         if self._focalLength <= 0:
@@ -187,7 +187,7 @@ class Camera:
         One can check if the telescope is a two mirror one with isTwoMirrorTelescope.
         '''
 
-        if isTwoMirrorTelescope(self._telescopeName):
+        if isTwoMirrorTelescope(self._telescopeModelName):
             pixels['y'] = [(-1) * yVal for yVal in pixels['y']]
 
         rotateAngle = pixels['rotateAngle']  # So not to change the original angle
@@ -558,7 +558,7 @@ class Camera:
 
         invertYaxis = False
         xLeft = 0.7  # Position of the left most axis
-        if not isTwoMirrorTelescope(self._telescopeName):
+        if not isTwoMirrorTelescope(self._telescopeModelName):
             invertYaxis = True
             xLeft = 0.8
 
@@ -701,7 +701,7 @@ class Camera:
         plt: pyplot.plt instance with the pixel layout
         '''
 
-        self._logger.info('Plotting the {} camera'.format(self._telescopeName))
+        self._logger.info('Plotting the {} camera'.format(self._telescopeModelName))
 
         _, ax = plt.subplots()
         plt.gcf().set_size_inches(8, 8)
@@ -740,7 +740,7 @@ class Camera:
 
             if self._pixels['pixID'][i_pix] < 51:
                 fontSize = 4
-                if getTelescopeClass(self._telescopeName) == 'SCT':
+                if getTelescopeClass(self._telescopeModelName) == 'SCT':
                     fontSize = 2
                 plt.text(
                     xyPixPos[0],
@@ -797,7 +797,7 @@ class Camera:
         plt.xlabel('Horizontal scale [cm]', fontsize=18, labelpad=0)
         plt.ylabel('Vertical scale [cm]', fontsize=18, labelpad=0)
         ax.set_title(
-            'Pixels layout in {0:s} camera'.format(self._telescopeName),
+            'Pixels layout in {0:s} camera'.format(self._telescopeModelName),
             fontsize=15,
             y=1.02
         )

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -524,8 +524,9 @@ class TelescopeModel:
             return None
 
         fileName = names.simtelSingleMirrorListFileName(
+            self.site,
+            self.name,
             self.modelVersion,
-            self.telescopeName,
             mirrorNumber,
             self.label
         )
@@ -601,7 +602,7 @@ class TelescopeModel:
         if not hasattr(self, 'simtelConfigWriter'):
             self.simtelConfigWriter = SimtelConfigWriter(
                 site=self.site,
-                telescopeName=self.telescopeName,
+                telescopeModelName=self.name,
                 modelVersion=self.modelVersion,
                 label=self.label
             )
@@ -615,7 +616,7 @@ class TelescopeModel:
         bool:
             True if telescope  is a ASTRI, False otherwise.
         '''
-        return self.telescopeName in ['SST-2M-ASTRI', 'SST', 'South-SST-D']
+        return self.name in ['SST-2M-ASTRI', 'SST', 'SST-D']
 
     def isFile2D(self, par):
         '''

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -29,8 +29,8 @@ class TelescopeModel:
     ----------
     site: str
         North or South.
-    telescopeName: str
-        Telescope name for the base set of parameters (ex. North-LST-1, ...).
+    name: str
+        Telescope name for the base set of parameters (ex. LST-1, ...).
     modelVersion: str
         Version of the model (ex. prod4).
     label: str
@@ -68,7 +68,8 @@ class TelescopeModel:
 
     def __init__(
         self,
-        telescopeName,
+        site,
+        telescopeModelName,
         modelVersion='Current',
         label=None,
         modelFilesLocations=None,
@@ -80,8 +81,10 @@ class TelescopeModel:
 
         Parameters
         ----------
-        telescopeName: str
-            Telescope name (ex. North-LST-1, ...).
+        site: str
+            South or North.
+        telescopeModelName: str
+            Telescope name (ex. LST-1, ...).
         modelVersion: str, optional
             Version of the model (ex. prod4) (default='Current').
         label: str, optional
@@ -98,11 +101,11 @@ class TelescopeModel:
         self._logger = logging.getLogger(__name__)
         self._logger.debug('Init TelescopeModel')
 
+        self.site = names.validateSiteName(site)
+        self.name = names.validateTelescopeName(telescopeModelName)
         self.modelVersion = names.validateModelVersionName(modelVersion)
-        self.telescopeName = names.validateTelescopeName(telescopeName)
         self.label = label
         self._extraLabel = None
-        self.site = names.getSiteFromTelescopeName(self.telescopeName)
 
         self._modelFilesLocations = cfg.getConfigArg('modelFilesLocations', modelFilesLocations)
         self._filesLocation = cfg.getConfigArg('outputLocation', filesLocation)
@@ -135,7 +138,8 @@ class TelescopeModel:
     def fromConfigFile(
         cls,
         configFileName,
-        telescopeName,
+        site,
+        telescopeModelName,
         label=None,
         modelFilesLocations=None,
         filesLocation=None
@@ -152,8 +156,10 @@ class TelescopeModel:
         ----------
         configFileName: str or Path
             Path to the input config file.
-        telescopeName: str
-            Telescope name for the base set of parameters (ex. North-LST-1, ...).
+        site: str
+            South or North.
+        telescopeModelName: str
+            Telescope model name for the base set of parameters (ex. LST-1, ...).
         label: str, optional
             Instance label. Important for output file naming.
         modelFilesLocation: str (or Path), optional
@@ -169,7 +175,8 @@ class TelescopeModel:
         '''
         parameters = dict()
         tel = cls(
-            telescopeName=telescopeName,
+            site=site,
+            telescopeModelName=telescopeModelName,
             label=label,
             modelFilesLocations=modelFilesLocations,
             filesLocation=filesLocation,
@@ -247,8 +254,9 @@ class TelescopeModel:
 
         # Setting file name and the location
         configFileName = names.simtelTelescopeConfigFileName(
+            self.site,
+            self.name,
             self.modelVersion,
-            self.telescopeName,
             self.label,
             self._extraLabel
         )
@@ -262,7 +270,8 @@ class TelescopeModel:
         self._setConfigFileDirectoryAndName()
         db = db_handler.DatabaseHandler()
         self._parameters = db.getModelParameters(
-            self.telescopeName,
+            self.site,
+            self.name,
             self.modelVersion,
             self._configFileDirectory,
             onlyApplicable=True

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -44,7 +44,7 @@ class TelescopeModel:
 
     Methods
     -------
-    fromConfigFile(configFileName, telescopeName, label=None, filesLocation=None)
+    fromConfigFile(configFileName, telescopeModelName, label=None, filesLocation=None)
         Create a TelescopeModel from a sim_telarray cfg file.
     setExtraLabel(extraLabel)
         Set an extra label for the name of the config file.
@@ -102,7 +102,7 @@ class TelescopeModel:
         self._logger.debug('Init TelescopeModel')
 
         self.site = names.validateSiteName(site)
-        self.name = names.validateTelescopeName(telescopeModelName)
+        self.name = names.validateTelescopeModelName(telescopeModelName)
         self.modelVersion = names.validateModelVersionName(modelVersion)
         self.label = label
         self._extraLabel = None
@@ -593,7 +593,7 @@ class TelescopeModel:
             cameraConfigFilePath = cfg.findFile(cameraConfigFile, self._modelFilesLocations)
 
         self._camera = Camera(
-            telescopeName=self.telescopeName,
+            telescopeModelName=self.name,
             cameraConfigFile=cameraConfigFilePath,
             focalLength=focalLength
         )

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -145,7 +145,7 @@ class RayTracing:
 
         # Results file
         fileNameResults = names.rayTracingResultsFileName(
-            self._telescopeModel.telescopeName,
+            self._telescopeModel.name,
             self._sourceDistance,
             self._zenithAngle,
             self.label
@@ -242,7 +242,7 @@ class RayTracing:
                     self._logger.debug('mirrorNumber={}'.format(thisMirror))
 
                 photonsFileName = names.rayTracingFileName(
-                    self._telescopeModel.telescopeName,
+                    self._telescopeModel.name,
                     self._sourceDistance,
                     self._zenithAngle,
                     thisOffAxis,
@@ -376,7 +376,7 @@ class RayTracing:
         if save:
             plotFileName = names.rayTracingPlotFileName(
                 key,
-                self._telescopeModel.telescopeName,
+                self._telescopeModel.name,
                 self._sourceDistance,
                 self._zenithAngle,
                 self.label

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -243,6 +243,7 @@ class RayTracing:
                     self._logger.debug('mirrorNumber={}'.format(thisMirror))
 
                 photonsFileName = names.rayTracingFileName(
+                    self._telescopeModel.site,
                     self._telescopeModel.name,
                     self._sourceDistance,
                     self._zenithAngle,

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -145,6 +145,7 @@ class RayTracing:
 
         # Results file
         fileNameResults = names.rayTracingResultsFileName(
+            self._telescopeModel.site,
             self._telescopeModel.name,
             self._sourceDistance,
             self._zenithAngle,

--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -79,7 +79,7 @@ class SimtelConfigWriter:
         'sum_after_peak': 4
     }
 
-    def __init__(self, site, modelVersion, layoutName=None, telescopeName=None, label=None):
+    def __init__(self, site, modelVersion, layoutName=None, telescopeModelName=None, label=None):
         '''
         SimtelConfigWriter.
 
@@ -89,8 +89,8 @@ class SimtelConfigWriter:
             South or North.
         modelVersion: str, required.
             Version of the model (ex. prod4).
-        telescopeName: str, optional.
-            Telescope name.
+        telescopeModelName: str, optional.
+            Telescope model name.
         layoutName: str, optional.
             Layout name.
         label: str, optional
@@ -103,7 +103,7 @@ class SimtelConfigWriter:
         self._modelVersion = modelVersion
         self._label = label
         self._layoutName = layoutName
-        self._telescopeName = telescopeName
+        self._telescopeModelName = telescopeModelName
 
     def writeTelescopeConfigFile(self, configFilePath, parameters):
         '''
@@ -121,7 +121,7 @@ class SimtelConfigWriter:
 
             file.write('#ifdef TELESCOPE\n')
             file.write(
-                '   echo Configuration for {}'.format(self._telescopeName)
+                '   echo Configuration for {}'.format(self._telescopeModelName)
                 + ' - TELESCOPE $(TELESCOPE)\n'
             )
             file.write('#endif\n\n')
@@ -249,8 +249,8 @@ class SimtelConfigWriter:
         header += '{} Site: {}\n'.format(commentChar, self._site)
         header += '{} ModelVersion: {}\n'.format(commentChar, self._modelVersion)
         header += (
-            '{} TelescopeName: {}\n'.format(commentChar, self._telescopeName)
-            if self._telescopeName is not None else ''
+            '{} TelescopeModelName: {}\n'.format(commentChar, self._telescopeModelName)
+            if self._telescopeModelName is not None else ''
         )
         header += (
             '{} LayoutName: {}\n'.format(commentChar, self._layoutName)

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -214,6 +214,7 @@ class SimtelRunner:
         ''' Tells if simulations should be run again based on the existence of output files. '''
         if self._isRayTracingMode():
             photonsFileName = names.rayTracingFileName(
+                self.telescopeModel.site,
                 self.telescopeModel.name,
                 self._sourceDistance,
                 self._zenithAngle,
@@ -241,6 +242,7 @@ class SimtelRunner:
             # Files will be named _baseFileName = self.__dict__['_' + base + 'FileName']
             for baseName in ['stars', 'photons', 'log']:
                 fileName = names.rayTracingFileName(
+                    self.telescopeModel.site,
                     self.telescopeModel.name,
                     self._sourceDistance,
                     self._zenithAngle,

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -214,7 +214,7 @@ class SimtelRunner:
         ''' Tells if simulations should be run again based on the existence of output files. '''
         if self._isRayTracingMode():
             photonsFileName = names.rayTracingFileName(
-                self.telescopeModel.telescopeName,
+                self.telescopeModel.name,
                 self._sourceDistance,
                 self._zenithAngle,
                 self._offAxisAngle,
@@ -241,7 +241,7 @@ class SimtelRunner:
             # Files will be named _baseFileName = self.__dict__['_' + base + 'FileName']
             for baseName in ['stars', 'photons', 'log']:
                 fileName = names.rayTracingFileName(
-                    self.telescopeModel.telescopeName,
+                    self.telescopeModel.name,
                     self._sourceDistance,
                     self._zenithAngle,
                     self._offAxisAngle,

--- a/simtools/tests/__init__.py
+++ b/simtools/tests/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logging.basicConfig(format='%(levelname)s::%(module)s(l%(lineno)s)::%(funcName)s::%(message)s')

--- a/simtools/tests/test_camera_efficiency.py
+++ b/simtools/tests/test_camera_efficiency.py
@@ -13,7 +13,8 @@ logger.setLevel(logging.DEBUG)
 
 def test_main():
     tel = TelescopeModel(
-        telescopeName='north-lst-1',
+        site='north',
+        telescopeModelName='lst-1',
         modelVersion='p3',
         label='test_camera_eff'
     )

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -17,7 +17,7 @@ def test_reading_db_lst():
 
     logger.info('----Testing reading LST-----')
     db = db_handler.DatabaseHandler()
-    pars = db.getModelParameters('north-lst-1', 'Current', testDataDirectory)
+    pars = db.getModelParameters('north', 'lst-1', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['parabolic_dish']['Value'] == 1)
         assert(pars['camera_pixels']['Value'] == 1855)
@@ -35,7 +35,7 @@ def test_reading_db_mst_nc():
 
     logger.info('----Testing reading MST-NectarCam-----')
     db = db_handler.DatabaseHandler()
-    pars = db.getModelParameters('north-mst-NectarCam-D', 'Current', testDataDirectory)
+    pars = db.getModelParameters('north', 'mst-NectarCam-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 1855)
     else:
@@ -54,7 +54,7 @@ def test_reading_db_mst_fc():
 
     logger.info('----Testing reading MST-FlashCam-----')
     db = db_handler.DatabaseHandler()
-    pars = db.getModelParameters('north-mst-FlashCam-D', 'Current', testDataDirectory)
+    pars = db.getModelParameters('north', 'mst-FlashCam-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 1764)
     else:
@@ -73,7 +73,7 @@ def test_reading_db_sst():
 
     logger.info('----Testing reading SST-----')
     db = db_handler.DatabaseHandler()
-    pars = db.getModelParameters('south-sst-D', 'Current', testDataDirectory)
+    pars = db.getModelParameters('south', 'sst-D', 'Current', testDataDirectory)
     if cfg.get('useMongoDB'):
         assert(pars['camera_pixels']['Value'] == 2048)
     else:
@@ -193,10 +193,10 @@ def test_reading_db_sites():
 if __name__ == '__main__':
 
     # test_get_model_file()
-    # test_reading_db_lst()
+    test_reading_db_lst()
     # test_reading_db_mst_nc()
     # test_reading_db_mst_fc()
     # test_reading_db_sst()
     # test_modify_db()
-    test_reading_db_sites()
+    # test_reading_db_sites()
     pass

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -69,23 +69,23 @@ def test_reading_db_mst_fc():
     return
 
 
-# def test_reading_db_sst():
+def test_reading_db_sst():
 
-#     logger.info('----Testing reading SST-----')
-#     db = db_handler.DatabaseHandler()
-#     pars = db.getModelParameters('south', 'sst-D', 'Current', testDataDirectory)
-#     if cfg.get('useMongoDB'):
-#         assert(pars['camera_pixels']['Value'] == 2048)
-#     else:
-#         assert(pars['camera_pixels'] == 2048)
+    logger.info('----Testing reading SST-----')
+    db = db_handler.DatabaseHandler()
+    pars = db.getModelParameters('south', 'sst-D', 'Current', testDataDirectory)
+    if cfg.get('useMongoDB'):
+        assert(pars['camera_pixels']['Value'] == 2048)
+    else:
+        assert(pars['camera_pixels'] == 2048)
 
-#     logger.info('Listing files written in {}'.format(testDataDirectory))
-#     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
+    logger.info('Listing files written in {}'.format(testDataDirectory))
+    subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
 
-#     logger.info('Removing the files written in {}'.format(testDataDirectory))
-#     subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
+    logger.info('Removing the files written in {}'.format(testDataDirectory))
+    subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
 
-#     return
+    return
 
 
 def test_modify_db():

--- a/simtools/tests/test_db_handler.py
+++ b/simtools/tests/test_db_handler.py
@@ -69,23 +69,23 @@ def test_reading_db_mst_fc():
     return
 
 
-def test_reading_db_sst():
+# def test_reading_db_sst():
 
-    logger.info('----Testing reading SST-----')
-    db = db_handler.DatabaseHandler()
-    pars = db.getModelParameters('south', 'sst-D', 'Current', testDataDirectory)
-    if cfg.get('useMongoDB'):
-        assert(pars['camera_pixels']['Value'] == 2048)
-    else:
-        assert(pars['camera_pixels'] == 2048)
+#     logger.info('----Testing reading SST-----')
+#     db = db_handler.DatabaseHandler()
+#     pars = db.getModelParameters('south', 'sst-D', 'Current', testDataDirectory)
+#     if cfg.get('useMongoDB'):
+#         assert(pars['camera_pixels']['Value'] == 2048)
+#     else:
+#         assert(pars['camera_pixels'] == 2048)
 
-    logger.info('Listing files written in {}'.format(testDataDirectory))
-    subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
+#     logger.info('Listing files written in {}'.format(testDataDirectory))
+#     subprocess.call(['ls -lh {}'.format(testDataDirectory)], shell=True)
 
-    logger.info('Removing the files written in {}'.format(testDataDirectory))
-    subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
+#     logger.info('Removing the files written in {}'.format(testDataDirectory))
+#     subprocess.call(['rm -f {}/*'.format(testDataDirectory)], shell=True)
 
-    return
+#     return
 
 
 def test_modify_db():
@@ -193,10 +193,10 @@ def test_reading_db_sites():
 if __name__ == '__main__':
 
     # test_get_model_file()
-    test_reading_db_lst()
+    # test_reading_db_lst()
     # test_reading_db_mst_nc()
     # test_reading_db_mst_fc()
-    # test_reading_db_sst()
+    test_reading_db_sst()
     # test_modify_db()
     # test_reading_db_sites()
-    pass
+

--- a/simtools/tests/test_names.py
+++ b/simtools/tests/test_names.py
@@ -13,7 +13,7 @@ def test_validate_telescope_names():
         newName = names.validateTelescopeModelName(name)
         print('New name {}'.format(newName))
 
-    for n in ['north-sst-d', 'south-mst-flashcam-d', 'north-sct-d']:
+    for n in ['sst-d', 'mst-flashcam-d', 'sct-d']:
         validate(n)
 
 
@@ -26,4 +26,3 @@ if __name__ == '__main__':
 
     test_validate_telescope_names()
     test_validate_other_names()
-    pass

--- a/simtools/tests/test_names.py
+++ b/simtools/tests/test_names.py
@@ -10,7 +10,7 @@ def test_validate_telescope_names():
 
     def validate(name):
         print('Validating {}'.format(name))
-        newName = names.validateTelescopeName(name)
+        newName = names.validateTelescopeModelName(name)
         print('New name {}'.format(newName))
 
     for n in ['north-sst-d', 'south-mst-flashcam-d', 'north-sct-d']:

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -59,13 +59,13 @@ def test_ssts(show=False):
 
 def test_rx():
     sourceDistance = 10 * u.km
-    version = 'prod3'
+    version = 'current'
     label = 'test-lst'
     zenithAngle = 20 * u.deg
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        site='south',
+        site='north',
         telescopeModelName='lst-1',
         modelVersion=version,
         label=label

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -26,7 +26,8 @@ def test_ssts(show=False):
     rayTracing = list()
     for t in telTypes:
         tel = TelescopeModel(
-            telescopeName='south-' + t,
+            site='south',
+            telescopeModelName=t,
             modelVersion=version,
             label='test-sst'
         )
@@ -64,7 +65,8 @@ def test_rx():
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeName='north-lst-1',
+        site='south',
+        telescopeModelName='lst-1',
         modelVersion=version,
         label=label
     )
@@ -116,7 +118,8 @@ def test_plot_image():
     offAxisAngle = [0, 2.5, 5.0] * u.deg
 
     tel = TelescopeModel(
-        telescopeName='south-sst-D',
+        site='south',
+        telescopeModelName='sst-D',
         modelVersion=version,
         label=label
     )
@@ -149,7 +152,8 @@ def test_single_mirror(plot=False):
     version = 'prod3'
 
     tel = TelescopeModel(
-        telescopeName='north-mst-FlashCam-D',
+        site='north',
+        telescopeModelName='mst-FlashCam-D',
         modelVersion=version,
         label='test-mst'
     )
@@ -178,10 +182,10 @@ def test_integral_curve():
     label = 'lst_integral'
     zenithAngle = 20 * u.deg
     offAxisAngle = [0] * u.deg
-    show = True
 
     tel = TelescopeModel(
-        telescopeName='north-mst-FlashCam-D',
+        site='north',
+        telescopeModelName='mst-FlashCam-D',
         modelVersion=version,
         label=label
     )

--- a/simtools/tests/test_simtel_config_writer.py
+++ b/simtools/tests/test_simtel_config_writer.py
@@ -20,10 +20,11 @@ class TestSimtelConfigWriter(unittest.TestCase):
             site='North',
             modelVersion='Current',
             label='test-simtel-config-writer',
-            telescopeName='TestTelecope'
+            telescopeModelName='TestTelecope'
         )
         self.telescopeModel = TelescopeModel(
-            telescopeName='North-LST-1',
+            site='North',
+            telescopeModelName='LST-1',
             modelVersion='Current',
             label='test-telescope-model'
         )

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -13,7 +13,8 @@ logger.setLevel(logging.DEBUG)
 
 def test_ray_tracing_mode():
     tel = TelescopeModel(
-        telescopeName='north-lst-1',
+        site='north',
+        telescopeModelName='lst-1',
         modelVersion='Current',
         label='test-simtel'
     )
@@ -32,7 +33,8 @@ def test_ray_tracing_mode():
 
 def test_catching_model_error():
     tel = TelescopeModel(
-        telescopeName='north-lst-1',
+        site='north',
+        telescopeModelName='lst-1',
         modelVersion='Current',
         label='test-simtel'
     )

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -14,7 +14,8 @@ class TestTelescopeModel(unittest.TestCase):
     def setUp(self):
         self.label = 'test-telescope-model'
         self.telModel = TelescopeModel(
-            telescopeName='North-LST-1',
+            site='North',
+            telescopeModelName='LST-1',
             modelVersion='Current',
             label='test-telescope-model'
         )
@@ -58,7 +59,8 @@ class TestTelescopeModel(unittest.TestCase):
         # Importing
         cfgFile = self.telModel.getConfigFile()
         tel = TelescopeModel.fromConfigFile(
-            telescopeName='south-sst-d',
+            site='south',
+            telescopeModelName='sst-d',
             label='test-sst',
             configFileName=cfgFile
         )

--- a/simtools/util/model.py
+++ b/simtools/util/model.py
@@ -65,14 +65,14 @@ def validateModelParameter(parNameIn, parValueIn):
     return parNameIn, parValueIn
 
 
-def getCameraName(telescopeName):
+def getCameraName(telescopeModelName):
     '''
     Get camera name from the telescope name.
 
     Parameters
     ----------
-    telescopeName: str
-        Telescope name (ex. South-LST-1)
+    telescopeModelName: str
+        Telescope model name (ex. LST-1)
 
     Returns
     -------
@@ -81,7 +81,7 @@ def getCameraName(telescopeName):
     '''
     _logger = logging.getLogger(__name__)
     cameraName = ''
-    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    telClass, telType = names.splitTelescopeModelName(telescopeModelName)
     if telClass == 'LST':
         cameraName = 'LST'
     elif telClass == 'MST':
@@ -110,39 +110,39 @@ def getCameraName(telescopeName):
     return cameraName
 
 
-def getTelescopeClass(telescopeName):
+def getTelescopeClass(telescopeModelName):
     '''
     Get telescope class from telescope name.
 
     Parameters
     ----------
-    telescopeName: str
-        Telescope name (ex. South-LST-1)
+    telescopeModelName: str
+        Telescope model name (ex. LST-1)
 
     Returns
     -------
     str
         Telescope class (SST, MST, ...)
     '''
-    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    telClass, _ = names.splitTelescopeModelName(telescopeModelName)
     return telClass
 
 
-def isTwoMirrorTelescope(telescopeName):
+def isTwoMirrorTelescope(telescopeModelName):
     '''
     Check if the telescope is a two mirror design.
 
     Parameters
     ----------
-    telescopeName: str
-        Telescope name (ex. South-LST-1)
+    telescopeModelName: str
+        Telescope model name (ex. LST-1)
 
     Returns
     -------
     bool
         True if the telescope is a two mirror one.
     '''
-    telSite, telClass, telType = names.splitTelescopeName(telescopeName)
+    telClass, telType = names.splitTelescopeName(telescopeModelName)
     if telClass == 'SST':
         # Only 1M is False
         return False if '1M' in telType else True

--- a/simtools/util/model.py
+++ b/simtools/util/model.py
@@ -142,7 +142,7 @@ def isTwoMirrorTelescope(telescopeModelName):
     bool
         True if the telescope is a two mirror one.
     '''
-    telClass, telType = names.splitTelescopeName(telescopeModelName)
+    telClass, telType = names.splitTelescopeModelName(telescopeModelName)
     if telClass == 'SST':
         # Only 1M is False
         return False if '1M' in telType else True

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -410,16 +410,18 @@ def simtelArrayConfigFileName(arrayName, site, version, label):
     return name
 
 
-def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
+def simtelSingleMirrorListFileName(site, telescopeModelName, modelVersion, mirrorNumber, label):
     '''
     sim_telarray mirror list file with a single mirror.
 
     Parameters
     ----------
-    version: str
-        Version of the model.
-    telescopeName: str
+    site: str
+        South or North.
+    telescopeModelName: str
         North-LST-1, South-MST-FlashCam, ...
+    modelVersion: str
+        Version of the model.
     mirrorNumber: int
         Mirror number.
     label: str
@@ -430,7 +432,7 @@ def simtelSingleMirrorListFileName(version, telescopeName, mirrorNumber, label):
     str
         File name.
     '''
-    name = 'CTA-single-mirror-list-{}-{}'.format(version, telescopeName)
+    name = 'CTA-single-mirror-list-{}-{}-{}'.format(site, telescopeModelName, modelVersion)
     name += '-mirror{}'.format(mirrorNumber)
     name += '_{}'.format(label) if label is not None else ''
     name += '.dat'

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -532,7 +532,7 @@ def rayTracingResultsFileName(site, telescopeModelName, sourceDistance, zenithAn
     str
         File name.
     '''
-    name = 'ray-tracing-{}-d{:.1f}-za{:.1f}'.format(
+    name = 'ray-tracing-{}-{}-d{:.1f}-za{:.1f}'.format(
         site,
         telescopeModelName,
         sourceDistance,

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -355,16 +355,18 @@ allLayoutArrayNames = {
 }
 
 
-def simtelTelescopeConfigFileName(version, telescopeName, label, extraLabel):
+def simtelTelescopeConfigFileName(site, telescopeModelName, modelVersion, label, extraLabel):
     '''
     sim_telarray config file name for a telescope.
 
     Parameters
     ----------
-    version: str
+    site: str
+        South or North.
+    telescopeModelName: str
+        LST-1, MST-FlashCam, ...
+    modelVersion: str
         Version of the model.
-    telescopeName: str
-        North-LST-1, South-MST-FlashCam, ...
     label: str
         Instance label.
     extraLabel: str
@@ -375,7 +377,7 @@ def simtelTelescopeConfigFileName(version, telescopeName, label, extraLabel):
     str
         File name.
     '''
-    name = 'CTA-{}-{}'.format(version, telescopeName)
+    name = 'CTA-{}-{}-{}'.format(site, telescopeModelName, modelVersion)
     name += '_{}'.format(label) if label is not None else ''
     name += '_{}'.format(extraLabel) if extraLabel is not None else ''
     name += '.cfg'


### PR DESCRIPTION
This PR does not add any new module. Many small changes were made in order to make the telescope model name consistent.

Before, the telescope model names included site (e.g. North-LST-1) in some places, and did not include it in some other places (e.g. in the array_model, where the site is given only once for the whole array).

Now, site is always given separate from the telescope model name. In the new convention, telescopeModelNames contain only telescope class (SST, MST or LST) and the specific identifier (e.g. MST-FlashCam-D).

There are few functions in db_handler that still uses the telescopeModelName with site, because they communicate directly with the DB. In these cases, the variable name was changed to telescopeModelNameDB.

The names of the variables were made consistent as well. Now telescopeModelName is used everywhere for the name of the model and telescopeName is used at the layout, to indicate the name of a certain telescope in the array (L-01, M-05 ...).

The variables for the model version were all replaced by modelVersion, instead of just version, for clarity. 

The attribute 'telescopeName' of TelescopeModel was changed by just 'name'. 

Some small refactoring were done in some places, e.g. db_handler.
 