### PR TITLE
Fixing bug in the app derive mirror rnda

### DIFF
--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -287,7 +287,6 @@ if __name__ == "__main__":
         rndaStart = args.rnda
     else:
         rndaStart = tel.getParameter("mirror_reflection_random_angle")["Value"]
-        print('HEREEE {}'.format(rndaStart))
         if isinstance(rndaStart, str):
             rndaStart = rndaStart.split()
             rndaStart = float(rndaStart[0])

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -286,7 +286,8 @@ if __name__ == "__main__":
     if args.rnda != 0:
         rndaStart = args.rnda
     else:
-        rndaStart = tel.getParameter("mirror_reflection_random_angle")
+        rndaStart = tel.getParameter("mirror_reflection_random_angle")["Value"]
+        print('HEREEE {}'.format(rndaStart))
         if isinstance(rndaStart, str):
             rndaStart = rndaStart.split()
             rndaStart = float(rndaStart[0])


### PR DESCRIPTION
Single-line change in the application derive_mirror_rnda to fix a bug.
The parameter was being readfrom the DB as a dict, so the key Value should be used instead of the whole dict.