### PR TITLE
Replacing system to validate configurable parameters

### DIFF
--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -185,7 +185,7 @@ if __name__ == '__main__':
             newPars = yaml.load(file, Loader=yaml.FullLoader)
         telModel.changeParameters(**newPars)
 
-    ray = RayTracing(
+    ray = RayTracing.fromKwargs(
         telescopeModel=telModel,
         sourceDistance=args.src_distance * u.km,
         zenithAngle=args.zenith * u.deg,

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -243,7 +243,7 @@ if __name__ == '__main__':
     def run(rnda, plot=False):
         ''' Runs the simulations for one given value of rnda '''
         tel.changeParameter('mirror_reflection_random_angle', str(rnda))
-        ray = RayTracing(
+        ray = RayTracing.fromKwargs(
             telescopeModel=tel,
             singleMirrorMode=True,
             mirrorNumbers=list(range(1, 10)) if args.test else 'all',

--- a/applications/make_regular_arrays.py
+++ b/applications/make_regular_arrays.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
     for site in ['South', 'North']:
         for arrayName in ['1SST', '4SST', '1MST', '4MST', '1LST', '4LST']:
             logger.info('Processing array {}'.format(arrayName))
-            layout = LayoutArray(
+            layout = LayoutArray.fromKwargs(
                 label=label,
                 name=site + '-' + arrayName,
                 **sitePars[site]

--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -159,7 +159,7 @@ if __name__ == '__main__':
         ' for {}\n'.format(telModel.name)
     )
 
-    ray = RayTracing(
+    ray = RayTracing.fromKwargs(
         telescopeModel=telModel,
         sourceDistance=args.src_distance * u.km,
         zenithAngle=args.zenith * u.deg,

--- a/data/parameters/camera-efficiency_parameters.yml
+++ b/data/parameters/camera-efficiency_parameters.yml
@@ -1,0 +1,7 @@
+zenithAngle: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  default: !astropy.units.Quantity
+    value: 20
+    unit: !astropy.units.Unit {unit: deg}
+  names: ['zenith', 'theta']

--- a/data/parameters/layout-array_parameters.yml
+++ b/data/parameters/layout-array_parameters.yml
@@ -1,0 +1,63 @@
+epsg: 
+  len: 1
+  names: []
+  default: null
+centerLongitude: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['longitude', 'long', 'center_longitude']
+  default: null
+centerLatitude: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['latitude', 'lat', 'center_latitude']
+  default: null
+centerNorthing: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['northing', 'north', center_northing']
+  default: null
+centerEasting: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['easting', 'east', center_easting']
+  default: null
+centerAltitude: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['altitude', 'centeralt']
+  default: null
+corsikaObsLevel: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['obslevel']
+  default: null
+corsikaSphereCenter: 
+  len: 3
+  unit: [!astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}]
+  names: ['spherecenter']
+  default: 
+    LST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 16.0
+    MST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 9.0
+    SST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 3.25
+corsikaSphereRadius: 
+  len: 3
+  unit: [!astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}, !astropy.units.Unit {unit: m}]
+  names: ['sphereradius']
+  default:
+    LST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 12.5
+    MST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 9.6
+    SST: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: m}
+      value: 3.5
+

--- a/data/parameters/ray-tracing_parameters.yml
+++ b/data/parameters/ray-tracing_parameters.yml
@@ -1,17 +1,23 @@
 zenithAngle: 
   len: 1
   unit: !astropy.units.Unit {unit: deg}
-  default: 20
+  default: !astropy.units.Quantity
+    value: 20
+    unit: !astropy.units.Unit {unit: deg}
   names: ['zenith', 'theta']
 offAxisAngle: 
   len: null
   unit: !astropy.units.Unit {unit: deg}
-  default: 0
+  default: !astropy.units.Quantity
+    value: 0
+    unit: !astropy.units.Unit {unit: deg}
   names: ['offaxis', 'offset']
 sourceDistance:
   len: 1
   unit: !astropy.units.Unit {unit: km}
-  default: 10
+  default: !astropy.units.Quantity
+    value: 10
+    unit: !astropy.units.Unit {unit: km}
   names: ['sourcedist', 'srcdist']
 singleMirrorMode:
   len: 1

--- a/data/parameters/ray-tracing_parameters.yml
+++ b/data/parameters/ray-tracing_parameters.yml
@@ -6,8 +6,19 @@ zenithAngle:
 offAxisAngle: 
   len: null
   unit: !astropy.units.Unit {unit: deg}
+  default: 0
   names: ['offaxis', 'offset']
 sourceDistance:
   len: 1
-  unit': !astropy.units.Unit {unit: km}
+  unit: !astropy.units.Unit {unit: km}
   default: 10
+  names: ['sourcedist', 'srcdist']
+singleMirrorMode:
+  len: 1
+  default: False
+useRandomFocalLength:
+  len: 1
+  default: False
+mirrorNumbers:
+  len: 1
+  default: 'all'

--- a/data/parameters/ray-tracing_parameters.yml
+++ b/data/parameters/ray-tracing_parameters.yml
@@ -27,4 +27,4 @@ useRandomFocalLength:
   default: False
 mirrorNumbers:
   len: null
-  default: 'all'
+  default: null

--- a/data/parameters/ray-tracing_parameters.yml
+++ b/data/parameters/ray-tracing_parameters.yml
@@ -20,5 +20,5 @@ useRandomFocalLength:
   len: 1
   default: False
 mirrorNumbers:
-  len: 1
+  len: null
   default: 'all'

--- a/data/parameters/simtel-runner_parameters.yml
+++ b/data/parameters/simtel-runner_parameters.yml
@@ -22,6 +22,6 @@ sourceDistance:
 useRandomFocalLength:
   len: 1
   default: False
-mirrorNumbers:
+mirrorNumber:
   len: 1
   default: 1

--- a/data/parameters/simtel-runner_parameters.yml
+++ b/data/parameters/simtel-runner_parameters.yml
@@ -1,0 +1,27 @@
+zenithAngle: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  default: !astropy.units.Quantity
+    value: 20
+    unit: !astropy.units.Unit {unit: deg}
+  names: ['zenith', 'theta']
+offAxisAngle: 
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  default: !astropy.units.Quantity
+    value: 0
+    unit: !astropy.units.Unit {unit: deg}
+  names: ['offaxis', 'offset']
+sourceDistance:
+  len: 1
+  unit: !astropy.units.Unit {unit: km}
+  default: !astropy.units.Quantity
+    value: 10
+    unit: !astropy.units.Unit {unit: km}
+  names: ['sourcedist', 'srcdist']
+useRandomFocalLength:
+  len: 1
+  default: False
+mirrorNumbers:
+  len: 1
+  default: 1

--- a/data/parameters/telescope-data_parameters.yml
+++ b/data/parameters/telescope-data_parameters.yml
@@ -1,0 +1,41 @@
+posX: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['x']
+posY: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['x']
+posZ: 
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['x']
+longitude:
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['long']
+latitude:
+  len: 1
+  unit: !astropy.units.Unit {unit: deg}
+  names: ['lat']
+utmEast:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['east']
+utmNorth:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['north']
+altitude:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+  names: ['alt']
+corsikaObsLevel:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+corsikaSphereCenter:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}
+corsikaSphereRadius:
+  len: 1
+  unit: !astropy.units.Unit {unit: m}

--- a/data/parameters/telescope-data_parameters.yml
+++ b/data/parameters/telescope-data_parameters.yml
@@ -6,12 +6,12 @@ posX:
 posY: 
   len: 1
   unit: !astropy.units.Unit {unit: m}
-  names: ['x']
+  names: ['y']
   default: null
 posZ: 
   len: 1
   unit: !astropy.units.Unit {unit: m}
-  names: ['x']
+  names: ['z']
   default: null
 longitude:
   len: 1

--- a/data/parameters/telescope-data_parameters.yml
+++ b/data/parameters/telescope-data_parameters.yml
@@ -2,40 +2,51 @@ posX:
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['x']
+  default: null
 posY: 
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['x']
+  default: null
 posZ: 
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['x']
+  default: null
 longitude:
   len: 1
   unit: !astropy.units.Unit {unit: deg}
   names: ['long']
+  default: null
 latitude:
   len: 1
   unit: !astropy.units.Unit {unit: deg}
   names: ['lat']
+  default: null
 utmEast:
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['east']
+  default: null
 utmNorth:
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['north']
+  default: null
 altitude:
   len: 1
   unit: !astropy.units.Unit {unit: m}
   names: ['alt']
+  default: null
 corsikaObsLevel:
   len: 1
   unit: !astropy.units.Unit {unit: m}
+  default: null
 corsikaSphereCenter:
   len: 1
   unit: !astropy.units.Unit {unit: m}
+  default: null
 corsikaSphereRadius:
   len: 1
   unit: !astropy.units.Unit {unit: m}
+  default: null

--- a/data/test-data/test_parameters.yml
+++ b/data/test-data/test_parameters.yml
@@ -19,7 +19,9 @@
 #
 # A default value can be given by the key 'default'.
 # Parameters without default key will raise error when missing. 
-
+#
+# Dict can be given similarly to lists, with the proper len.
+#
 zenithAngle: 
   len: 1
   unit: !astropy.units.Unit {unit: deg}
@@ -41,3 +43,11 @@ validatedName:
   len: 1
   unit: null
   names: ['testname']
+dictPar:
+  len: 2
+  unit: [null, !astropy.units.Unit {unit: cm}]
+  default:
+    blah: 1
+    bleh: !astropy.units.Quantity
+      unit: !astropy.units.Unit {unit: cm}
+      value: 2

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -73,7 +73,7 @@ class CameraEfficiency:
             taken from the config.yml file.
         configData: dict.
             Dict containing the configurable parameters.
-        configFIle: str or Path
+        configFile: str or Path
             Path of the yaml file containing the configurable parameters.
         '''
         self._logger = logging.getLogger(__name__)

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -96,6 +96,28 @@ class CameraEfficiency:
         self._loadFiles()
     # END of init
 
+    @classmethod
+    def fromKwargs(cls, **kwargs):
+        '''
+        Builds a CameraEfficiency object from kwargs only.
+        The configurable parameters can be given as kwargs, instead of using the
+        configData or configFile arguments.
+
+        Parameters
+        ----------
+        kwargs
+            Containing the arguments and the configurable parameters.
+
+        Returns
+        -------
+        Instance of this class.
+        '''
+        args, configData = gen.separateArgsAndConfigData(
+            expectedArgs=['telescopeModel', 'label', 'simtelSourcePath', 'filesLocation'],
+            **kwargs
+        )
+        return cls(**args, configData=configData)
+
     def __repr__(self):
         return 'CameraEfficiency(label={})\n'.format(self.label)
 

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -12,9 +12,9 @@ from astropy.table import Table
 
 import simtools.config as cfg
 import simtools.io_handler as io
+import simtools.util.general as gen
 from simtools import visualize
 from simtools.util import names
-from simtools.util.general import collectArguments
 from simtools.util.model import getCameraName
 from simtools.model.telescope_model import TelescopeModel
 from simtools.model.model_parameters import CAMERA_RADIUS_CURV
@@ -42,7 +42,6 @@ class CameraEfficiency:
     plot(key, **kwargs)
         Plot key vs wavelength, where key may be cherenkov or nsb.
     '''
-    ALL_INPUTS = {'zenithAngle': {'default': 20, 'unit': u.deg}}
 
     def __init__(
         self,
@@ -50,7 +49,8 @@ class CameraEfficiency:
         label=None,
         simtelSourcePath=None,
         filesLocation=None,
-        **kwargs
+        configData=None,
+        configFile=None
     ):
         '''
         CameraEfficiency init.
@@ -82,7 +82,12 @@ class CameraEfficiency:
 
         self._hasResults = False
 
-        collectArguments(self, args=['zenithAngle'], allInputs=self.ALL_INPUTS, **kwargs)
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData, allowEmpty=True)
+        _parameterFile = io.getDataFile('parameters', 'camera-efficiency_parameters.yml')
+        _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
+        _configData = gen.validateConfigData(_configDataIn, _parameters)
+        for par, value in _configData.items():
+            self.__dict__['_' + par] = value
 
         self._loadFiles()
     # END of init

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -105,7 +105,7 @@ class LayoutArray:
 
         # Loading configData
         _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
-        _parameterFile = io.getDataFile('parameters', 'telescope-data_parameters.yml')
+        _parameterFile = io.getDataFile('parameters', 'layout-array_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self._configData = gen.validateConfigData(_configDataIn, _parameters)
 

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -6,8 +6,8 @@ from astropy.table import Table
 
 import simtools.config as cfg
 import simtools.io_handler as io
+import simtools.util.general as gen
 from simtools.util import names
-from simtools.util.general import collectArguments
 from simtools.layout.telescope_data import TelescopeData
 
 
@@ -69,7 +69,7 @@ class LayoutArray:
         'corsikaSphereRadius': {'default': None, 'isDict': True, 'unit': u.m}
     }
 
-    def __init__(self, label=None, name=None, filesLocation=None, **kwargs):
+    def __init__(self, label=None, name=None, filesLocation=None, configData=None, configFile=None):
         '''
         LayoutArray init.
 
@@ -103,13 +103,15 @@ class LayoutArray:
         self.name = name
         self._telescopeList = []
 
-        # Collecting arguments
-        collectArguments(
-            self,
-            args=[*self.ALL_INPUTS],
-            allInputs=self.ALL_INPUTS,
-            **kwargs
-        )
+        # Loading configData
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
+        _parameterFile = io.getDataFile('parameters', 'telescope-data_parameters.yml')
+        _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
+        self._configData = gen.validateConfigData(_configDataIn, _parameters)
+
+        # Making configData entries into attributes
+        for par, value in self._configData.items():
+            self.__dict__['_' + par] = value
 
         self._loadArrayCenter()
 

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -119,6 +119,10 @@ class LayoutArray:
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self.config = gen.validateConfigData(_configDataIn, _parameters)
 
+        # Making config entries into attributes
+        for par, value in zip(self.config._fields, self.config):
+            self.__dict__['_' + par] = value
+
         self._loadArrayCenter()
 
         # Output directory
@@ -147,13 +151,6 @@ class LayoutArray:
             **kwargs
         )
         return cls(**args, configData=configData)
-
-
-    def __len__(self):
-        return len(self._telescopeList)
-
-    def __getitem__(self, i):
-        return self._telescopeList[i]
 
     @classmethod
     def fromLayoutArrayName(
@@ -199,6 +196,12 @@ class LayoutArray:
         return layout
         # End of fromLayoutArrayName
 
+    def __len__(self):
+        return len(self._telescopeList)
+
+    def __getitem__(self, i):
+        return self._telescopeList[i]
+
     def _loadArrayCenter(self):
         ''' Load the array center and make convertions if needed. '''
 
@@ -206,18 +209,18 @@ class LayoutArray:
         self._arrayCenter.name = 'array_center'
 
         self._arrayCenter.setLocalCoordinates(0 * u.m, 0 * u.m, 0 * u.m)
-        if self.config.centerLatitude is not None and self.config.centerLongitude is not None:
+        if self._centerLatitude is not None and self._centerLongitude is not None:
             self._arrayCenter.setMercatorCoordinates(
-                self.config.centerLatitude * u.deg,
-                self.config.centerLongitude * u.deg
+                self._centerLatitude * u.deg,
+                self._centerLongitude * u.deg
             )
-        if self.config.centerEasting is not None and self.config.centerNorthing is not None:
+        if self._centerEasting is not None and self._centerNorthing is not None:
             self._arrayCenter.setUtmCoordinates(
-                self.config.centerEasting * u.m,
-                self.config.centerNorthing * u.m
+                self._centerEasting * u.m,
+                self._centerNorthing * u.m
             )
-        if self.config.centerAltitude is not None:
-            self._arrayCenter.setAltitude(self.config.centerAltitude * u.m)
+        if self._centerAltitude is not None:
+            self._arrayCenter.setAltitude(self._centerAltitude * u.m)
 
         # Converting
         wgs84 = self._getWgs84()
@@ -231,12 +234,12 @@ class LayoutArray:
 
         # Filling in center UTM coordinates if needed
         if (
-            (self.config.centerNorthing is None or self.config.centerEasting is None)
+            (self._centerNorthing is None or self._centerEasting is None)
             and self._arrayCenter.hasUtmCoordinates()
         ):
             centerNorthingWithUnit, centerEastingWithUnit = self._arrayCenter.getUtmCoordinates()
-            self.config.centerNorthing = centerNorthingWithUnit.to(u.m).value
-            self.config.centerEasting = centerEastingWithUnit.to(u.m).value
+            self._centerNorthing = centerNorthingWithUnit.to(u.m).value
+            self._centerEasting = centerEastingWithUnit.to(u.m).value
     # End of _loadArrayCenter
 
     def _appendTelescope(self, row, table, prodList):
@@ -303,27 +306,27 @@ class LayoutArray:
 
         # Reference coordinate system
         if 'EPSG' in table.meta:
-            self.config.epsg = table.meta['EPSG']
+            self._epsg = table.meta['EPSG']
         if 'center_northing' in table.meta and 'center_easting' in table.meta:
-            self.config.centerNorthing = u.Quantity(table.meta['center_northing']).to(u.m).value
-            self.config.centerEasting = u.Quantity(table.meta['center_easting']).to(u.m).value
+            self._centerNorthing = u.Quantity(table.meta['center_northing']).to(u.m).value
+            self._centerEasting = u.Quantity(table.meta['center_easting']).to(u.m).value
         if 'center_lon' in table.meta and 'center_lat' in table.meta:
-            self.config.centerLongitude = u.Quantity(table.meta['center_lon']).to(u.deg).value
-            self.config.centerLatitude = u.Quantity(table.meta['center_lat']).to(u.deg).value
+            self._centerLongitude = u.Quantity(table.meta['center_lon']).to(u.deg).value
+            self._centerLatitude = u.Quantity(table.meta['center_lat']).to(u.deg).value
         if 'center_alt' in table.meta:
-            self.config.centerAltitude = u.Quantity(table.meta['center_alt']).to(u.m).value
+            self._centerAltitude = u.Quantity(table.meta['center_alt']).to(u.m).value
 
         # CORSIKA parameters
         if 'corsika_obs_level' in table.meta:
-            self.config.corsikaObsLevel = u.Quantity(table.meta['corsika_obs_level']).value
+            self._corsikaObsLevel = u.Quantity(table.meta['corsika_obs_level']).value
         if 'corsika_sphere_center' in table.meta:
-            self.config.corsikaSphereCenter = dict()
+            self._corsikaSphereCenter = dict()
             for key, value in table.meta['corsika_sphere_center'].items():
-                self.config.corsikaSphereCenter[key] = u.Quantity(value).to(u.m).value
+                self._corsikaSphereCenter[key] = u.Quantity(value).to(u.m).value
         if 'corsika_sphere_radius' in table.meta:
-            self.config.corsikaSphereRadius = dict()
+            self._corsikaSphereRadius = dict()
             for key, value in table.meta['corsika_sphere_radius'].items():
-                self.config.corsikaSphereRadius[key] = u.Quantity(value).to(u.m).value
+                self._corsikaSphereRadius[key] = u.Quantity(value).to(u.m).value
 
         # Initialise telescope lists from productions
         # (require column names include 'prod' string)
@@ -407,19 +410,19 @@ class LayoutArray:
         )
 
         metaData = {
-            'center_lon': self.config.centerLongitude * u.deg,
-            'center_lat': self.config.centerLatitude * u.deg,
-            'center_alt': self.config.centerAltitude * u.m,
-            'center_northing': self.config.centerNorthing * u.m,
-            'center_easting': self.config.centerEasting * u.m,
-            'corsika_obs_level': self.config.corsikaObsLevel * u.m,
+            'center_lon': self._centerLongitude * u.deg,
+            'center_lat': self._centerLatitude * u.deg,
+            'center_alt': self._centerAltitude * u.m,
+            'center_northing': self._centerNorthing * u.m,
+            'center_easting': self._centerEasting * u.m,
+            'corsika_obs_level': self._corsikaObsLevel * u.m,
             'corsika_sphere_center': {
-                key: value * u.m for (key, value) in self.config.corsikaSphereCenter.items()
+                key: value * u.m for (key, value) in self._corsikaSphereCenter.items()
             },
             'corsika_sphere_radius': {
-                key: value * u.m for (key, value) in self.config.corsikaSphereRadius.items()
+                key: value * u.m for (key, value) in self._corsikaSphereRadius.items()
             },
-            'EPSG': self.config.epsg
+            'EPSG': self._epsg
         }
 
         table = Table(meta=metaData)
@@ -497,7 +500,7 @@ class LayoutArray:
         corsikaList = ''
         for tel in self._telescopeList:
             posX, posY, posZ = tel.getLocalCoordinates()
-            sphereRadius = self.config.corsikaSphereRadius[tel.getTelescopeSize()]
+            sphereRadius = self._corsikaSphereRadius[tel.getTelescopeSize()]
 
             corsikaList += 'TELESCOPE'
             corsikaList += '\t {:.3f}E2'.format(posX.value)
@@ -536,13 +539,13 @@ class LayoutArray:
         # 2. convert coordinates
         for tel in self._telescopeList:
 
-            if self.config.corsikaObsLevel is not None:
-                corsikaObsLevel = self.config.corsikaObsLevel * u.m
+            if self._corsikaObsLevel is not None:
+                corsikaObsLevel = self._corsikaObsLevel * u.m
             else:
                 corsikaObsLevel = None
 
-            if self.config.corsikaSphereCenter is not None:
-                corsikaSphereCenter = self.config.corsikaSphereCenter[tel.getTelescopeSize()] * u.m
+            if self._corsikaSphereCenter is not None:
+                corsikaSphereCenter = self._corsikaSphereCenter[tel.getTelescopeSize()] * u.m
             else:
                 corsikaSphereCenter = None
 
@@ -557,10 +560,10 @@ class LayoutArray:
 
     def _getCrsLocal(self):
         ''' Get the crs_local '''
-        if self.config.centerLongitude is not None and self.config.centerLatitude is not None:
+        if self._centerLongitude is not None and self._centerLatitude is not None:
             proj4_string = (
                 '+proj=tmerc +ellps=WGS84 +datum=WGS84'
-                + ' +lon_0={} +lat_0={}'.format(self.config.centerLongitude, self.config.centerLatitude)
+                + ' +lon_0={} +lat_0={}'.format(self._centerLongitude, self._centerLatitude)
                 + ' +axis=nwu +units=m +k_0=1.0'
             )
             crs_local = pyproj.CRS.from_proj4(proj4_string)
@@ -572,8 +575,8 @@ class LayoutArray:
 
     def _getCrsUtm(self):
         ''' Get crs_utm '''
-        if self.config.epsg is not None:
-            crs_utm = pyproj.CRS.from_user_input(self.config.epsg)
+        if self._epsg is not None:
+            crs_utm = pyproj.CRS.from_user_input(self._epsg)
             self._logger.info('UTM system: {}'.format(crs_utm))
             return crs_utm
         else:

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -101,6 +101,23 @@ class LayoutArray:
         for par, value in self._configData.items():
             self.__dict__['_' + par] = value
 
+        print('Center')
+        print(self._corsikaSphereCenter)
+        print('Radius')
+        print(self._corsikaSphereRadius)
+
+        # Making corsikaSphere parameters into dict
+        # self._corsikaSphereCenter = {
+        #     'LST': self._corsikaSphereCenter[0],
+        #     'MST': self._corsikaSphereCenter[1],
+        #     'SST': self._corsikaSphereCenter[2],
+        # }
+        # self._corsikaSphereRadius = {
+        #     'LST': self._corsikaSphereRadius[0],
+        #     'MST': self._corsikaSphereRadius[1],
+        #     'SST': self._corsikaSphereRadius[2],
+        # }
+
         self._loadArrayCenter()
 
         # Output directory

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -126,6 +126,29 @@ class LayoutArray:
         self._outputDirectory = io.getLayoutOutputDirectory(self._filesLocation, self.label)
         self._outputDirectory.mkdir(parents=True, exist_ok=True)
 
+    @classmethod
+    def fromKwargs(cls, **kwargs):
+        '''
+        Builds a LayoutArray object from kwargs only.
+        The configurable parameters can be given as kwargs, instead of using the
+        configData or configFile arguments.
+
+        Parameters
+        ----------
+        kwargs
+            Containing the arguments and the configurable parameters.
+
+        Returns
+        -------
+        Instance of this class.
+        '''
+        args, configData = gen.separateArgsAndConfigData(
+            expectedArgs=['name', 'label', 'filesLocation'],
+            **kwargs
+        )
+        return cls(**args, configData=configData)
+
+
     def __len__(self):
         return len(self._telescopeList)
 

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -92,7 +92,7 @@ class LayoutArray:
         self._telescopeList = []
 
         # Loading configData
-        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData, allowEmpty=True)
         _parameterFile = io.getDataFile('parameters', 'layout-array_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self._configData = gen.validateConfigData(_configDataIn, _parameters)
@@ -100,23 +100,6 @@ class LayoutArray:
         # Making configData entries into attributes
         for par, value in self._configData.items():
             self.__dict__['_' + par] = value
-
-        print('Center')
-        print(self._corsikaSphereCenter)
-        print('Radius')
-        print(self._corsikaSphereRadius)
-
-        # Making corsikaSphere parameters into dict
-        # self._corsikaSphereCenter = {
-        #     'LST': self._corsikaSphereCenter[0],
-        #     'MST': self._corsikaSphereCenter[1],
-        #     'SST': self._corsikaSphereCenter[2],
-        # }
-        # self._corsikaSphereRadius = {
-        #     'LST': self._corsikaSphereRadius[0],
-        #     'MST': self._corsikaSphereRadius[1],
-        #     'SST': self._corsikaSphereRadius[2],
-        # }
 
         self._loadArrayCenter()
 
@@ -355,16 +338,20 @@ class LayoutArray:
             Altitude coordinate in equivalent units of u.m.
         '''
 
+        configData = {
+            'posX': posX,
+            'posY': posY,
+            'posZ': posZ,
+            'longitude': longitude,
+            'latitude': latitude,
+            'utmEast': utmEast,
+            'utmNorth': utmNorth,
+            'altitude': altitude
+        }
+
         tel = TelescopeData(
             name=telescopeName,
-            posX=posX,
-            posY=posY,
-            posZ=posZ,
-            longitude=longitude,
-            latitude=latitude,
-            utmEast=utmEast,
-            utmNorth=utmNorth,
-            altitude=altitude
+            configData=configData
         )
         self._telescopeList.append(tel)
 

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -57,18 +57,6 @@ class LayoutArray:
         Perform all the possible conversions the coordinates of the tel positions.
     '''
 
-    ALL_INPUTS = {
-        'epsg': {'default': None, 'unit': None},
-        'centerLongitude': {'default': None, 'unit': u.deg},
-        'centerLatitude': {'default': None, 'unit': u.deg},
-        'centerNorthing': {'default': None, 'unit': u.m},
-        'centerEasting': {'default': None, 'unit': u.m},
-        'centerAltitude': {'default': None, 'unit': u.m},
-        'corsikaObsLevel': {'default': None, 'unit': u.m},
-        'corsikaSphereCenter': {'default': None, 'isDict': True, 'unit': u.m},
-        'corsikaSphereRadius': {'default': None, 'isDict': True, 'unit': u.m}
-    }
-
     def __init__(self, label=None, name=None, filesLocation=None, configData=None, configFile=None):
         '''
         LayoutArray init.

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -135,10 +135,10 @@ class TelescopeData:
         _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData, allowEmpty=True)
         _parameterFile = io.getDataFile('parameters', 'telescope-data_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
-        self._configData = gen.validateConfigData(_configDataIn, _parameters)
+        self.config = gen.validateConfigData(_configDataIn, _parameters)
 
         # Making config entries into attributes
-        for par, value in self._configData.items():
+        for par, value in zip(self.config._fields, self.config):
             self.__dict__['_' + par] = value
 
     def __repr__(self):

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -66,20 +66,6 @@ class TelescopeData:
         Perform all the necessary convertions in order to fill all the coordinate variables.
     '''
 
-    ALL_INPUTS = {
-        'posX': {'default': None, 'unit': u.m},
-        'posY': {'default': None, 'unit': u.m},
-        'posZ': {'default': None, 'unit': u.m},
-        'longitude': {'default': None, 'unit': u.deg},
-        'latitude': {'default': None, 'unit': u.deg},
-        'utmEast': {'default': None, 'unit': u.m},
-        'utmNorth': {'default': None, 'unit': u.m},
-        'altitude': {'default': None, 'unit': u.m},
-        'corsikaObsLevel': {'default': None, 'unit': u.m},
-        'corsikaSphereCenter': {'default': None, 'unit': u.m},
-        'corsikaSphereRadius': {'default': None, 'unit': u.m}
-    }
-
     def __init__(
         self,
         name=None,
@@ -109,7 +95,7 @@ class TelescopeData:
         self._prodId = prodId
 
         # Loading configData
-        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData, allowEmpty=True)
         _parameterFile = io.getDataFile('parameters', 'telescope-data_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self._configData = gen.validateConfigData(_configDataIn, _parameters)

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -20,13 +20,13 @@ class TelescopeData:
     Store and perform coordinate transformations with single telescope positions.
 
     Configurable parameters:
-        posX: 
+        posX:
             len: 1
             unit: m
-        posY: 
+        posY:
             len: 1
             unit: m
-        posZ: 
+        posZ:
             len: 1
             unit: m
         longitude:
@@ -137,7 +137,7 @@ class TelescopeData:
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self._configData = gen.validateConfigData(_configDataIn, _parameters)
 
-        # Making configData entries into attributes
+        # Making config entries into attributes
         for par, value in self._configData.items():
             self.__dict__['_' + par] = value
 

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -3,7 +3,8 @@ import astropy.units as u
 
 import pyproj
 
-from simtools.util.general import collectArguments
+import simtools.util.general as gen
+import simtools.io_handler as io
 
 
 class InvalidCoordSystem(Exception):
@@ -83,7 +84,8 @@ class TelescopeData:
         self,
         name=None,
         prodId=dict(),
-        **kwargs
+        configData=None,
+        configFile=None
     ):
         '''
         TelescopeData init.
@@ -106,14 +108,15 @@ class TelescopeData:
         self.name = name
         self._prodId = prodId
 
-        # Collecting arguments
-        collectArguments(
-            self,
-            args=[*self.ALL_INPUTS],
-            allInputs=self.ALL_INPUTS,
-            **kwargs
-        )
-        # End of __init__
+        # Loading configData
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
+        _parameterFile = io.getDataFile('parameters', 'telescope-data_parameters.yml')
+        _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
+        self._configData = gen.validateConfigData(_configDataIn, _parameters)
+
+        # Making configData entries into attributes
+        for par, value in self._configData.items():
+            self.__dict__['_' + par] = value
 
     def __repr__(self):
         telstr = self.name

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -141,6 +141,28 @@ class TelescopeData:
         for par, value in zip(self.config._fields, self.config):
             self.__dict__['_' + par] = value
 
+    @classmethod
+    def fromKwargs(cls, **kwargs):
+        '''
+        Builds a TelescopeData object from kwargs only.
+        The configurable parameters can be given as kwargs, instead of using the
+        configData or configFile arguments.
+
+        Parameters
+        ----------
+        kwargs
+            Containing the arguments and the configurable parameters.
+
+        Returns
+        -------
+        Instance of this class.
+        '''
+        args, configData = gen.separateArgsAndConfigData(
+            expectedArgs=['name', 'prodId'],
+            **kwargs
+        )
+        return cls(**args, configData=configData)
+
     def __repr__(self):
         telstr = self.name
         if self.hasLocalCoordinates():

--- a/simtools/layout/telescope_data.py
+++ b/simtools/layout/telescope_data.py
@@ -17,12 +17,49 @@ class MissingInputForConvertion(Exception):
 
 class TelescopeData:
     '''
-    Store and do coordinate transformations with single telescope positions
+    Store and perform coordinate transformations with single telescope positions.
+
+    Configurable parameters:
+        posX: 
+            len: 1
+            unit: m
+        posY: 
+            len: 1
+            unit: m
+        posZ: 
+            len: 1
+            unit: m
+        longitude:
+            len: 1
+            unit: m
+        latitude:
+            len: 1
+            unit: m
+        utmEast:
+            len: 1
+            unit: m
+        utmNorth:
+            len: 1
+            unit: m
+        altitude:
+            len: 1
+            unit: m
+        corsikaObsLevel:
+            len: 1
+            unit: m
+        corsikaSphereCenter:
+            len: 1
+            unit: m
+        corsikaSphereRadius:
+            len: 1
+            unit: m
 
     Attributes
     ----------
     name: str
         Name of the telescope (e.g L-01, S-05, ...).
+    config: namedtuple
+        Contains the configurable parameters (zenithAngle).
 
     Methods
     -------
@@ -82,10 +119,10 @@ class TelescopeData:
             Name of the telescope (e.g L-01, S-05, ...)
         prodId: dict
             ...
-        **kwargs:
-            Physical parameters with units (if applicable). Options: posX, posY, posZ,
-            longitude, latitude, utmsEast, utmNorth, altitude, corsikaSphereRadius,
-            corsikaSphereCenter
+        configData: dict.
+            Dict containing the configurable parameters.
+        configFile: str or Path
+            Path of the yaml file containing the configurable parameters.
         '''
 
         self._logger = logging.getLogger(__name__)

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -165,6 +165,20 @@ class RayTracing:
 
     @classmethod
     def fromKwargs(cls, **kwargs):
+        '''
+        Builds a RayTracing object from kwargs only.
+        The configurable parameters can be given as kwargs, instead of using the
+        configData or configFile arguments.
+
+        Parameters
+        ----------
+        kwargs
+            Containing the arguments and the configurable parameters.
+
+        Returns
+        -------
+        Instance of this class.
+        '''
         args, configData = gen.separateArgsAndConfigData(
             expectedArgs=['telescopeModel', 'label', 'simtelSourcePath', 'filesLocation'],
             **kwargs

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -176,7 +176,7 @@ class RayTracing:
                     mode='ray-tracing' if not self._singleMirrorMode else 'raytracing-singlemirror',
                     telescopeModel=self._telescopeModel,
                     zenithAngle=self._configData['zenithAngle'] * u.deg,
-                    sourceDistance=self._config['sourceDistance'] * u.km,
+                    sourceDistance=self._configData['sourceDistance'] * u.km,
                     offAxisAngle=thisOffAxis * u.deg,
                     mirrorNumber=thisMirror,
                     useRandomFocalLength=self._configData['useRandomFocalLength']

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -28,11 +28,11 @@ class RayTracing:
     Class for handling ray tracing simulations and analysis.
 
     Configurable parameters:
-        zenithAngle: 
+        zenithAngle:
             len: 1
             unit: deg
             default: 20 deg
-        offAxisAngle: 
+        offAxisAngle:
             len: null
             unit: deg
             default: [0 deg]

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -220,7 +220,7 @@ class RayTracing:
             self._readResults()
 
         allMirrors = self._mirrorNumbers if self._singleMirrorMode else [0]
-        for thisOffAxis in self._offAxisAngle:
+        for thisOffAxis in self._configData['offAxisAngle']:
             for thisMirror in allMirrors:
                 self._logger.debug('Analyzing RayTracing for offAxis={}'.format(thisOffAxis))
                 if self._singleMirrorMode:

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -101,7 +101,6 @@ class RayTracing:
         _parameterFile = io.getDataFile('parameters', 'ray-tracing_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
         self._configData = gen.validateConfigData(_configDataIn, _parameters)
-        self._logger.debug(self._configData)
 
         self.label = label if label is not None else self._telescopeModel.label
 

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -163,6 +163,14 @@ class RayTracing:
 
     # END of init
 
+    @classmethod
+    def fromKwargs(cls, **kwargs):
+        args, configData = gen.separateArgsAndConfigData(
+            expectedArgs=['telescopeModel', 'label', 'simtelSourcePath', 'filesLocation'],
+            **kwargs
+        )
+        return cls(**args, configData=configData)
+
     def __repr__(self):
         return 'RayTracing(label={})\n'.format(self.label)
 

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -131,19 +131,6 @@ class RayTracing:
         self._outputDirectory = io.getRayTracingOutputDirectory(self._filesLocation, self.label)
         self._outputDirectory.mkdir(parents=True, exist_ok=True)
 
-        self._hasResults = False
-
-        # Results file
-        fileNameResults = names.rayTracingResultsFileName(
-            self._telescopeModel.site,
-            self._telescopeModel.name,
-            self.config.sourceDistance,
-            self.config.zenithAngle,
-            self.label
-        )
-        self._outputDirectory.joinpath('results').mkdir(parents=True, exist_ok=True)
-        self._fileResults = self._outputDirectory.joinpath('results').joinpath(fileNameResults)
-
         # Loading relevant attributes in case of single mirror mode.
         if self.config.singleMirrorMode:
             # Recalculating source distance.
@@ -161,6 +148,18 @@ class RayTracing:
         else:
             self._sourceDistance = self.config.sourceDistance
 
+        self._hasResults = False
+
+        # Results file
+        fileNameResults = names.rayTracingResultsFileName(
+            self._telescopeModel.site,
+            self._telescopeModel.name,
+            self._sourceDistance,
+            self.config.zenithAngle,
+            self.label
+        )
+        self._outputDirectory.joinpath('results').mkdir(parents=True, exist_ok=True)
+        self._fileResults = self._outputDirectory.joinpath('results').joinpath(fileNameResults)
     # END of init
 
     @classmethod
@@ -226,9 +225,9 @@ class RayTracing:
                     telescopeModel=self._telescopeModel,
                     configData={
                         'zenithAngle': self.config.zenithAngle * u.deg,
-                        'sourceDistance': self.config.sourceDistance * u.km,
+                        'sourceDistance': self._sourceDistance * u.km,
                         'offAxisAngle': thisOffAxis * u.deg,
-                        'mirrorNumbers': thisMirror,
+                        'mirrorNumber': thisMirror,
                         'useRandomFocalLength': self.config.useRandomFocalLength
                     }
                 )

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -36,13 +36,6 @@ class SimtelRunner:
         Run sim_telarray. test=True will make it faster and force=True will remove existing files
         and run again.
     '''
-    ALL_INPUTS = {
-        'zenithAngle': {'default': 20, 'unit': u.deg},
-        'sourceDistance': {'default': 10, 'unit': u.km},
-        'offAxisAngle': {'default': 0, 'unit': u.deg},
-        'mirrorNumber': {'default': 1, 'unit': None},
-        'useRandomFocalLength': {'default': False, 'unit': None}
-    }
 
     def __init__(
         self,
@@ -51,7 +44,8 @@ class SimtelRunner:
         label=None,
         simtelSourcePath=None,
         filesLocation=None,
-        **kwargs
+        configData=None,
+        configFile=None
     ):
         '''
         SimtelRunner.
@@ -96,19 +90,16 @@ class SimtelRunner:
         self.RUNS_PER_SET = 1 if self._isSingleMirrorMode() else 20  # const
         self.PHOTONS_PER_RUN = 10000  # const
 
+        # Loading configData
+        _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
+        _parameterFile = io.getDataFile('parameters', 'simtel-runner_parameters.yml')
+        _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
+
         if self._isRayTracingMode():
-            gen.collectArguments(
-                self,
-                args=[
-                    'zenithAngle',
-                    'offAxisAngle',
-                    'sourceDistance',
-                    'mirrorNumber',
-                    'useRandomFocalLength'
-                ],
-                allInputs=self.ALL_INPUTS,
-                **kwargs
-            )
+            self._configData = gen.validateConfigData(_configDataIn, _parameters)
+            for par, value in self._configData.items():
+                self.__dict__['_' + par] = value
+
     # END of _init_
 
     def __repr__(self):

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -21,6 +21,26 @@ class SimtelRunner:
     '''
     SimtelRunner is the interface with sim_telarray.
 
+    Configurable parameters:
+        zenithAngle:
+            len: 1
+            unit: deg
+            default: 20 deg
+        offAxisAngle:
+            len: 1
+            unit: deg
+            default: 0 deg
+        sourceDistance:
+            len: 1
+            unit: km
+            default: 10 km
+        useRandomFocalLength:
+            len: 1
+            default: False
+        mirrorNumbers:
+            len: 1
+            default: 1
+
     Attributes
     ----------
     mode: str
@@ -29,6 +49,8 @@ class SimtelRunner:
         Instance of the TelescopeModel class.
     label: str, optional
         Instance label.
+    config: namedtuple
+        Contains the configurable parameters (zenithAngle).
 
     Methods
     -------
@@ -64,9 +86,10 @@ class SimtelRunner:
         filesLocation: str (or Path), optional
             Parent location of the output files created by this class. If not given, it will be
             taken from the config.yml file.
-        **kwargs:
-            Input parameters listed in ALL_INPUTS (zenithAngle, sourceDistance, offAxisAngle,
-            mirrorNumber, useRandomFocalLength)
+        configData: dict.
+            Dict containing the configurable parameters.
+        configFile: str or Path
+            Path of the yaml file containing the configurable parameters.
         '''
         self._logger = logging.getLogger(__name__)
         self._logger.debug('Init SimtelRunner')
@@ -94,11 +117,7 @@ class SimtelRunner:
         _configDataIn = gen.collectDataFromYamlOrDict(configFile, configData)
         _parameterFile = io.getDataFile('parameters', 'simtel-runner_parameters.yml')
         _parameters = gen.collectDataFromYamlOrDict(_parameterFile, None)
-
-        if self._isRayTracingMode():
-            self._configData = gen.validateConfigData(_configDataIn, _parameters)
-            for par, value in self._configData.items():
-                self.__dict__['_' + par] = value
+        self.config = gen.validateConfigData(_configDataIn, _parameters)
 
     # END of _init_
 
@@ -207,10 +226,10 @@ class SimtelRunner:
             photonsFileName = names.rayTracingFileName(
                 self.telescopeModel.site,
                 self.telescopeModel.name,
-                self._sourceDistance,
-                self._zenithAngle,
-                self._offAxisAngle,
-                self._mirrorNumber if self._isSingleMirrorMode() else None,
+                self.config.sourceDistance,
+                self.config.zenithAngle,
+                self.config.offAxisAngle,
+                self.config.mirrorNumber if self._isSingleMirrorMode() else None,
                 self.label,
                 'photons'
             )
@@ -235,10 +254,10 @@ class SimtelRunner:
                 fileName = names.rayTracingFileName(
                     self.telescopeModel.site,
                     self.telescopeModel.name,
-                    self._sourceDistance,
-                    self._zenithAngle,
-                    self._offAxisAngle,
-                    self._mirrorNumber if self._isSingleMirrorMode() else None,
+                    self.config.sourceDistance,
+                    self.config.zenithAngle,
+                    self.config.offAxisAngle,
+                    self.config.mirrorNumber if self._isSingleMirrorMode() else None,
                     self.label,
                     baseName
                 )
@@ -254,15 +273,18 @@ class SimtelRunner:
                 file.write('# List of photons for RayTracing simulations\n')
                 file.write('#{}\n'.format(50 * '='))
                 file.write('# configFile = {}\n'.format(self.telescopeModel.getConfigFile()))
-                file.write('# zenithAngle [deg] = {}\n'.format(self._zenithAngle))
-                file.write('# offAxisAngle [deg] = {}\n'.format(self._offAxisAngle))
-                file.write('# sourceDistance [km] = {}\n'.format(self._sourceDistance))
+                file.write('# zenithAngle [deg] = {}\n'.format(self.config.zenithAngle))
+                file.write('# offAxisAngle [deg] = {}\n'.format(self.config.offAxisAngle))
+                file.write('# sourceDistance [km] = {}\n'.format(self.config.sourceDistance))
                 if self._isSingleMirrorMode():
-                    file.write('# mirrorNumber = {}\n\n'.format(self._mirrorNumber))
+                    file.write('# mirrorNumber = {}\n\n'.format(self.config.mirrorNumber))
 
             # Filling in star file with a single star.
             with self._starsFileName.open('w') as file:
-                file.write('0. {} 1.0 {}'.format(90. - self._zenithAngle, self._sourceDistance))
+                file.write('0. {} 1.0 {}'.format(
+                    90. - self.config.zenithAngle,
+                    self.config.sourceDistance)
+                )
 
         # Trigger
         # elif self._isTriggerMode()
@@ -287,7 +309,10 @@ class SimtelRunner:
         command += _configOption('IMAGING_LIST', str(self._photonsFileName))
         command += _configOption('stars', str(self._starsFileName))
         command += _configOption('altitude', self.telescopeModel.getParameterValue('altitude'))
-        command += _configOption('telescope_theta', self._zenithAngle + self._offAxisAngle)
+        command += _configOption(
+            'telescope_theta',
+            self.config.zenithAngle + self.config.offAxisAngle
+        )
         command += _configOption('star_photons', str(self.PHOTONS_PER_RUN))
         command += _configOption('telescope_phi', '0')
         command += _configOption('camera_transmission', '1.0')
@@ -308,11 +333,11 @@ class SimtelRunner:
             command += _configOption(
                 'mirror_list',
                 self.telescopeModel.getSingleMirrorListFile(
-                    self._mirrorNumber,
-                    self._useRandomFocalLength
+                    self.config.mirrorNumber,
+                    self.config.useRandomFocalLength
                 )
             )
-            command += _configOption('focal_length', self._sourceDistance * u.km.to(u.cm))
+            command += _configOption('focal_length', self.config.sourceDistance * u.km.to(u.cm))
             command += _configOption('dish_shape_length', _mirrorFocalLength)
             command += _configOption('mirror_focal_length', _mirrorFocalLength)
             command += _configOption('parabolic_dish', '0')

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -37,7 +37,7 @@ class SimtelRunner:
         useRandomFocalLength:
             len: 1
             default: False
-        mirrorNumbers:
+        mirrorNumber:
             len: 1
             default: 1
 

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -45,16 +45,16 @@ def test_validate_config_data():
     validatedData = gen.validateConfigData(configData=configData, parameters=parameters)
 
     # Testing undefined len
-    assert len(validatedData['offAxisAngle']) == 3
+    assert len(validatedData.offAxisAngle) == 3
 
     # Testing name validation
-    assert 'validatedName' in validatedData.keys()
+    assert validatedData.validatedName == 10
 
     # Testing unit convertion
-    assert validatedData['sourceDistance'] == 20
+    assert validatedData.sourceDistance == 20
 
     # Testing dict par
-    assert validatedData['dictPar']['bleh'] == 500
+    assert validatedData.dictPar['bleh'] == 500
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -10,30 +10,6 @@ import simtools.util.general as gen
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-def test_collect_args():
-    ''' Test collectArguments function from util.general '''
-
-    class Dummy():
-        ALL_INPUTS = {
-            'zenithAngle': {'default': 20, 'unit': u.deg},
-            'offAxisAngle': {'default': 0, 'unit': u.deg, 'isList': True},
-            'testDict': {'default': None, 'unit': u.deg, 'isDict': True}
-        }
-
-        def __init__(self, **kwargs):
-            gen.collectArguments(
-                self,
-                args=['zenithAngle', 'offAxisAngle', 'testDict'],
-                allInputs=self.ALL_INPUTS,
-                **kwargs
-            )
-            print(self.__dict__)
-
-    d = Dummy(zenithAngle=20 * u.deg, offAxisAngle=[0 * u.deg, 10 * u.deg])
-    d = Dummy(zenithAngle=20 * u.deg, testDict={'test1': 2 * u.deg, 'test2': 3 * u.deg})
-    print(d)
-
-
 def test_collect_dict_data():
     inDict = {
         'k1': 2,
@@ -83,6 +59,5 @@ def test_validate_config_data():
 
 if __name__ == '__main__':
 
-    # test_collect_dict_data()
     # test_collect_args()
     test_validate_config_data()

--- a/simtools/tests/test_general.py
+++ b/simtools/tests/test_general.py
@@ -62,7 +62,8 @@ def test_validate_config_data():
         'offaxis': [0 * u.deg, 0.2 * u.rad, 3 * u.deg],
         'cscat': [0, 10 * u.m, 3 * u.km],
         'sourceDistance': 20000 * u.m,
-        'testName': 10
+        'testName': 10,
+        'dictPar': {'blah': 10, 'bleh': 5 * u.m}
     }
 
     validatedData = gen.validateConfigData(configData=configData, parameters=parameters)
@@ -74,7 +75,10 @@ def test_validate_config_data():
     assert 'validatedName' in validatedData.keys()
 
     # Testing unit convertion
-    assert validatedData['sourceDistance'][0] == 20
+    assert validatedData['sourceDistance'] == 20
+
+    # Testing dict par
+    assert validatedData['dictPar']['bleh'] == 500
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_layout_array.py
+++ b/simtools/tests/test_layout_array.py
@@ -19,10 +19,10 @@ def test_read_tel_list():
 
 
 def test_dict_input():
-    layout = LayoutArray(
-        name='testLayout',
-        corsikaSphereRadius={'LST': 1 * u.m, 'MST': 1 * u.m, 'SST': 1 * u.m}
-    )
+    configData = {
+        'corsikaSphereRadius': {'LST': 1 * u.m, 'MST': 1 * u.m, 'SST': 1 * u.m}
+    }
+    layout = LayoutArray(name='testLayout', configData=configData)
     layout.printTelescopeList()
 
 
@@ -105,8 +105,8 @@ if __name__ == '__main__':
 
     # test_read_tel_list()
     # test_add_tel()
-    # test_dict_input()
-    test_build_layout()
+    test_dict_input()
+    # test_build_layout()
     # test_corsika_input()
     # test_classmethod()
     # test_converting_center_coordinates()

--- a/simtools/tests/test_layout_array.py
+++ b/simtools/tests/test_layout_array.py
@@ -20,7 +20,7 @@ def test_read_tel_list():
 
 def test_dict_input():
     configData = {
-        'corsikaSphereRadius': [1 * u.m, 1 * u.m, 1 * u.m]
+        'corsikaSphereRadius': {'LST': 1 * u.m, 'MST': 1 * u.m, 'SST': 1 * u.m}
     }
     layout = LayoutArray(name='testLayout', configData=configData)
     layout.printTelescopeList()

--- a/simtools/tests/test_layout_array.py
+++ b/simtools/tests/test_layout_array.py
@@ -20,7 +20,7 @@ def test_read_tel_list():
 
 def test_dict_input():
     configData = {
-        'corsikaSphereRadius': {'LST': 1 * u.m, 'MST': 1 * u.m, 'SST': 1 * u.m}
+        'corsikaSphereRadius': [1 * u.m, 1 * u.m, 1 * u.m]
     }
     layout = LayoutArray(name='testLayout', configData=configData)
     layout.printTelescopeList()

--- a/simtools/tests/test_layout_array.py
+++ b/simtools/tests/test_layout_array.py
@@ -30,13 +30,18 @@ def test_add_tel():
     layout = LayoutArray(name='testLayout')
     telFile = io.getTestDataFile('telescope_positions_prod5_north.ecsv')
     layout.readTelescopeListFile(telFile)
-    layout.addTelescope(telescopeName='L-05', posX=100 * u.m, posY=100 * u.m, posZ=100 * u.m)
+    layout.addTelescope(
+        telescopeName='L-05',
+        posX=100 * u.m,
+        posY=100 * u.m,
+        posZ=100 * u.m
+    )
 
     layout.printTelescopeList()
 
 
 def test_build_layout():
-    parameters = {
+    configData = {
         'centerLongitude': -17.8920302 * u.deg,
         'centerLatitude': 28.7621661 * u.deg,
         'epsg': 32628,
@@ -48,7 +53,7 @@ def test_build_layout():
         'corsikaObsLevel': 2158 * u.m
     }
 
-    layout = LayoutArray(label='test_layout', name='LST4', **parameters)
+    layout = LayoutArray(label='test_layout', name='LST4', configData=configData)
 
     # Adding 4 LST on a regular grid
     layout.addTelescope(telescopeName='L-01', posX=57.5 * u.m, posY=57.5 * u.m, posZ=0 * u.m)
@@ -87,7 +92,7 @@ def test_classmethod():
 
 
 def test_converting_center_coordinates():
-    parameters = {
+    configData = {
         'centerLongitude': -17.8920302 * u.deg,
         'centerLatitude': 28.7621661 * u.deg,
         'epsg': 32628,
@@ -97,15 +102,15 @@ def test_converting_center_coordinates():
         'corsikaObsLevel': 2158 * u.m
     }
 
-    layout = LayoutArray(label='test_layout', name='LST4', **parameters)
+    layout = LayoutArray(label='test_layout', name='LST4', configData=configData)
     layout.printTelescopeList()
 
 
 if __name__ == '__main__':
 
     # test_read_tel_list()
-    # test_add_tel()
-    test_dict_input()
+    test_add_tel()
+    # test_dict_input()
     # test_build_layout()
     # test_corsika_input()
     # test_classmethod()

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -223,6 +223,33 @@ def test_config_data():
     assert len(ray.config.offAxisAngle) == 2
 
 
+def test_from_kwargs():
+
+    label = 'test-from-kwargs'
+    version = 'prod4'
+
+    sourceDistance = 10 * u.km
+    zenithAngle = 30 * u.deg
+    offAxisAngle = [0, 2] * u.deg
+
+    tel = TelescopeModel(
+        site='north',
+        telescopeModelName='mst-FlashCam-D',
+        modelVersion=version,
+        label=label
+    )
+
+    ray = RayTracing.fromKwargs(
+        telescopeModel=tel,
+        sourceDistance=sourceDistance,
+        zenithAngle=zenithAngle,
+        offAxisAngle=offAxisAngle
+    )
+
+    assert ray.config.zenithAngle == 30
+    assert len(ray.config.offAxisAngle) == 2
+
+
 if __name__ == '__main__':
 
     # test_ssts()
@@ -230,4 +257,5 @@ if __name__ == '__main__':
     # test_single_mirror()
     # test_plot_image()
     # test_integral_curve()
-    test_config_data()
+    # test_config_data()
+    test_from_kwargs()

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -40,11 +40,14 @@ def test_ssts(telescopeModelName):
 
 
 def test_rx():
-    sourceDistance = 10 * u.km
     version = 'current'
     label = 'test-lst'
-    zenithAngle = 20 * u.deg
-    offAxisAngle = [0, 2.5, 5.0] * u.deg
+
+    configData = {
+        'sourceDistance': 10 * u.km,
+        'zenithAngle': 20 * u.deg,
+        'offAxisAngle': [0, 2.5, 5.0] * u.deg
+    }
 
     tel = TelescopeModel(
         site='north',
@@ -55,9 +58,7 @@ def test_rx():
 
     ray = RayTracing(
         telescopeModel=tel,
-        sourceDistance=sourceDistance,
-        zenithAngle=zenithAngle,
-        offAxisAngle=offAxisAngle
+        configData=configData
     )
 
     ray.simulate(test=True, force=True)
@@ -89,15 +90,16 @@ def test_rx():
 
     plotFileArea = io.getTestPlotFile('effArea_test_rx.pdf')
     plt.savefig(plotFileArea)
-    return
 
 
 def test_plot_image():
-    sourceDistance = 10 * u.km
     version = 'prod3'
     label = 'test-astri'
-    zenithAngle = 20 * u.deg
-    offAxisAngle = [0, 2.5, 5.0] * u.deg
+    configData = {
+        'sourceDistance': 10 * u.km,
+        'zenithAngle': 20 * u.deg,
+        'offAxisAngle': [0, 2.5, 5.0] * u.deg
+    }
 
     tel = TelescopeModel(
         site='south',
@@ -108,9 +110,7 @@ def test_plot_image():
 
     ray = RayTracing(
         telescopeModel=tel,
-        sourceDistance=sourceDistance,
-        zenithAngle=zenithAngle,
-        offAxisAngle=offAxisAngle
+        configData=configData
     )
 
     ray.simulate(test=True, force=True)
@@ -125,13 +125,16 @@ def test_plot_image():
         image.plotImage(psf_color='b')
         plotFile = io.getTestPlotFile('test_plot_image_{}.pdf'.format(ii))
         plt.savefig(plotFile)
-    return
 
 
 def test_single_mirror(plot=False):
 
     # Test MST, single mirror PSF simulation
     version = 'prod3'
+    configData = {
+        'mirrorNumbers': list(range(1, 5)),
+        'singleMirrorMode': True
+    }
 
     tel = TelescopeModel(
         site='north',
@@ -142,8 +145,7 @@ def test_single_mirror(plot=False):
 
     ray = RayTracing(
         telescopeModel=tel,
-        singleMirrorMode=True,
-        mirrorNumbers=list(range(1, 5))
+        configData=configData
     )
     ray.simulate(test=True, force=True)
     ray.analyze(force=True)
@@ -159,11 +161,14 @@ def test_single_mirror(plot=False):
 
 
 def test_integral_curve():
-    sourceDistance = 10 * u.km
     version = 'prod4'
     label = 'lst_integral'
-    zenithAngle = 20 * u.deg
-    offAxisAngle = [0] * u.deg
+
+    configData = {
+        'sourceDistance': 10 * u.km,
+        'zenithAngle': 20 * u.deg,
+        'offAxisAngle': [0] * u.deg
+    }
 
     tel = TelescopeModel(
         site='north',
@@ -174,9 +179,7 @@ def test_integral_curve():
 
     ray = RayTracing(
         telescopeModel=tel,
-        sourceDistance=sourceDistance,
-        zenithAngle=zenithAngle,
-        offAxisAngle=offAxisAngle
+        configData=configData
     )
 
     ray.simulate(test=True, force=True)

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -16,11 +16,12 @@ logger.setLevel(logging.DEBUG)
 
 def test_ssts(show=False):
     # Test with 3 SSTs
-    sourceDistance = 10 * u.km
     version = 'prod3'
-    zenithAngle = 20 * u.deg
-    offAxisAngle = [0, 1.0, 2.0, 3.0, 4.0] * u.deg
-
+    configData = {
+        'sourceDistance': 10 * u.km,
+        'zenithAngle': 20 * u.deg,
+        'offAxisAngle': [0, 1.0, 2.0, 3.0, 4.0] * u.deg
+    }
     telTypes = ['sst-1M', 'sst-ASTRI', 'sst-GCT']
     telModels = list()
     rayTracing = list()
@@ -218,7 +219,7 @@ def test_config_data():
 
     configData = {
         'sourceDistance': 10 * u.km,
-        'zenithAngle': 20 * u.deg,
+        'zenithAngle': 30 * u.deg,
         'offAxisAngle': [0, 2] * u.deg
     }
 
@@ -233,6 +234,9 @@ def test_config_data():
         telescopeModel=tel,
         configData=configData
     )
+
+    assert ray._configData['zenithAngle'] == 30
+    assert len(ray._configData['offAxisAngle']) == 2
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -211,10 +211,35 @@ def test_integral_curve():
     plt.savefig(plotFile)
 
 
+def test_config_data():
+
+    label = 'test-config-data'
+    version = 'prod4'
+
+    configData = {
+        'sourceDistance': 10 * u.km,
+        'zenithAngle': 20 * u.deg,
+        'offAxisAngle': [0, 2] * u.deg
+    }
+
+    tel = TelescopeModel(
+        site='north',
+        telescopeModelName='mst-FlashCam-D',
+        modelVersion=version,
+        label=label
+    )
+
+    ray = RayTracing(
+        telescopeModel=tel,
+        configData=configData
+    )
+
+
 if __name__ == '__main__':
 
     # test_ssts()
-    test_rx()
+    # test_rx()
     # test_single_mirror()
     # test_plot_image()
     # test_integral_curve()
+    test_config_data()

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -219,8 +219,8 @@ def test_config_data():
         configData=configData
     )
 
-    assert ray._configData['zenithAngle'] == 30
-    assert len(ray._configData['offAxisAngle']) == 2
+    assert ray.config.zenithAngle == 30
+    assert len(ray.config.offAxisAngle) == 2
 
 
 if __name__ == '__main__':

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -2,6 +2,7 @@
 
 import logging
 import matplotlib.pyplot as plt
+import pytest
 from copy import copy
 
 import astropy.units as u
@@ -14,7 +15,8 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-def test_ssts(show=False):
+@pytest.mark.parametrize('telescopeModelName', ['sst-1M', 'sst-ASTRI', 'sst-GCT'])
+def test_ssts(telescopeModelName):
     # Test with 3 SSTs
     version = 'prod3'
     configData = {
@@ -22,40 +24,19 @@ def test_ssts(show=False):
         'zenithAngle': 20 * u.deg,
         'offAxisAngle': [0, 1.0, 2.0, 3.0, 4.0] * u.deg
     }
-    telTypes = ['sst-1M', 'sst-ASTRI', 'sst-GCT']
-    telModels = list()
-    rayTracing = list()
-    for t in telTypes:
-        tel = TelescopeModel(
-            site='south',
-            telescopeModelName=t,
-            modelVersion=version,
-            label='test-sst'
-        )
-        telModels.append(t)
+    tel = TelescopeModel(
+        site='south',
+        telescopeModelName=telescopeModelName,
+        modelVersion=version,
+        label='test-sst'
+    )
 
-        ray = RayTracing(
-            telescopeModel=tel,
-            sourceDistance=sourceDistance,
-            zenithAngle=zenithAngle,
-            offAxisAngle=offAxisAngle
-        )
-        ray.simulate(test=True, force=True)
-        ray.analyze(force=True)
-
-        rayTracing.append(ray)
-
-    # Plotting
-    plt.figure(figsize=(8, 6), tight_layout=True)
-    ax = plt.gca()
-    ax.set_xlabel('off-axis')
-    ax.set_ylabel('d80')
-
-    for ray in rayTracing:
-        ray.plot('d80_deg', marker='o', linestyle=':')
-
-    plotFile = io.getTestPlotFile('d80_test_ssts.pdf')
-    plt.savefig(plotFile)
+    ray = RayTracing(
+        telescopeModel=tel,
+        configData=configData
+    )
+    ray.simulate(test=True, force=True)
+    ray.analyze(force=True)
 
 
 def test_rx():

--- a/simtools/tests/test_simtel_runner.py
+++ b/simtools/tests/test_simtel_runner.py
@@ -22,9 +22,11 @@ def test_ray_tracing_mode():
     simtel = SimtelRunner(
         mode='ray-tracing',
         telescopeModel=tel,
-        zenithAngle=20 * u.deg,
-        offAxisAngle=2 * u.deg,
-        sourceDistance=12 * u.km
+        configData={
+            'zenithAngle': 20 * u.deg,
+            'offAxisAngle': 2 * u.deg,
+            'sourceDistance': 12 * u.km
+        }
     )
 
     logger.info(simtel)
@@ -49,9 +51,11 @@ def test_catching_model_error():
     simtel = SimtelRunner(
         mode='ray-tracing',
         telescopeModel=tel,
-        zenithAngle=20 * u.deg,
-        offAxisAngle=0 * u.deg,
-        sourceDistance=12 * u.km
+        configData={
+            'zenithAngle': 20 * u.deg,
+            'offAxisAngle': 0 * u.deg,
+            'sourceDistance': 12 * u.km
+        }
     )
 
     logger.info(simtel)

--- a/simtools/tests/test_telescope_data.py
+++ b/simtools/tests/test_telescope_data.py
@@ -13,14 +13,13 @@ logger.setLevel(logging.DEBUG)
 
 
 def test_input():
-    inp = {
-        'name': 'L-01',
+    configData = {
         'posX': -70.93 * u.m,
         'posY': -52.07 * u.m,
         'posZ': 43.00 * u.m,
         'altitude': 2.177 * u.km
     }
-    tel = TelescopeData(**inp)
+    tel = TelescopeData(name='L-01', configData=configData)
 
     assert tel._posX == -70.93
     # Testing default unit convertion
@@ -29,14 +28,13 @@ def test_input():
 
 
 def test_coordinate_transformations():
-    inp = {
-        'name': 'L-01',
+    configData = {
         'posX': 0 * u.m,
         'posY': 0 * u.m,
         'posZ': 43.00 * u.m,
         'altitude': 2.177 * u.km,
     }
-    tel = TelescopeData(**inp)
+    tel = TelescopeData(name='L-01', configData=configData)
 
     wgs84 = pyproj.CRS('EPSG:4326')
 
@@ -71,13 +69,12 @@ def test_coordinate_transformations():
 
 
 def test_corsika_transformations():
-    inp = {
-        'name': 'L-01',
+    configData = {
         'posX': 0 * u.m,
         'posY': 0 * u.m,
         'altitude': 2.177 * u.km,
     }
-    tel = TelescopeData(**inp)
+    tel = TelescopeData(name='L-01', configData=configData)
 
     # ASL -> CORSIKA
     tel.convertAslToCorsika(
@@ -98,13 +95,12 @@ def test_corsika_transformations():
 
 
 def test_convert_all():
-    inp = {
-        'name': 'L-01',
+    configData = {
         'posX': 0 * u.m,
         'posY': 0 * u.m,
         'posZ': 43.00 * u.m,
     }
-    tel = TelescopeData(**inp)
+    tel = TelescopeData(name='L-01', configData=configData)
 
     wgs84 = pyproj.CRS('EPSG:4326')
 

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -171,13 +171,15 @@ def validateConfigData(configData, parameters):
     for parName, parInfo in parameters.items():
         if parName in outData.keys():
             continue
-        elif 'default' in parInfo.keys():
+        elif 'default' in parInfo.keys() and parInfo['default'] is not None:
             validatedValue = _validateAndConvertValue(
                 parName,
                 parInfo,
                 parInfo['default']
             )
             outData[parName] = validatedValue
+        elif 'default' in parInfo.keys() and parInfo['default'] is None:
+            outData[parName] = None
         else:
             msg = (
                 'Required entry in configData {} '.format(parName)

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -39,6 +39,10 @@ class InvalidConfigEntry(Exception):
     pass
 
 
+class InvalidConfigData(Exception):
+    pass
+
+
 def fileHasText(file, text):
     '''
     Check whether a file contain a certain piece of text.
@@ -390,8 +394,9 @@ def collectDataFromYamlOrDict(inYaml, inDict):
     elif inDict is not None:
         return dict(inDict)
     else:
-        _logger.error('No data was given - aborting')
-        return None
+        msg = 'configData has not been provided (by yaml file neither by dict)'
+        _logger.error(msg)
+        raise InvalidConfigData(msg)
 
 
 def collectKwargs(label, inKwargs):

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -81,8 +81,8 @@ def validateConfigData(configData, parameters):
 
     Returns
     -------
-    dict:
-        Dict containing the validated config data entries.
+    namedtuple:
+        Containing the validated config data entries.
     '''
 
     logger = logging.getLogger(__name__)

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -150,6 +150,9 @@ def validateConfigData(configData, parameters):
     # Dict to be filled and returned
     outData = dict()
 
+    if configData is None:
+        configData = dict()
+
     # Collecting all entries given as in configData.
     for keyData, valueData in configData.items():
 
@@ -226,7 +229,7 @@ def _validateAndConvertValue(parName, parInfo, valueIn):
     if 'unit' not in parInfo.keys():
 
         # Checking if values have unit and raising error, if so.
-        if any([u.Quanity(v).unit != u.dimensionless_unscaled for v in value]):
+        if any([u.Quantity(v).unit != u.dimensionless_unscaled for v in value]):
             msg = 'Config entry {} shoul not have units'.format(parName)
             logger.error(msg)
             raise InvalidConfigEntry(msg)
@@ -249,7 +252,8 @@ def _validateAndConvertValue(parName, parInfo, valueIn):
         # Checking units and converting them, if needed.
         valueWithUnits = list()
         for arg, unit in zip(value, parUnit):
-            if unit is None:
+            # In case a entry is None, None should be returned.
+            if unit is None or arg is None:
                 valueWithUnits.append(arg)
                 continue
 

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -1,5 +1,6 @@
 import logging
 import copy
+from collections import namedtuple
 
 import astropy.units as u
 from astropy.io.misc import yaml
@@ -133,7 +134,9 @@ def validateConfigData(configData, parameters):
             )
             logger.error(msg)
             raise MissingRequiredConfigEntry(msg)
-    return outData
+
+    ConfigData = namedtuple('ConfigData', outData)
+    return ConfigData(**outData)
 
 
 def _validateAndConvertValue(parName, parInfo, valueIn):

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -201,6 +201,7 @@ def _validateAndConvertValue(parName, parInfo, value):
 
     # Checking the entry length
     valueLength = len(value)
+    logger.debug('Value len of {}: {}'.format(parName, valueLength))
     undefinedLength = False
     if parInfo['len'] is None:
         undefinedLength = True
@@ -211,7 +212,7 @@ def _validateAndConvertValue(parName, parInfo, value):
 
     # Checking unit
     if 'unit' not in parInfo.keys():
-        return value
+        return value if len(value) > 1 else value[0]
     else:
         # Turning parInfo['unit'] into a list, if it is not.
         parUnit = copyAsList(parInfo['unit'])
@@ -241,7 +242,7 @@ def _validateAndConvertValue(parName, parInfo, value):
             else:
                 valueWithUnits.append(arg.to(unit).value)
 
-        return valueWithUnits
+        return valueWithUnits if len(valueWithUnits) > 1 else valueWithUnits[0]
 
 
 def collectArguments(obj, args, allInputs, **kwargs):
@@ -513,7 +514,10 @@ def copyAsList(value):
     value: list
         Copy of value if it is a list of [value] otherwise.
     '''
-    try:
-        return list(value)
-    except Exception:
+    if isinstance(value, str):
         return [value]
+    else:
+        try:
+            return list(value)
+        except Exception:
+            return [value]

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -5,7 +5,7 @@ import astropy.units as u
 from astropy.io.misc import yaml
 
 __all__ = [
-    'collectArguments',
+    'validateConfigData',
     'collectDataFromYamlOrDict',
     'collectKwargs',
     'setDefaultKwargs',
@@ -13,18 +13,6 @@ __all__ = [
     'collectFinalLines',
     'getLogLevelFromUser'
 ]
-
-
-class ArgumentWithWrongUnit(Exception):
-    pass
-
-
-class ArgumentCannotBeCollected(Exception):
-    pass
-
-
-class MissingRequiredArgument(Exception):
-    pass
 
 
 class UnableToIdentifyConfigEntry(Exception):
@@ -63,55 +51,6 @@ def fileHasText(file, text):
             if text in ll:
                 return True
     return False
-
-
-def _unitsAreConvertible(quantity_1, quantity_2):
-    '''
-    Parameters
-    ----------
-    quantity_1: astropy.Quantity
-    quantity_2: astropy.Quantity
-
-    Returns
-    -------
-    Bool
-    '''
-    try:
-        quantity_1.to(quantity_2)
-        return True
-    except Exception:
-        return False
-
-
-def _unitIsValid(quantity, unit):
-    '''
-    Parameters
-    ----------
-    quantity: astropy.Quantity
-    unit: astropy.unit
-
-    Returns
-    -------
-    Bool
-    '''
-    if unit is None and not isinstance(1 * quantity, u.quantity.Quantity):
-        return True
-    else:
-        return _unitsAreConvertible(quantity, unit)
-
-
-def _convertUnit(quantity, unit):
-    '''
-    Parameters
-    ----------
-    quantity: astropy.Quantity
-    unit: astropy.unit
-
-    Returns
-    -------
-    astropy.quantity
-    '''
-    return quantity if unit is None else quantity.to(unit).value
 
 
 def validateConfigData(configData, parameters):
@@ -274,121 +213,6 @@ def _validateAndConvertValue(parName, parInfo, valueIn):
             return (
                 valueWithUnits if len(valueWithUnits) > 1 or undefinedLength else valueWithUnits[0]
             )
-
-
-def collectArguments(obj, args, allInputs, **kwargs):
-    '''
-    Collect certain arguments and validate them.
-    To be used during initialization of classes, where kwargs with
-    physical meaning and units are expected.
-
-    Note
-    ----
-
-    In ray_tracing class,
-
-    .. code-block:: python
-
-        collectArguments(
-            self,
-            args=['zenithAngle', 'offAxisAngle', 'sourceDistance'],
-            allInputs=self.ALL_INPUTS,
-            **kwargs
-        )
-
-    where,
-
-    .. code-block:: python
-
-        ALL_INPUTS = {
-            'zenithAngle': {'default': 20, 'unit': u.deg},
-            'offAxisAngle': {'default': [0, 1.5, 3.0], 'unit': u.deg, 'isList': True},
-            'sourceDistance': {'default': 10, 'unit': u.km},
-            'mirrorNumbers': {'default': [1], 'unit': None, 'isList': True}
-        }
-
-
-    Parameters
-    ----------
-    obj: class instance (self)
-    args: list of str
-        List of names of the parameters to be collected.
-    allInputs: dict
-        Dict with info about all the expected inputs. See example.
-    **kwargs:
-        kwargs from the input arguments.
-    '''
-    _logger = logging.getLogger(__name__)
-
-    def processSingleArg(arg, inArgName, argG, argD):
-        if _unitIsValid(argG, argD['unit']):
-            obj.__dict__[inArgName] = _convertUnit(argG, argD['unit'])
-        else:
-            msg = 'Argument {} given with wrong unit'.format(arg)
-            _logger.error(msg)
-            raise ArgumentWithWrongUnit(msg)
-
-    def processListArg(arg, inArgName, argG, argD):
-        outArg = list()
-        try:
-            argG = list(argG)
-        except Exception:
-            argG = [argG]
-
-        for aa in argG:
-            if _unitIsValid(aa, argD['unit']):
-                outArg.append(_convertUnit(aa, argD['unit']))
-            else:
-                msg = 'Argument {} given with wrong unit'.format(arg)
-                _logger.error(msg)
-                raise ArgumentWithWrongUnit(msg)
-        obj.__dict__[inArgName] = outArg
-
-    def processDictArg(arg, inArgName, argG, argD):
-        outArg = dict()
-
-        if not isinstance(argG, dict):
-            msg = 'Argument is not a dict - aborting'
-            _logger.error(msg)
-            raise ArgumentCannotBeCollected(msg)
-
-        for key, value in argG.items():
-            if _unitIsValid(value, argD['unit']):
-                outArg[key] = _convertUnit(value, argD['unit'])
-            else:
-                msg = 'Argument {} given with wrong unit'.format(arg)
-                _logger.error(msg)
-                raise ArgumentWithWrongUnit(msg)
-        obj.__dict__[inArgName] = outArg
-
-    for arg in args:
-        inArgName = '_' + arg
-        argData = allInputs[arg]
-
-        if arg not in allInputs.keys():
-            msg = 'Arg {} cannot be collected because it is not in allInputs'.format(arg)
-            _logger.error(msg)
-            raise ArgumentCannotBeCollected(msg)
-
-        if arg in kwargs.keys():
-            argGiven = kwargs[arg]
-            if argGiven is None:
-                obj.__dict__[inArgName] = None
-            elif 'isDict' in argData and argData['isDict']:  # Dict
-                processDictArg(arg, inArgName, argGiven, argData)
-            elif 'isList' in argData and argData['isList']:  # List
-                processListArg(arg, inArgName, argGiven, argData)
-            else:  # Not a list or dict
-                processSingleArg(arg, inArgName, argGiven, argData)
-
-        elif 'default' in argData:
-            obj.__dict__[inArgName] = argData['default']
-        else:
-            msg = 'Required argument (without default) {} was not given'.format(arg)
-            _logger.warning(msg)
-            raise MissingRequiredArgument(msg)
-
-    return
 
 
 def collectDataFromYamlOrDict(inYaml, inDict, allowEmpty=False):

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -387,7 +387,7 @@ def collectArguments(obj, args, allInputs, **kwargs):
     return
 
 
-def collectDataFromYamlOrDict(inYaml, inDict):
+def collectDataFromYamlOrDict(inYaml, inDict, allowEmpty=False):
     '''
     Collect input data that can be given either as a dict
     or as a yaml file.
@@ -398,6 +398,8 @@ def collectDataFromYamlOrDict(inYaml, inDict):
         Name of the Yaml file.
     inDict: dict
         Data as dict.
+    allowEmpty: bool
+        If True, an error won't be raised in case both yaml and dict are None.
 
     Returns
     -------
@@ -416,8 +418,12 @@ def collectDataFromYamlOrDict(inYaml, inDict):
         return dict(inDict)
     else:
         msg = 'configData has not been provided (by yaml file neither by dict)'
-        _logger.error(msg)
-        raise InvalidConfigData(msg)
+        if allowEmpty:
+            _logger.warning(msg)
+            return None
+        else:
+            _logger.error(msg)
+            raise InvalidConfigData(msg)
 
 
 def collectKwargs(label, inKwargs):

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -12,7 +12,8 @@ __all__ = [
     'setDefaultKwargs',
     'sortArrays',
     'collectFinalLines',
-    'getLogLevelFromUser'
+    'getLogLevelFromUser',
+    'separateArgsAndConfigData'
 ]
 
 
@@ -386,3 +387,32 @@ def copyAsList(value):
             return list(value)
         except Exception:
             return [value]
+
+
+def separateArgsAndConfigData(expectedArgs, **kwargs):
+    '''
+    Separate kwargs into the arguments expected for instancing a class and
+    the dict to be given as configData.
+    This function is specific for methods fromKwargs in classes which use the
+    validateConfigData system.
+
+    Parameters
+    ----------
+    expectedArgs: list of str
+        List of arguments expected for the class.
+    **kwargs:
+
+    Returns
+    -------
+    dict, dict
+        A dict with the args collected and another one with configData.
+    '''
+    args = dict()
+    configData = dict()
+    for key, value in kwargs.items():
+        if key in expectedArgs:
+            args[key] = value
+        else:
+            configData[key] = value
+
+    return args, configData

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -212,7 +212,7 @@ def _validateAndConvertValue(parName, parInfo, value):
 
     # Checking unit
     if 'unit' not in parInfo.keys():
-        return value if len(value) > 1 else value[0]
+        return value if len(value) > 1 or undefinedLength else value[0]
     else:
         # Turning parInfo['unit'] into a list, if it is not.
         parUnit = copyAsList(parInfo['unit'])
@@ -242,7 +242,7 @@ def _validateAndConvertValue(parName, parInfo, value):
             else:
                 valueWithUnits.append(arg.to(unit).value)
 
-        return valueWithUnits if len(valueWithUnits) > 1 else valueWithUnits[0]
+        return valueWithUnits if len(valueWithUnits) > 1 or undefinedLength else valueWithUnits[0]
 
 
 def collectArguments(obj, args, allInputs, **kwargs):


### PR DESCRIPTION
Following up #134, I replaced the old system by the new one in all the modules.

I also changed the output of validateConfigData to a namedtuple, instead of a dict. 
Now the classes contain an attribute called config which contains the validated parameters as namedtuple.
Some classes need to manipulate these parameters, so in these cases we are turning them into private attributes.

All classes that deals with configurable parameters have now a classmethod called fromKwargs that can be used to instance by giving all the configurable parameters as kwargs, instead a dict or yaml file.

Each class that uses the system has a correspondent parameter file in data/parameters with the info about all the configurable parameters (len, unit, etc).
