### PR TITLE
New strategy for pytest - separating unit and integration tests

### DIFF
--- a/applications/get_parameter.py
+++ b/applications/get_parameter.py
@@ -60,8 +60,6 @@ if __name__ == "__main__":
             "This application works only with MongoDB and you asked not to use it"
         )
 
-    logger.info("TEST")
-
     db = db_handler.DatabaseHandler()
 
     if args.model_version == "all":

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 import simtools.config as cfg
-import simtools.db_handler as db
+from simtools import db_handler
 
 logger = logging.getLogger()
 
@@ -33,11 +33,16 @@ else:
         os.environ["HAS_DB_CONNECTION"] = "0"
     else:
         # Trying to connect to the DB
-        db.DatabaseHandler()
-        os.environ["HAS_DB_CONNECTION"] = "1"
-        print('DB CONNECTEDDDDDDDDDDDDDD')
-
-    logger.debug("Setting HAS_DB_CONNECTION = {}".format(os.environ["HAS_DB_CONNECTION"]))
+        db = db_handler.DatabaseHandler()
+        try:
+            db.getModelParameters("north", "lst-1", "Current")
+            os.environ["HAS_DB_CONNECTION"] = "1"
+            logger.debug("DB connection is available")
+            logger.debug("Setting HAS_DB_CONNECTION = 1")
+        except Exception:
+            os.environ["HAS_DB_CONNECTION"] = "0"
+            logger.debug("DB connection is NOT available")
+            logger.debug("Setting HAS_DB_CONNECTION = 0")
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/conftest.py
+++ b/conftest.py
@@ -21,3 +21,7 @@ else:
     # Checking whether there is DB connection
     useMongoDB = cfg.get("useMongoDB")
     os.environ["HAS_DB_CONNECTION"] = "1" if useMongoDB else "0"
+
+
+def pytest_sessionfinish(session, exitstatus):
+    os.system('./clean_files')

--- a/conftest.py
+++ b/conftest.py
@@ -47,4 +47,4 @@ else:
 
 def pytest_sessionfinish(session, exitstatus):
     """ Cleaning up output files before ending the pytest session. """
-    os.system('./clean_files')
+    os.system("./clean_files")

--- a/conftest.py
+++ b/conftest.py
@@ -1,27 +1,45 @@
 import os
+import logging
 
 import simtools.config as cfg
+import simtools.db_handler as db
+
+logger = logging.getLogger()
 
 
 try:
     cfg.loadConfig()
 except FileNotFoundError:
+    logger.debug("simtools configuration file was NOT found")
+    logger.debug("Setting HAS_CONFIG_FILE = 0")
+    logger.debug("Setting SIMTEL_INSTALLED = 0")
+    logger.debug("Setting HAS_DB_CONNECTION = 0")
     os.environ["HAS_CONFIG_FILE"] = "0"
     os.environ["SIMTEL_INSTALLED"] = "0"
     os.environ["HAS_DB_CONNECTION"] = "0"
 else:
-
     os.environ["HAS_CONFIG_FILE"] = "1"
+    logger.debug("simtools configuration found WAS found")
+    logger.debug("Setting HAS_CONFIG_FILE = 1")
 
     # Checking whether sim_telarray is properly installed
     simtelPath = cfg.get("simtelPath")
     simtelBinPath = simtelPath + "/sim_telarray/bin/sim_telarray"
     os.environ["SIMTEL_INSTALLED"] = "1" if os.path.exists(simtelBinPath) else "0"
+    logger.debug("Setting SIMTEL_INSTALLED = {}".format(os.environ["SIMTEL_INSTALLED"]))
 
     # Checking whether there is DB connection
-    useMongoDB = cfg.get("useMongoDB")
-    os.environ["HAS_DB_CONNECTION"] = "1" if useMongoDB else "0"
+    if not cfg.get("useMongoDB"):
+        os.environ["HAS_DB_CONNECTION"] = "0"
+    else:
+        # Trying to connect to the DB
+        db.DatabaseHandler()
+        os.environ["HAS_DB_CONNECTION"] = "1"
+        print('DB CONNECTEDDDDDDDDDDDDDD')
+
+    logger.debug("Setting HAS_DB_CONNECTION = {}".format(os.environ["HAS_DB_CONNECTION"]))
 
 
 def pytest_sessionfinish(session, exitstatus):
+    """ Cleaning up output files before ending the pytest session. """
     os.system('./clean_files')

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,23 @@
+import os
+
+import simtools.config as cfg
+
+
+try:
+    cfg.loadConfig()
+except FileNotFoundError:
+    os.environ["HAS_CONFIG_FILE"] = "0"
+    os.environ["SIMTEL_INSTALLED"] = "0"
+    os.environ["HAS_DB_CONNECTION"] = "0"
+else:
+
+    os.environ["HAS_CONFIG_FILE"] = "1"
+
+    # Checking whether sim_telarray is properly installed
+    simtelPath = cfg.get("simtelPath")
+    simtelBinPath = simtelPath + "/sim_telarray/bin/sim_telarray"
+    os.environ["SIMTEL_INSTALLED"] = "1" if os.path.exists(simtelBinPath) else "0"
+
+    # Checking whether there is DB connection
+    useMongoDB = cfg.get("useMongoDB")
+    os.environ["HAS_DB_CONNECTION"] = "1" if useMongoDB else "0"

--- a/data/test-data/CTA-North-LST-1-Current_test-telescope-model.cfg
+++ b/data/test-data/CTA-North-LST-1-Current_test-telescope-model.cfg
@@ -1,0 +1,107 @@
+%==================================================
+% TELESCOPE CONFIGURATION FILE
+% Site: North
+% ModelVersion: Current
+% TelescopeModelName: LST-1
+% Label: test-telescope-model
+%==================================================
+%
+#ifdef TELESCOPE
+   echo Configuration for LST-1 - TELESCOPE $(TELESCOPE)
+#endif
+
+asum_clipping = 9999.0
+asum_offset = 0.0
+asum_shaping_file = none
+asum_threshold = 270.0
+camera_body_diameter = 348.0
+camera_body_shape = 2
+camera_config_file = camera_CTA-LST-234_analogsum21_v2020-04-14.dat
+camera_config_name = LST
+camera_config_version = 2020-06-28
+camera_filter = transmission_lst_window_No7-10_ave.dat
+camera_pixels = 1855
+camera_transmission = 1.0
+default_trigger = AnalogSum
+disc_bins = 68
+discriminator_amplitude = 6.5
+discriminator_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat
+disc_start = 3
+dish_shape_length = 2800.0
+effective_focal_length = 2930.57
+fadc_amplitude = 25.0
+fadc_bins = 75
+fadc_err_pedestal = 0.5
+fadc_lg_amplitude = 1.28
+fadc_lg_err_pedestal = 0.3
+fadc_lg_max_signal = 4288
+fadc_lg_noise = 5.7
+fadc_lg_pedestal = 400.0
+fadc_lg_var_pedestal = 0.4
+fadc_max_signal = 4249
+fadc_max_sum = 16777215
+fadc_mhz = 1024.0
+fadc_noise = 6.7
+fadc_pedestal = 400.0
+fadc_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat
+fadc_sum_bins = 40
+fadc_sum_offset = 9
+fadc_var_pedestal = 0.4
+fadc_var_sensitivity = 0.01416
+focal_length = 2800.0
+focus_offset = 6.55 28 0 0
+gain_variation = 0.0187
+min_photoelectrons = 25
+min_photons = 300.0
+mirror_align_random_distance = 0.0
+mirror_align_random_horizontal = 0.0039 28 0 0
+mirror_align_random_vertical = 0.0039 28 0 0
+mirror_focal_length = 0.0
+mirror_list = mirror_CTA-S-LST_v2020-04-07.dat
+mirror_offset = 93.25
+mirror_reflection_random_angle = 0.0075 0.125 0.037
+mirror_reflectivity = ref_LST_2020-04-23.dat
+nightsky_background = all: 0.25307
+num_gains = 2
+optics_config_name = LST
+optics_config_version = 2020-04-29
+output_format = 1
+parabolic_dish = 1
+photon_delay = 19
+pixel_cells = 0
+pm_average_gain = 40000.0
+pm_collection_efficiency = 1.0
+pm_gain_index = 3.92
+pm_photoelectron_spectrum = spe_LST_2020-05-09_AP2.0e-4.dat
+pm_transit_time = 20.89 9 350 1135
+pm_voltage_variation = 0.03
+pulse_analysis = -30
+qe_variation = 0.03
+quantum_efficiency = qe_lst2-4_20200318_high+low.dat
+random_focal_length = all: 0
+store_photoelectrons = 20
+sum_after_peak = 4
+sum_before_peak = 3
+tailcut_scale = 2.6
+telescope_random_angle = 0.0
+telescope_random_error = 0.0
+telescope_transmission = 0.969 0 0 0 0 0
+transit_time_jitter = 0.7
+trigger_current_limit = 20.0
+trigger_delay_compensation = all: 0
+trigger_telescopes = 1
+discriminator_threshold = 99999.0
+dsum_threshold = 0.0
+multiplicity_offset = -0.5
+teltrig_min_sigsum = 7.8
+teltrig_min_time = 0.5
+trigger_pixels = 3
+array_window = 1000.0
+convergent_depth = 0.0
+iobuf_maximum = 1000000000
+iobuf_output_maximum = 400000000
+nsb_scaling_factor = 1.0
+only_triggered_telescopes = 1
+altitude = 2158.0
+atmospheric_transmission = atm_trans_2158_1_3_2_0_0_0.1_0.1.dat
+array_triggers = array_trigger_prod5_lapalma_extended.dat

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -10,11 +10,13 @@ import astropy.units as u
 import simtools.io_handler as io
 from simtools.ray_tracing import RayTracing
 from simtools.model.telescope_model import TelescopeModel
+from simtools.util.tests import simtel_installed, SIMTEL_MSG
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 @pytest.mark.parametrize("telescopeModelName", ["sst-1M", "sst-ASTRI", "sst-GCT"])
 def test_ssts(telescopeModelName):
     # Test with 3 SSTs
@@ -36,6 +38,7 @@ def test_ssts(telescopeModelName):
     ray.analyze(force=True)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_rx():
     version = "current"
     label = "test-lst"
@@ -83,6 +86,7 @@ def test_rx():
     plt.savefig(plotFileArea)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_plot_image():
     version = "prod3"
     label = "test-astri"
@@ -112,6 +116,7 @@ def test_plot_image():
         plt.savefig(plotFile)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_single_mirror(plot=False):
 
     # Test MST, single mirror PSF simulation
@@ -139,6 +144,7 @@ def test_single_mirror(plot=False):
     plt.savefig(plotFile)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_integral_curve():
     version = "prod4"
     label = "lst_integral"
@@ -172,6 +178,7 @@ def test_integral_curve():
     plt.savefig(plotFile)
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_config_data():
 
     label = "test-config-data"
@@ -196,6 +203,7 @@ def test_config_data():
     assert len(ray.config.offAxisAngle) == 2
 
 
+@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_from_kwargs():
 
     label = "test-from-kwargs"

--- a/simtools/tests/test_ray_tracing.py
+++ b/simtools/tests/test_ray_tracing.py
@@ -203,20 +203,20 @@ def test_config_data():
     assert len(ray.config.offAxisAngle) == 2
 
 
-@pytest.mark.skipif(not simtel_installed(), reason=SIMTEL_MSG)
 def test_from_kwargs():
 
     label = "test-from-kwargs"
-    version = "prod4"
 
     sourceDistance = 10 * u.km
     zenithAngle = 30 * u.deg
     offAxisAngle = [0, 2] * u.deg
 
-    tel = TelescopeModel(
+    cfgFile = io.getTestDataFile("CTA-North-LST-1-Current_test-telescope-model.cfg")
+
+    tel = TelescopeModel.fromConfigFile(
         site="north",
-        telescopeModelName="mst-FlashCam-D",
-        modelVersion=version,
+        telescopeModelName="lst-1",
+        configFileName=cfgFile,
         label=label,
     )
 

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import pytest
 import logging
 import unittest
 
@@ -19,6 +20,7 @@ class TestTelescopeModel(unittest.TestCase):
             label="test-telescope-model",
         )
 
+    @pytest.mark.skipif(True, reason="TESTING")
     def test_handling_parameters(self):
         logger.info(
             "Old mirror_reflection_random_angle:{}".format(
@@ -47,85 +49,85 @@ class TestTelescopeModel(unittest.TestCase):
         )
         self.assertIsInstance(flenInfo["Value"], float)
 
-    def test_cfg_file(self):
-        # Exporting
-        self.telModel.exportConfigFile()
+    # def test_cfg_file(self):
+    #     # Exporting
+    #     self.telModel.exportConfigFile()
 
-        logger.info("Config file: {}".format(self.telModel.getConfigFile()))
+    #     logger.info("Config file: {}".format(self.telModel.getConfigFile()))
 
-        # Importing
-        cfgFile = self.telModel.getConfigFile()
-        tel = TelescopeModel.fromConfigFile(
-            site="south",
-            telescopeModelName="sst-d",
-            label="test-sst",
-            configFileName=cfgFile,
-        )
-        tel.exportConfigFile()
+    #     # Importing
+    #     cfgFile = self.telModel.getConfigFile()
+    #     tel = TelescopeModel.fromConfigFile(
+    #         site="south",
+    #         telescopeModelName="sst-d",
+    #         label="test-sst",
+    #         configFileName=cfgFile,
+    #     )
+    #     tel.exportConfigFile()
 
-    def test_updating_export_model_files(self):
-        """
-        It was found in derive_mirror_rnda_angle that the DB was being
-        accessed each time the model was changed, because the model
-        files were being re-exported. A flag called _isExportedModelFilesUpToDate
-        was added to prevent this behavior. This test is meant to assure
-        it is working properly.
-        """
+    # def test_updating_export_model_files(self):
+    #     """
+    #     It was found in derive_mirror_rnda_angle that the DB was being
+    #     accessed each time the model was changed, because the model
+    #     files were being re-exported. A flag called _isExportedModelFilesUpToDate
+    #     was added to prevent this behavior. This test is meant to assure
+    #     it is working properly.
+    #     """
 
-        # We need a brand new telescopeModel to avoid interference
-        tel = TelescopeModel(
-            site="North",
-            telescopeModelName="LST-1",
-            modelVersion="Current",
-            label="test-telescope-model-2",
-        )
+    #     # We need a brand new telescopeModel to avoid interference
+    #     tel = TelescopeModel(
+    #         site="North",
+    #         telescopeModelName="LST-1",
+    #         modelVersion="Current",
+    #         label="test-telescope-model-2",
+    #     )
 
-        logger.debug(
-            "tel._isExportedModelFiles should be False because exportConfigFile"
-            " was not called yet."
-        )
-        self.assertFalse(tel._isExportedModelFilesUpToDate)
+    #     logger.debug(
+    #         "tel._isExportedModelFiles should be False because exportConfigFile"
+    #         " was not called yet."
+    #     )
+    #     self.assertFalse(tel._isExportedModelFilesUpToDate)
 
-        # Exporting config file
-        tel.exportConfigFile()
-        logger.debug(
-            "tel._isExportedModelFiles should be True because exportConfigFile"
-            " was called."
-        )
-        self.assertTrue(tel._isExportedModelFilesUpToDate)
+    #     # Exporting config file
+    #     tel.exportConfigFile()
+    #     logger.debug(
+    #         "tel._isExportedModelFiles should be True because exportConfigFile"
+    #         " was called."
+    #     )
+    #     self.assertTrue(tel._isExportedModelFilesUpToDate)
 
-        # Changing a non-file parameter
-        logger.info(
-            "Changing a parameter that IS NOT a file - mirror_reflection_random_angle"
-        )
-        tel.changeParameter("mirror_reflection_random_angle", "0.0080 0 0")
-        logger.debug(
-            "tel._isExportedModelFiles should still be True because the changed "
-            "parameter was not a file"
-        )
-        self.assertTrue(tel._isExportedModelFilesUpToDate)
+    #     # Changing a non-file parameter
+    #     logger.info(
+    #         "Changing a parameter that IS NOT a file - mirror_reflection_random_angle"
+    #     )
+    #     tel.changeParameter("mirror_reflection_random_angle", "0.0080 0 0")
+    #     logger.debug(
+    #         "tel._isExportedModelFiles should still be True because the changed "
+    #         "parameter was not a file"
+    #     )
+    #     self.assertTrue(tel._isExportedModelFilesUpToDate)
 
-        # Testing the DB connection
-        logger.info("DB should NOT be read next.")
-        tel.exportConfigFile()
+    #     # Testing the DB connection
+    #     logger.info("DB should NOT be read next.")
+    #     tel.exportConfigFile()
 
-        # Changing a parameter that is a file
-        logger.debug(
-            "Changing a parameter that IS a file - camera_config_file"
-        )
-        tel.changeParameter(
-            "camera_config_file",
-            tel.getParameterValue("camera_config_file")
-        )
-        logger.debug(
-            "tel._isExportedModelFiles should be False because a parameter that "
-            "is a file was changed."
-        )
-        self.assertFalse(tel._isExportedModelFilesUpToDate)
+    #     # Changing a parameter that is a file
+    #     logger.debug(
+    #         "Changing a parameter that IS a file - camera_config_file"
+    #     )
+    #     tel.changeParameter(
+    #         "camera_config_file",
+    #         tel.getParameterValue("camera_config_file")
+    #     )
+    #     logger.debug(
+    #         "tel._isExportedModelFiles should be False because a parameter that "
+    #         "is a file was changed."
+    #     )
+    #     self.assertFalse(tel._isExportedModelFilesUpToDate)
 
-        # Testing the DB connection
-        logger.info("DB should be read next.")
-        tel.exportConfigFile()
+    #     # Testing the DB connection
+    #     logger.info("DB should be read next.")
+    #     tel.exportConfigFile()
 
 
 if __name__ == "__main__":

--- a/simtools/tests/test_telescope_model.py
+++ b/simtools/tests/test_telescope_model.py
@@ -4,7 +4,10 @@ import pytest
 import logging
 import unittest
 
+import simtools.io_handler as io
 from simtools.model.telescope_model import TelescopeModel, InvalidParameter
+from simtools.util.tests import has_db_connection, DB_CONNECTION_MSG
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -12,15 +15,15 @@ logger.setLevel(logging.DEBUG)
 
 class TestTelescopeModel(unittest.TestCase):
     def setUp(self):
+        cfgFile = io.getTestDataFile("CTA-North-LST-1-Current_test-telescope-model.cfg")
         self.label = "test-telescope-model"
-        self.telModel = TelescopeModel(
+        self.telModel = TelescopeModel.fromConfigFile(
             site="North",
             telescopeModelName="LST-1",
-            modelVersion="Current",
-            label="test-telescope-model",
+            label=self.label,
+            configFileName=cfgFile,
         )
 
-    @pytest.mark.skipif(True, reason="TESTING")
     def test_handling_parameters(self):
         logger.info(
             "Old mirror_reflection_random_angle:{}".format(
@@ -49,85 +52,87 @@ class TestTelescopeModel(unittest.TestCase):
         )
         self.assertIsInstance(flenInfo["Value"], float)
 
-    # def test_cfg_file(self):
-    #     # Exporting
-    #     self.telModel.exportConfigFile()
+    @pytest.mark.skipif(not has_db_connection(), reason=DB_CONNECTION_MSG)
+    def test_cfg_file(self):
+        # Exporting
+        self.telModel.exportConfigFile()
 
-    #     logger.info("Config file: {}".format(self.telModel.getConfigFile()))
+        logger.info("Config file: {}".format(self.telModel.getConfigFile()))
 
-    #     # Importing
-    #     cfgFile = self.telModel.getConfigFile()
-    #     tel = TelescopeModel.fromConfigFile(
-    #         site="south",
-    #         telescopeModelName="sst-d",
-    #         label="test-sst",
-    #         configFileName=cfgFile,
-    #     )
-    #     tel.exportConfigFile()
+        # Importing
+        cfgFile = self.telModel.getConfigFile()
+        tel = TelescopeModel.fromConfigFile(
+            site="south",
+            telescopeModelName="sst-d",
+            label="test-sst",
+            configFileName=cfgFile,
+        )
+        tel.exportConfigFile()
 
-    # def test_updating_export_model_files(self):
-    #     """
-    #     It was found in derive_mirror_rnda_angle that the DB was being
-    #     accessed each time the model was changed, because the model
-    #     files were being re-exported. A flag called _isExportedModelFilesUpToDate
-    #     was added to prevent this behavior. This test is meant to assure
-    #     it is working properly.
-    #     """
+    @pytest.mark.skipif(not has_db_connection(), reason=DB_CONNECTION_MSG)
+    def test_updating_export_model_files(self):
+        """
+        It was found in derive_mirror_rnda_angle that the DB was being
+        accessed each time the model was changed, because the model
+        files were being re-exported. A flag called _isExportedModelFilesUpToDate
+        was added to prevent this behavior. This test is meant to assure
+        it is working properly.
+        """
 
-    #     # We need a brand new telescopeModel to avoid interference
-    #     tel = TelescopeModel(
-    #         site="North",
-    #         telescopeModelName="LST-1",
-    #         modelVersion="Current",
-    #         label="test-telescope-model-2",
-    #     )
+        # We need a brand new telescopeModel to avoid interference
+        tel = TelescopeModel(
+            site="North",
+            telescopeModelName="LST-1",
+            modelVersion="Current",
+            label="test-telescope-model-2",
+        )
 
-    #     logger.debug(
-    #         "tel._isExportedModelFiles should be False because exportConfigFile"
-    #         " was not called yet."
-    #     )
-    #     self.assertFalse(tel._isExportedModelFilesUpToDate)
+        logger.debug(
+            "tel._isExportedModelFiles should be False because exportConfigFile"
+            " was not called yet."
+        )
+        self.assertFalse(tel._isExportedModelFilesUpToDate)
 
-    #     # Exporting config file
-    #     tel.exportConfigFile()
-    #     logger.debug(
-    #         "tel._isExportedModelFiles should be True because exportConfigFile"
-    #         " was called."
-    #     )
-    #     self.assertTrue(tel._isExportedModelFilesUpToDate)
+        # Exporting config file
+        tel.exportConfigFile()
+        logger.debug(
+            "tel._isExportedModelFiles should be True because exportConfigFile"
+            " was called."
+        )
+        self.assertTrue(tel._isExportedModelFilesUpToDate)
 
-    #     # Changing a non-file parameter
-    #     logger.info(
-    #         "Changing a parameter that IS NOT a file - mirror_reflection_random_angle"
-    #     )
-    #     tel.changeParameter("mirror_reflection_random_angle", "0.0080 0 0")
-    #     logger.debug(
-    #         "tel._isExportedModelFiles should still be True because the changed "
-    #         "parameter was not a file"
-    #     )
-    #     self.assertTrue(tel._isExportedModelFilesUpToDate)
+        # Changing a non-file parameter
+        logger.info(
+            "Changing a parameter that IS NOT a file - mirror_reflection_random_angle"
+        )
+        tel.changeParameter("mirror_reflection_random_angle", "0.0080 0 0")
+        logger.debug(
+            "tel._isExportedModelFiles should still be True because the changed "
+            "parameter was not a file"
+        )
+        self.assertTrue(tel._isExportedModelFilesUpToDate)
 
-    #     # Testing the DB connection
-    #     logger.info("DB should NOT be read next.")
-    #     tel.exportConfigFile()
+        # Testing the DB connection
+        logger.info("DB should NOT be read next.")
+        tel.exportConfigFile()
 
-    #     # Changing a parameter that is a file
-    #     logger.debug(
-    #         "Changing a parameter that IS a file - camera_config_file"
-    #     )
-    #     tel.changeParameter(
-    #         "camera_config_file",
-    #         tel.getParameterValue("camera_config_file")
-    #     )
-    #     logger.debug(
-    #         "tel._isExportedModelFiles should be False because a parameter that "
-    #         "is a file was changed."
-    #     )
-    #     self.assertFalse(tel._isExportedModelFilesUpToDate)
+        # Changing a parameter that is a file
+        logger.debug(
+            "Changing a parameter that IS a file - camera_config_file"
+        )
+        tel.changeParameter(
+            "camera_config_file",
+            tel.getParameterValue("camera_config_file")
+        )
+        logger.debug(
+            "tel._isExportedModelFiles should be False because a parameter that "
+            "is a file was changed."
+        )
+        self.assertFalse(tel._isExportedModelFilesUpToDate)
 
-    #     # Testing the DB connection
-    #     logger.info("DB should be read next.")
-    #     tel.exportConfigFile()
+        # Testing the DB connection
+        logger.info("DB should be read next.")
+        tel.exportConfigFile()
 
 
 if __name__ == "__main__":

--- a/simtools/util/tests.py
+++ b/simtools/util/tests.py
@@ -1,11 +1,11 @@
 import os
 
 
-CONFIG_FILE_MSG = "Configuration file is not available"
+CONFIG_FILE_MSG = "The simtools configuration file (config.yml) is not available"
 
-DB_CONNECTION_MSG = "There is not connection with DB"
+DB_CONNECTION_MSG = "Connection with the DB is not available"
 
-SIMTEL_MSG = "sim_telarray is not installed"
+SIMTEL_MSG = "sim_telarray installation is not available"
 
 
 def _collect_conftest_flag(name):

--- a/simtools/util/tests.py
+++ b/simtools/util/tests.py
@@ -1,0 +1,25 @@
+import os
+
+
+CONFIG_FILE_MSG = "Configuration file is not available"
+
+DB_CONNECTION_MSG = "There is not connection with DB"
+
+SIMTEL_MSG = "sim_telarray is not installed"
+
+
+def _collect_conftest_flag(name):
+    flag = os.environ.get(name, "0")
+    return (flag == "1")
+
+
+def has_config_file():
+    return _collect_conftest_flag("HAS_CONFIG_FILE")
+
+
+def has_db_connection():
+    return _collect_conftest_flag("HAS_DB_CONNECTION")
+
+
+def simtel_installed():
+    return _collect_conftest_flag("SIMTEL_INSTALLED")


### PR DESCRIPTION
Currently the tests run by pytest are strongly dependent on the DB connection and sim_telarray installation (which makes it hard to add it to a CI workflow). Ideally we should have "unit tests" independent of DB and simtel and "integration tests" specifics to each of them.

This PR presents a possible solution for this issue.

The general idea here is to mark the tests that require DB connection or sim_telarray installation and skip them, in case these are not available. This means that unit and integration tests will not be explicitly separated in the test modules, but they will be called separately depending on the availability of the DB and sim_telarray.

Why not separate all the test modules into unit and integration tests? First, this would mean rewriting all the tests modules and redesign them. Secondly, given the nature of our package (strong dependence with DB and sim_telarray), this separation can be quite difficult.

Now the technicalities.

Marking the tests in order to skip them is straightforward when using the the pytest decorator @pytest.mark.skipif. The more complicated step for us is to automatically identify whether the DB connection and sim_telarray installation are available.
I decided to do that by setting up a conftest.py file, that is loaded in the beginning of any pytest session. In this file I used the simtools config module to flag three things: a) the existence of the config file, b) the availability of the DB connection and c) the sim_telarray installation. 

a) is very simple. b) is also simple because we have a config entry called useMongoDB.
For c), I am looking at the sim_telarray path given in the config file and checking for the existence of the sim_telarray binary file.

The trick part was to pass these flags to the test modules. I tried to used pytest fixtures but it is not designed for that.
In the end I found a solution by using environment variables that are set in conftest.py and read by the modules. To encapsulate the reading of these variables I wrote some function in utils/tests.py.

Everything is working fine in the end. I have changed test_telescope_model and test_ray_tracing to exemplify how the test modules should me modified.

The next step is to add the skipif decorator to all test modules and also redesign some test modules in order to remove the dependence with the DB and simtel.

In summary, this is how our test setup will look like if this solution is accepted:

- The test modules run by pytest will contain unit tests and integration tests (DB and sim_telarray).
- If pytest is run in a environment without DB connection and sim_telarray installation (e.g. a CI environment), only the unit tests will be performed.
- Note that DB connection and sim_telarray are independent, so an environment may have only one of them available and only the respective integration tests will be run.