### PR TITLE
Adding test flag to simtel_histograms in order to make tests faster

### DIFF
--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -34,7 +34,7 @@ class SimtelHistograms:
         List of histogram data.
     """
 
-    def __init__(self, histogramFiles):
+    def __init__(self, histogramFiles, test=False):
         """
         SimtelHistograms
 
@@ -42,10 +42,13 @@ class SimtelHistograms:
         ----------
         histogramFiles: list
             List of sim_telarray histogram files (str of Path).
-
+        test: bool
+            If True, only a fraction of the histograms will be processed, leading to \
+        a much shorter runtime.
         """
         self._logger = logging.getLogger(__name__)
         self._histogramFiles = histogramFiles
+        self._isTest = test
 
     def plotAndSaveFigures(self, figName):
         """
@@ -144,6 +147,13 @@ class SimtelHistograms:
 
         pdfPages = PdfPages(figName)
         for iHist in range(len(self.combinedHists)):
+
+            # Test case: processing only 1/5 of the histograms
+            if self._isTest and iHist % 5 != 0:
+                self._logger.debug(
+                    "Skipping (test=True): {}".format(self.combinedHists[iHist]["title"])
+                )
+                continue
 
             self._logger.debug(
                 "Processing: {}".format(self.combinedHists[iHist]["title"])

--- a/simtools/tests/test_simtel_histograms.py
+++ b/simtools/tests/test_simtel_histograms.py
@@ -22,9 +22,7 @@ def test_histograms():
         )
     )
 
-    print(histogram_files)
-
-    hists = SimtelHistograms(histogramFiles=histogram_files)
+    hists = SimtelHistograms(histogramFiles=histogram_files, test=True)
 
     figName = io.getTestPlotFile("simtelHistograms.pdf")
     hists.plotAndSaveFigures(figName=figName)


### PR DESCRIPTION
Simple change to add a test flag to simtel_histograms to make tests faster. When test=True, only a fraction (1/5) of the histograms are processed.