### PR TITLE
Add a CITATION file and connect to Zenodo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: >-
+  gammasim-tools - a prototype implementation of
+  tools for the Simulation System of the CTA
+  Observatory
+message: Please cite this software using these metadata.
+type: software
+authors:
+  - orcid: 'https://orcid.org/0000-0001-9152-2995'
+    affiliation: DESY
+    given-names: Raul
+    name-particle: R.
+    family-names: Prado
+  - given-names: Orel
+    family-names: Gueta
+    orcid: 'https://orcid.org/0000-0002-9440-2398'
+    affiliation: DESY
+  - given-names: Gernot
+    family-names: Maier
+    affiliation: DESY
+    orcid: 'https://orcid.org/0000-0001-9868-4700'
+repository-code: 'https://github.com/gammasim/gammasim-tools'
+license: BSD-3-Clause


### PR DESCRIPTION
Allow this software to be cited.

Added a minimal citation file.

After merging, the next steps will be:

- connect this github repository to Zenodo
- release a new version (I think we should start release more often; 0.1.0 was in 2019!!)
- update the CITATION file to add the persistent identifier provided by Zenodo

Citation file has been created using the tool linked from https://citation-file-format.github.io/
