### PR TITLE
Fixing bug with empty plot in compare_cumulative_psf

### DIFF
--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -201,7 +201,6 @@ if __name__ == "__main__":
 
     # Plotting image
     dataToPlot = im.getImageData()
-    print(dataToPlot)
     fig = visualize.plotHist2D(dataToPlot, bins=80)
     circle = plt.Circle((0, 0), im.getPSF(0.8) / 2, color="k", fill=False, lw=2, ls="--")
     fig.gca().add_artist(circle)

--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -201,9 +201,11 @@ if __name__ == "__main__":
 
     # Plotting image
     dataToPlot = im.getImageData()
-    visualize.plotHist2D(dataToPlot, bins=80)
+    print(dataToPlot)
+    fig = visualize.plotHist2D(dataToPlot, bins=80)
     circle = plt.Circle((0, 0), im.getPSF(0.8) / 2, color="k", fill=False, lw=2, ls="--")
     fig.gca().add_artist(circle)
+    fig.gca().set_aspect('equal')
 
     plotFileName = label + "_" + telModel.name + "_image"
     plotFile = outputDir.joinpath(plotFileName)

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -441,7 +441,7 @@ class RayTracing:
             )
             self._outputDirectory.joinpath("figures").mkdir(exist_ok=True)
             plotFile = self._outputDirectory.joinpath("figures").joinpath(plotFileName)
-            self._logger.info("Ssaving fig in {}".format(plotFile))
+            self._logger.info("Saving fig in {}".format(plotFile))
             plt.savefig(plotFile)
 
     def plotHistogram(self, key, **kwargs):

--- a/simtools/visualize.py
+++ b/simtools/visualize.py
@@ -489,8 +489,8 @@ def plotHist2D(data, **kwargs):
 
     Returns
     -------
-    pyplot.plt
-        a pyplot.plt instance in which the plot was produced
+    pyplot.figure
+        A pyplot.figure instance in which the plot was produced
 
     """
 
@@ -505,7 +505,7 @@ def plotHist2D(data, **kwargs):
     setStyle()
 
     gs = gridspec.GridSpec(1, 1)
-    plt.figure(figsize=(8, 6))
+    fig = plt.figure(figsize=(8, 6))
 
     ##########################################################################################
     # Plot the data
@@ -526,6 +526,6 @@ def plotHist2D(data, **kwargs):
     if len(title) > 0:
         plt.title(title, y=1.02)
 
-    plt.tight_layout()
+    fig.tight_layout()
 
-    return plt
+    return fig


### PR DESCRIPTION
There was a bug in the use of visualize.plotHist2D() in the application. The functions plot(...) return a figure, and this figure should be used by the application.