### PR TITLE
Preventing TelescopeModel to read the DB when not necessary 

### DIFF
--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -64,6 +64,8 @@
     random_flen (float, optional)
         Value to replace the default random_focal_length. Only used if use_random_flen \
         is activated.
+    no_tuning (activation mode, optional)
+        Turn off the tuning - A single case will be simulated and plotted.
     test (activation mode, optional)
         If activated, application will be faster by simulating only few mirrors.
     verbosity (str, optional)
@@ -166,11 +168,6 @@ if __name__ == "__main__":
         default=0.0,
     )
     parser.add_argument(
-        "--no_tuning",
-        help="Turn off the tuning - A single case will be simulated and plotted.",
-        action="store_true",
-    )
-    parser.add_argument(
         "--mirror_list",
         help=(
             "Mirror list file to replace the default one. It should be used if measured mirror"
@@ -192,6 +189,11 @@ if __name__ == "__main__":
         help="Value to replace the default random_focal_length.",
         type=float,
         required=False,
+    )
+    parser.add_argument(
+        "--no_tuning",
+        help="Turn off the tuning - A single case will be simulated and plotted.",
+        action="store_true",
     )
     parser.add_argument(
         "--test",

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -120,7 +120,7 @@ class TelescopeModel:
 
         self._setConfigFileDirectoryAndName()
         self._isConfigFileUpdated = False
-        self._isModelFilesUpdated = False
+        self._isExportedModelFilesUpdated = False
 
     @property
     def mirrors(self):
@@ -385,7 +385,7 @@ class TelescopeModel:
 
         self._isConfigFileUpdated = False
         if isFile:
-            self._isModelFilesUpdated = False
+            self._isExportedModelFilesUpdated = False
 
     def changeParameter(self, parName, value):
         """
@@ -419,7 +419,7 @@ class TelescopeModel:
 
             # In case parameter is a file, the model files will be outdated
             if self._parameters[parName]["File"]:
-                self._isModelFilesUpdated = False
+                self._isExportedModelFilesUpdated = False
 
         self._isConfigFileUpdated = False
 
@@ -499,13 +499,13 @@ class TelescopeModel:
                 parsFromDB.pop(par)
 
         db.exportModelFiles(parsFromDB, self._configFileDirectory)
-        self._isModelFilesUpdated = True
+        self._isExportedModelFilesUpdated = True
 
     def exportConfigFile(self):
         """Export the config file used by sim_telarray."""
 
         # Exporting model file
-        if not self._isModelFilesUpdated:
+        if not self._isExportedModelFilesUpdated:
             self.exportModelFiles()
 
         # Using SimtelConfigWriter to write the config file.

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -281,10 +281,7 @@ class TelescopeModel:
         _sitePars = db.getSiteParameters(
             self.site, self.modelVersion, onlyApplicable=True
         )
-        # UPDATE: SimtelConfigWriter deals with which parameters should be written or not.
-        # _parameters here can contain all the parameters from the DB.
         self._parameters.update(_sitePars)
-
     # END _loadParametersFromDB
 
     def hasParameter(self, parName):

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -418,7 +418,7 @@ class TelescopeModel:
             self._logger.debug("Changing parameter {}".format(parName))
 
             # In case parameter is a file, the model files will be outdated
-            if self._parameters[parName]["isFile"]:
+            if self._parameters[parName]["File"]:
                 self._isModelFilesUpdated = False
 
         self._isConfigFileUpdated = False

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -119,8 +119,8 @@ class TelescopeModel:
             self._loadParametersFromDB()
 
         self._setConfigFileDirectoryAndName()
-        self._isConfigFileUpdated = False
-        self._isExportedModelFilesUpdated = False
+        self._isConfigFileUpToDate = False
+        self._isExportedModelFilesUpToDate = False
 
     @property
     def mirrors(self):
@@ -383,9 +383,9 @@ class TelescopeModel:
             self._parameters[parName]["Applicable"] = isAplicable
             self._parameters[parName]["File"] = isFile
 
-        self._isConfigFileUpdated = False
+        self._isConfigFileUpToDate = False
         if isFile:
-            self._isExportedModelFilesUpdated = False
+            self._isExportedModelFilesUpToDate = False
 
     def changeParameter(self, parName, value):
         """
@@ -419,9 +419,9 @@ class TelescopeModel:
 
             # In case parameter is a file, the model files will be outdated
             if self._parameters[parName]["File"]:
-                self._isExportedModelFilesUpdated = False
+                self._isExportedModelFilesUpToDate = False
 
-        self._isConfigFileUpdated = False
+        self._isConfigFileUpToDate = False
 
     def changeMultipleParameters(self, **kwargs):
         """
@@ -444,7 +444,7 @@ class TelescopeModel:
             else:
                 self.addParameter(par, value)
 
-        self._isConfigFileUpdated = False
+        self._isConfigFileUpToDate = False
 
     def removeParameters(self, *args):
         """
@@ -470,7 +470,7 @@ class TelescopeModel:
                 )
                 self._logger.error(msg)
                 raise InvalidParameter(msg)
-        self._isConfigFileUpdated = False
+        self._isConfigFileUpToDate = False
 
     def addParameterFile(self, parName, filePath):
         """
@@ -499,13 +499,13 @@ class TelescopeModel:
                 parsFromDB.pop(par)
 
         db.exportModelFiles(parsFromDB, self._configFileDirectory)
-        self._isExportedModelFilesUpdated = True
+        self._isExportedModelFilesUpToDate = True
 
     def exportConfigFile(self):
         """Export the config file used by sim_telarray."""
 
         # Exporting model file
-        if not self._isExportedModelFilesUpdated:
+        if not self._isExportedModelFilesUpToDate:
             self.exportModelFiles()
 
         # Using SimtelConfigWriter to write the config file.
@@ -528,7 +528,7 @@ class TelescopeModel:
         -------
         Path of the exported config file for sim_telarray.
         """
-        if not self._isConfigFileUpdated and not noExport:
+        if not self._isConfigFileUpToDate and not noExport:
             self.exportConfigFile()
         return self._configFilePath
 

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -120,6 +120,7 @@ class TelescopeModel:
 
         self._setConfigFileDirectoryAndName()
         self._isConfigFileUpdated = False
+        self._isModelFilesUpdated = False
 
     @property
     def mirrors(self):
@@ -383,6 +384,8 @@ class TelescopeModel:
             self._parameters[parName]["File"] = isFile
 
         self._isConfigFileUpdated = False
+        if isFile:
+            self._isModelFilesUpdated = False
 
     def changeParameter(self, parName, value):
         """
@@ -413,6 +416,11 @@ class TelescopeModel:
                 self._logger.warning("Value type differs from the current one")
             self._parameters[parName]["Value"] = value
             self._logger.debug("Changing parameter {}".format(parName))
+
+            # In case parameter is a file, the model files will be outdated
+            if self._parameters[parName]["isFile"]:
+                self._isModelFilesUpdated = False
+
         self._isConfigFileUpdated = False
 
     def changeMultipleParameters(self, **kwargs):
@@ -491,12 +499,14 @@ class TelescopeModel:
                 parsFromDB.pop(par)
 
         db.exportModelFiles(parsFromDB, self._configFileDirectory)
+        self._isModelFilesUpdated = True
 
     def exportConfigFile(self):
         """Export the config file used by sim_telarray."""
 
         # Exporting model file
-        self.exportModelFiles()
+        if not self._isModelFilesUpdated:
+            self.exportModelFiles()
 
         # Using SimtelConfigWriter to write the config file.
         self._loadSimtelConfigWriter()

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -64,12 +64,13 @@ class TestTelescopeModel(unittest.TestCase):
         tel.exportConfigFile()
 
     def test_updating_export_model_files(self):
-        logger.info("Changing mirror_reflection_random_angle")
+        logger.info("Changing a parameter that is not a file - mirror_reflection_random_angle")
         new_mrra = "0.0080 0 0"
         self.telModel.changeParameter("mirror_reflection_random_angle", new_mrra)
 
-        self.assertTrue(self.telModel._areModelFilesUpdated)
+        self.assertTrue(self.telModel._isModelFilesUpdated)
 
+        # This should not connect to the DB
         self.telModel.exportConfigFile()
 
 

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -66,7 +66,12 @@ class TestTelescopeModel(unittest.TestCase):
     def test_updating_export_model_files(self):
         logger.info("Changing a parameter that is not a file - mirror_reflection_random_angle")
         new_mrra = "0.0080 0 0"
+
+        print('HEREE', self.telModel._isModelFilesUpdated)
+
         self.telModel.changeParameter("mirror_reflection_random_angle", new_mrra)
+
+        print('HEREE', self.telModel._isModelFilesUpdated)
 
         self.assertTrue(self.telModel._isModelFilesUpdated)
 

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -109,7 +109,7 @@ class TestTelescopeModel(unittest.TestCase):
         logger.info("DB should NOT be read next.")
         tel.exportConfigFile()
 
-        # Changing a file parameter
+        # Changing a parameter that is a file
         logger.debug(
             "Changing a parameter that IS a file - camera_config_file"
         )
@@ -118,8 +118,8 @@ class TestTelescopeModel(unittest.TestCase):
             tel.getParameterValue("camera_config_file")
         )
         logger.debug(
-            "tel._isExportedModelFiles should be False because a file parameter "
-            "was changed."
+            "tel._isExportedModelFiles should be False because a parameter that "
+            "is a file was changed."
         )
         self.assertFalse(tel._isExportedModelFilesUpToDate)
 

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -64,6 +64,13 @@ class TestTelescopeModel(unittest.TestCase):
         tel.exportConfigFile()
 
     def test_updating_export_model_files(self):
+        """
+        It was found in derive_mirror_rnda_angle that the DB was being
+        accessed each time the model was changed, because the model
+        files were being re-exported. A flag called _isExportedModelFilesUpdated
+        was added to prevent this behavior. This test is meant to assure
+        it is working properly.
+        """
 
         # We need a brand new telescopeModel to avoid interference
         tel = TelescopeModel(

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -63,6 +63,15 @@ class TestTelescopeModel(unittest.TestCase):
         )
         tel.exportConfigFile()
 
+    def test_updating_export_model_files(self):
+        logger.info("Changing mirror_reflection_random_angle")
+        new_mrra = "0.0080 0 0"
+        self.telModel.changeParameter("mirror_reflection_random_angle", new_mrra)
+
+        self.assertTrue(self.telModel._areModelFilesUpdated)
+
+        self.telModel.exportConfigFile()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -67,7 +67,7 @@ class TestTelescopeModel(unittest.TestCase):
         """
         It was found in derive_mirror_rnda_angle that the DB was being
         accessed each time the model was changed, because the model
-        files were being re-exported. A flag called _isExportedModelFilesUpdated
+        files were being re-exported. A flag called _isExportedModelFilesUpToDate
         was added to prevent this behavior. This test is meant to assure
         it is working properly.
         """
@@ -84,7 +84,7 @@ class TestTelescopeModel(unittest.TestCase):
             "tel._isExportedModelFiles should be False because exportConfigFile"
             " was not called yet."
         )
-        self.assertFalse(tel._isExportedModelFilesUpdated)
+        self.assertFalse(tel._isExportedModelFilesUpToDate)
 
         # Exporting config file
         tel.exportConfigFile()
@@ -92,7 +92,7 @@ class TestTelescopeModel(unittest.TestCase):
             "tel._isExportedModelFiles should be True because exportConfigFile"
             " was called."
         )
-        self.assertTrue(tel._isExportedModelFilesUpdated)
+        self.assertTrue(tel._isExportedModelFilesUpToDate)
 
         # Changing a non-file parameter
         logger.info(
@@ -103,7 +103,7 @@ class TestTelescopeModel(unittest.TestCase):
             "tel._isExportedModelFiles should still be True because the changed "
             "parameter was not a file"
         )
-        self.assertTrue(tel._isExportedModelFilesUpdated)
+        self.assertTrue(tel._isExportedModelFilesUpToDate)
 
         # Testing the DB connection
         logger.info("DB should NOT be read next.")
@@ -121,7 +121,7 @@ class TestTelescopeModel(unittest.TestCase):
             "tel._isExportedModelFiles should be False because a file parameter "
             "was changed."
         )
-        self.assertFalse(tel._isExportedModelFilesUpdated)
+        self.assertFalse(tel._isExportedModelFilesUpToDate)
 
         # Testing the DB connection
         logger.info("DB should be read next.")

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -19,49 +19,49 @@ class TestTelescopeModel(unittest.TestCase):
             label="test-telescope-model",
         )
 
-    def test_handling_parameters(self):
-        logger.info(
-            "Old mirror_reflection_random_angle:{}".format(
-                self.telModel.getParameterValue("mirror_reflection_random_angle")
-            )
-        )
-        logger.info("Changing mirror_reflection_random_angle")
-        new_mrra = "0.0080 0 0"
-        self.telModel.changeParameter("mirror_reflection_random_angle", new_mrra)
-        self.assertEqual(
-            self.telModel.getParameterValue("mirror_reflection_random_angle"), new_mrra
-        )
+    # def test_handling_parameters(self):
+    #     logger.info(
+    #         "Old mirror_reflection_random_angle:{}".format(
+    #             self.telModel.getParameterValue("mirror_reflection_random_angle")
+    #         )
+    #     )
+    #     logger.info("Changing mirror_reflection_random_angle")
+    #     new_mrra = "0.0080 0 0"
+    #     self.telModel.changeParameter("mirror_reflection_random_angle", new_mrra)
+    #     self.assertEqual(
+    #         self.telModel.getParameterValue("mirror_reflection_random_angle"), new_mrra
+    #     )
 
-        logging.info("Adding new_parameter")
-        new_par = "23"
-        self.telModel.addParameter("new_parameter", new_par)
-        self.assertEqual(self.telModel.getParameterValue("new_parameter"), new_par)
+    #     logging.info("Adding new_parameter")
+    #     new_par = "23"
+    #     self.telModel.addParameter("new_parameter", new_par)
+    #     self.assertEqual(self.telModel.getParameterValue("new_parameter"), new_par)
 
-        with self.assertRaises(InvalidParameter):
-            self.telModel.getParameter("bla_bla")
+    #     with self.assertRaises(InvalidParameter):
+    #         self.telModel.getParameter("bla_bla")
 
-    def test_flen_type(self):
-        flenInfo = self.telModel.getParameter("focal_length")
-        logger.info(
-            "Focal Length = {}, type = {}".format(flenInfo["Value"], flenInfo["Type"])
-        )
-        self.assertIsInstance(flenInfo["Value"], float)
+    # def test_flen_type(self):
+    #     flenInfo = self.telModel.getParameter("focal_length")
+    #     logger.info(
+    #         "Focal Length = {}, type = {}".format(flenInfo["Value"], flenInfo["Type"])
+    #     )
+    #     self.assertIsInstance(flenInfo["Value"], float)
 
-    def test_cfg_file(self):
-        # Exporting
-        self.telModel.exportConfigFile()
+    # def test_cfg_file(self):
+    #     # Exporting
+    #     self.telModel.exportConfigFile()
 
-        logger.info("Config file: {}".format(self.telModel.getConfigFile()))
+    #     logger.info("Config file: {}".format(self.telModel.getConfigFile()))
 
-        # Importing
-        cfgFile = self.telModel.getConfigFile()
-        tel = TelescopeModel.fromConfigFile(
-            site="south",
-            telescopeModelName="sst-d",
-            label="test-sst",
-            configFileName=cfgFile,
-        )
-        tel.exportConfigFile()
+    #     # Importing
+    #     cfgFile = self.telModel.getConfigFile()
+    #     tel = TelescopeModel.fromConfigFile(
+    #         site="south",
+    #         telescopeModelName="sst-d",
+    #         label="test-sst",
+    #         configFileName=cfgFile,
+    #     )
+    #     tel.exportConfigFile()
 
     def test_updating_export_model_files(self):
         logger.info("Changing a parameter that is not a file - mirror_reflection_random_angle")


### PR DESCRIPTION
Motivated by #187.

A flag was added to TelescopeModel to prevent reading the DB when there is no new parameter that is a file in the model.
