### PR TITLE
Changing the system to validate input config data

### DIFF
--- a/data/ray-tracing/ray-tracing_parameters.yml
+++ b/data/ray-tracing/ray-tracing_parameters.yml
@@ -1,0 +1,13 @@
+zenithAngle: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  default: 20
+  names: ['zenith', 'theta']
+offAxisAngle: 
+  len: null
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['offaxis', 'offset']
+sourceDistance:
+  len: 1
+  unit': !astropy.units.Unit {unit: km}
+  default: 10

--- a/data/test-data/test_parameters.yml
+++ b/data/test-data/test_parameters.yml
@@ -1,0 +1,30 @@
+
+
+zenithAngle: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  default: 20
+  names: ['zenith', 'theta']
+# Parameters with undefined length must contain len: null
+# A single unit must be given in this case
+offAxisAngle: 
+  len: null
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['offaxis', 'offset']
+
+sourceDistance:
+  len: 1
+  unit: !astropy.units.Unit {unit: km}
+  default: 10
+
+# Unit must be given as a list when len > 1
+cscat:
+  len: 3
+  unit: [null, !astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}]
+  names: ['scat']
+
+# Names are case insensitive
+validatedName:
+  len: 1
+  unit: null
+  names: ['testname']

--- a/data/test-data/test_parameters.yml
+++ b/data/test-data/test_parameters.yml
@@ -1,6 +1,6 @@
 # This is an example of the parameter file to be used
 # to validate config data.
-# 
+#
 # Each parameter is listed by its main name as parent key.
 # A list of alternative names can be listed using the key 'names'.
 # If a config entry with one of the names listed are found (case insensitive),
@@ -8,19 +8,19 @@
 #
 # The length of the entry must be given by the key 'len'.
 # Lists with undefined length can be set by len: null.
-# 
+#
 # The 'unit' has to be a list of the same len as the entry.
 # No units can be set by null or by not adding the 'unit' key.
 #
 # Config entries will be checked whether they are given
-# with equivalents units or not. If so, the entry will 
+# with equivalents units or not. If so, the entry will
 # be converted to the proper unit and only its value
 # will be returned.
 #
 # A default value can be given by the key 'default'.
-# Parameters without default key will raise error when missing. 
+# Parameters without default key will raise error when missing.
 
-zenithAngle: 
+zenithAngle:
   len: 1
   unit: !astropy.units.Unit {unit: deg}
   default: 20
@@ -33,7 +33,7 @@ sourceDistance:
   len: 1
   unit: !astropy.units.Unit {unit: km}
   default: 10
-cscat: # Parameter with len > 1 and multiple units. 
+cscat: # Parameter with len > 1 and multiple units.
   len: 3
   unit: [null, !astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}]
   names: ['scat']

--- a/data/test-data/test_parameters.yml
+++ b/data/test-data/test_parameters.yml
@@ -1,29 +1,42 @@
-
+# This is an example of the parameter file to be used
+# to validate config data.
+# 
+# Each parameter is listed by its main name as parent key.
+# A list of alternative names can be listed using the key 'names'.
+# If a config entry with one of the names listed are found (case insensitive),
+# a validated config entry is set with the main name.
+#
+# The length of the entry must be given by the key 'len'.
+# Lists with undefined length can be set by len: null.
+# 
+# The 'unit' has to be a list of the same len as the entry.
+# No units can be set by null or by not adding the 'unit' key.
+#
+# Config entries will be checked whether they are given
+# with equivalents units or not. If so, the entry will 
+# be converted to the proper unit and only its value
+# will be returned.
+#
+# A default value can be given by the key 'default'.
+# Parameters without default key will raise error when missing. 
 
 zenithAngle: 
   len: 1
   unit: !astropy.units.Unit {unit: deg}
   default: 20
   names: ['zenith', 'theta']
-# Parameters with undefined length must contain len: null
-# A single unit must be given in this case
-offAxisAngle: 
+offAxisAngle: # Parameter with undefined length
   len: null
   unit: !astropy.units.Unit {unit: deg}
   names: ['offaxis', 'offset']
-
 sourceDistance:
   len: 1
   unit: !astropy.units.Unit {unit: km}
   default: 10
-
-# Unit must be given as a list when len > 1
-cscat:
+cscat: # Parameter with len > 1 and multiple units. 
   len: 3
   unit: [null, !astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}]
   names: ['scat']
-
-# Names are case insensitive
 validatedName:
   len: 1
   unit: null

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -55,30 +55,26 @@ def test_collect_dict_data():
 def test_validate_config_data():
 
     parameterFile = io.getTestDataFile('test_parameters.yml')
-
     parameters = gen.collectDataFromYamlOrDict(parameterFile, None)
 
     configData = {
         'zenith': 0 * u.deg,
-        'offaxis': [0 * u.deg, 0.2 * u.rad],
+        'offaxis': [0 * u.deg, 0.2 * u.rad, 3 * u.deg],
         'cscat': [0, 10 * u.m, 3 * u.km],
+        'sourceDistance': 20000 * u.m,
         'testName': 10
     }
 
     validatedData = gen.validateConfigData(configData=configData, parameters=parameters)
 
+    # Testing undefined len
+    assert len(validatedData['offAxisAngle']) == 3
+
+    # Testing name validation
     assert 'validatedName' in validatedData.keys()
 
-    print(validatedData)
-
-    # configData1 = {
-    #     'zenith': 0 * u.deg,
-    #     'offaxis': [0, 20] * u.deg
-    # }
-
-    # validatedData1 = gen.validateConfigData(configData=configData1, parameters=parameters)
-
-    # print(validatedData1)
+    # Testing unit convertion
+    assert validatedData['sourceDistance'][0] == 20
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -54,29 +54,31 @@ def test_collect_dict_data():
 
 def test_validate_config_data():
 
-    parameterFile = io.getDataFile('ray-tracing', 'ray-tracing_parameters.yml')
+    parameterFile = io.getTestDataFile('test_parameters.yml')
 
     parameters = gen.collectDataFromYamlOrDict(parameterFile, None)
 
-    print(parameters)
-
-    configData0 = {
+    configData = {
         'zenith': 0 * u.deg,
-        'offaxis': [0 * u.deg, 0.2 * u.rad]
+        'offaxis': [0 * u.deg, 0.2 * u.rad],
+        'cscat': [0, 10 * u.m, 3 * u.km],
+        'testName': 10
     }
 
-    validatedData0 = gen.validateConfigData(configData=configData0, parameters=parameters)
+    validatedData = gen.validateConfigData(configData=configData, parameters=parameters)
 
-    print(validatedData0)
+    assert 'validatedName' in validatedData.keys()
 
-    configData1 = {
-        'zenith': 0 * u.deg,
-        'offaxis': [0, 20] * u.deg
-    }
+    print(validatedData)
 
-    validatedData1 = gen.validateConfigData(configData=configData1, parameters=parameters)
+    # configData1 = {
+    #     'zenith': 0 * u.deg,
+    #     'offaxis': [0, 20] * u.deg
+    # }
 
-    print(validatedData1)
+    # validatedData1 = gen.validateConfigData(configData=configData1, parameters=parameters)
+
+    # print(validatedData1)
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -4,7 +4,7 @@ import logging
 import astropy.units as u
 
 import simtools.io_handler as io
-from simtools.util.general import collectArguments, collectDataFromYamlOrDict
+import simtools.util.general as gen
 
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -21,7 +21,7 @@ def test_collect_args():
         }
 
         def __init__(self, **kwargs):
-            collectArguments(
+            gen.collectArguments(
                 self,
                 args=['zenithAngle', 'offAxisAngle', 'testDict'],
                 allInputs=self.ALL_INPUTS,
@@ -41,20 +41,46 @@ def test_collect_dict_data():
     }
     inYaml = io.getTestDataFile('test_collect_dict_data.yml')
 
-    d1 = collectDataFromYamlOrDict(None, inDict)
+    d1 = gen.collectDataFromYamlOrDict(None, inDict)
     assert 'k2' in d1.keys()
     assert d1['k1'] == 2
 
-    d2 = collectDataFromYamlOrDict(inYaml, None)
+    d2 = gen.collectDataFromYamlOrDict(inYaml, None)
     assert 'k3' in d2.keys()
     assert d2['k4'] == ['bla', 2]
 
-    d3 = collectDataFromYamlOrDict(inYaml, inDict)
+    d3 = gen.collectDataFromYamlOrDict(inYaml, inDict)
     assert d3 == d2
+
+def test_validate_config_data():
+
+    parameterFile = io.getDataFile('ray-tracing', 'ray-tracing_parameters.yml')
+
+    parameters = gen.collectDataFromYamlOrDict(parameterFile, None)
+
+    print(parameters)
+
+    configData0 = {
+        'zenith': 0 * u.deg,
+        'offaxis': [0 * u.deg, 0.2 * u.rad]
+    }
+
+    validatedData0 = gen.validateConfigData(configData=configData0, parameters=parameters)
+
+    print(validatedData0)
+
+    configData1 = {
+        'zenith': 0 * u.deg,
+        'offaxis': [0, 20] * u.deg
+    }
+
+    validatedData1 = gen.validateConfigData(configData=configData1, parameters=parameters)
+
+    print(validatedData1)
 
 
 if __name__ == '__main__':
 
-    test_collect_dict_data()
+    # test_collect_dict_data()
     # test_collect_args()
-    pass
+    test_validate_config_data()

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -218,4 +218,3 @@ if __name__ == '__main__':
     # test_single_mirror()
     # test_plot_image()
     # test_integral_curve()
-    pass

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -123,7 +123,7 @@ def validateConfigData(configData, parameters):
         isIdentified = False
         for parName, parInfo in parameters.items():
             names = parInfo.get('names', [])
-            if keyData != parName and keyData.lower() not in names:
+            if keyData != parName and keyData.lower() not in [n.lower() for n in names]:
                 continue
             # Matched parameter
             validatedValue = validateAndConvertValue(parName, parInfo, valueData)

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -169,10 +169,11 @@ def validateAndConvertValue(parName, parInfo, value):
     # Turning valueArgs into a list, if it is not.
     value = copyAsList(value)
 
+    valueLength = len(value)
     undefinedLength = False
     if parInfo['len'] is None:
         undefinedLength = True
-    elif len(value) != parInfo['len']:
+    elif valueLength != parInfo['len']:
         msg = 'Config entry with wrong len: {}'.format(parName)
         logger.error(msg)
         raise InvalidConfigEntry(msg)
@@ -188,8 +189,7 @@ def validateAndConvertValue(parName, parInfo, value):
             logger.error(msg)
             raise InvalidConfigEntry(msg)
         elif len(parUnit) == 1:
-            parUnit *= len(value)
-            print(parUnit)
+            parUnit *= valueLength
 
         # Checking units and converting them, if needed.
         valueWithUnits = list()

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -27,6 +27,18 @@ class MissingRequiredArgument(Exception):
     pass
 
 
+class UnableToIdentifyConfigEntry(Exception):
+    pass
+
+
+class MissingRequiredConfigEntry(Exception):
+    pass
+
+
+class InvalidConfigEntry(Exception):
+    pass
+
+
 def fileHasText(file, text):
     '''
     Check whether a file contain a certain piece of text.
@@ -96,6 +108,108 @@ def _convertUnit(quantity, unit):
     astropy.quantity
     '''
     return quantity if unit is None else quantity.to(unit).value
+
+
+def validateConfigData(configData, parameters):
+
+    logger = logging.getLogger(__name__)
+
+    # Dict to be filled and returned
+    outData = dict()
+
+    # Collecting all parameters given as arguments
+    for keyData, valueData in configData.items():
+
+        isIdentified = False
+        for parName, parInfo in parameters.items():
+            names = parInfo.get('names', [])
+            if keyData != parName and keyData.lower() not in names:
+                continue
+            # Matched parameter
+            validatedValue = validateAndConvertValue(parName, parInfo, valueData)
+            outData[parName] = validatedValue
+            isIdentified = True
+
+        # Raising error for an unidentified input.
+        if not isIdentified:
+            msg = 'Entry {} in configData cannot be identified.'.format(keyData)
+            logger.error(msg)
+            raise UnableToIdentifyConfigEntry(msg)
+
+    # Checking for parameters with default option
+    # If it is not given, filling it with the default value
+    for parName, parInfo in parameters.items():
+        if parName in outData.keys():
+            continue
+        elif 'default' in parInfo.keys():
+            validatedValue = validateAndConvertValue(
+                parName,
+                parInfo,
+                parInfo['default']
+            )
+            outData[parName] = validatedValue
+        else:
+            msg = (
+                'Required entry in configData {} '.format(parName)
+                + 'was not given (there may be more).'
+            )
+            logger.error(msg)
+            raise MissingRequiredConfigEntry(msg)
+    return outData
+
+
+def validateAndConvertValue(parName, parInfo, value):
+    '''
+    Validate input user parameter and convert it to the right units, if needed.
+    Returns the validated arguments in a list.
+    '''
+
+    logger = logging.getLogger(__name__)
+
+    # Turning valueArgs into a list, if it is not.
+    value = copyAsList(value)
+
+    undefinedLength = False
+    if parInfo['len'] is None:
+        undefinedLength = True
+    elif len(value) != parInfo['len']:
+        msg = 'Config entry with wrong len: {}'.format(parName)
+        logger.error(msg)
+        raise InvalidConfigEntry(msg)
+
+    if 'unit' not in parInfo.keys():
+        return value
+    else:
+        # Turning parInfo['unit'] into a list, if it is not.
+        parUnit = copyAsList(parInfo['unit'])
+
+        if undefinedLength and len(parUnit) != 1:
+            msg = 'Config entry with undefined length should have a single unit: {}'.format(parName)
+            logger.error(msg)
+            raise InvalidConfigEntry(msg)
+        elif len(parUnit) == 1:
+            parUnit *= len(value)
+            print(parUnit)
+
+        # Checking units and converting them, if needed.
+        valueWithUnits = list()
+        for arg, unit in zip(value, parUnit):
+            if unit is None:
+                valueWithUnits.append(arg)
+                continue
+
+            if not isinstance(arg, u.quantity.Quantity):
+                msg = 'Config entry given without unit: {}'.format(parName)
+                logger.error(msg)
+                raise InvalidConfigEntry(msg)
+            elif not arg.unit.is_equivalent(unit):
+                msg = 'Config entry given with wrong unit: {}'.format(parName)
+                logger.error(msg)
+                raise InvalidConfigEntry(msg)
+            else:
+                valueWithUnits.append(arg.to(unit).value)
+
+        return valueWithUnits
 
 
 def collectArguments(obj, args, allInputs, **kwargs):
@@ -353,6 +467,7 @@ def getLogLevelFromUser(logLevel):
     else:
         return possibleLevels[logLevelLower]
 
+
 def copyAsList(value):
     '''
     Copy value and, if it is not a list, turn it into a list with a single entry.
@@ -366,5 +481,7 @@ def copyAsList(value):
     value: list
         Copy of value if it is a list of [value] otherwise.
     '''
-    return copy.copy(value) if isinstance(value, list) else [value]
-
+    try:
+        return list(value)
+    except Exception:
+        return [value]


### PR DESCRIPTION
We have a system in place to collect and validate input config data that uses kwargs and requires the information about the expected input to be stored in a class dict (called ALL_INPUTS).
This system is not ideal, and this PR intend to start changing it.

The plan is to implement a clearer system that reads a dict with the config data and uses the parameter information given from another dict. These parameters can be stored in yml files (or DB in the future).

I implemented something similar in corsika_config, and now I want to expand it and use it consistently all around the modules.

This PR only includes the implementation of the functions in util/general.py, its test module and an example of the parameter yml file. After we agree on these, I will start replacing the old system by this new one. This will clean significantly few modules and the general module.

I suggest to have a look at:
- the function validateConfigData in util/general
- the function test_validate_config_data in tests/test_general
- the example of the parameter file in data/test-data/test_parameters.yml

I tried to add enough comments to make it clear.

