### PR TITLE
Fixing CI trigger on PR merge

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Deploy to gihub pages
         # only run when PR is merged
-        if: ${{ github.event.pull_request.merged }}
+        if: github.event.pull_request.merged
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The CI step to deploy the gh-pages is not triggering when PR is merged. I am trying to fix it.