### PR TITLE
Add image plotting to validate optics (was fix effective focal length)

### DIFF
--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -39,6 +39,8 @@
         Zenith angle in deg (default=20).
     max_offset (float, optional)
         Maximum offset angle in deg (default=4).
+    plot_images (activation mode, optional)
+        Produce a multiple pages pdf file with the image plots.
     test (activation mode, optional)
         If activated, application will be faster by simulating fewer photons.
     verbosity (str, optional)
@@ -53,10 +55,6 @@
     .. code-block:: console
 
         python applications/validate_optics.py --site North --telescope LST-1 --max_offset 5.0
-
-    .. todo::
-
-        * Change default model to default (after this feature is implemented in db_handler)
 """
 
 import logging
@@ -99,7 +97,7 @@ if __name__ == "__main__":
         "--model_version",
         help="Model version (default=prod4)",
         type=str,
-        default="prod4",
+        default="Current",
     )
     parser.add_argument(
         "--src_distance",

--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
         telescopeModel=telModel,
         sourceDistance=args.src_distance * u.km,
         zenithAngle=args.zenith * u.deg,
-        offAxisAngle=np.linspace(0, args.max_offset, int(args.max_offset / 1.0) + 1)
+        offAxisAngle=np.linspace(0, args.max_offset, int(args.max_offset / 0.25) + 1)
         * u.deg,
     )
     ray.simulate(test=args.test, force=False)

--- a/simtools/psf_analysis.py
+++ b/simtools/psf_analysis.py
@@ -415,6 +415,9 @@ class PSFImage:
         circle = plt.Circle(center, self.getPSF(0.8) / 2, **kwargsForPSF)
         ax.add_artist(circle)
 
+        ax.axhline(0, color="k", linestyle="--", zorder=3, linewidth=0.5)
+        ax.axvline(0, color="k", linestyle="--", zorder=3, linewidth=0.5)
+
     def getCumulativeData(self, radius=None):
         """
         Provide cumulative data (intensity vs radius).

--- a/simtools/psf_analysis.py
+++ b/simtools/psf_analysis.py
@@ -408,6 +408,7 @@ class PSFImage:
         ax = plt.gca()
         # Image histogram
         ax.hist2d(data["X"], data["Y"], **kwargsForImage)
+        ax.set_aspect("equal", "datalim")
 
         # PSF circle
         center = (0, 0) if centralized else (self.centroidX, self.centroidY)

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -3,7 +3,7 @@ import subprocess
 import matplotlib.pyplot as plt
 from copy import copy
 from pathlib import Path
-from math import pi, tan
+from math import pi, tan, sqrt
 
 import numpy as np
 import astropy.units as u
@@ -327,10 +327,12 @@ class RayTracing:
                     centroidY = image.centroidY
                     effArea = image.getEffectiveArea() * telTransmission
 
+                centroidR = sqrt(centroidX * centroidX + centroidY * centroidY)
+
                 effFlen = (
                     np.nan
                     if thisOffAxis == 0
-                    else centroidX / tan(thisOffAxis * pi / 180.0)
+                    else centroidR / tan(thisOffAxis * pi / 180.0)
                 )
                 _currentResults = (
                     thisOffAxis * u.deg,

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -3,7 +3,7 @@ import subprocess
 import matplotlib.pyplot as plt
 from copy import copy
 from pathlib import Path
-from math import pi, tan, sqrt
+from math import pi, tan
 
 import numpy as np
 import astropy.units as u

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -327,12 +327,10 @@ class RayTracing:
                     centroidY = image.centroidY
                     effArea = image.getEffectiveArea() * telTransmission
 
-                centroidR = sqrt(centroidX * centroidX + centroidY * centroidY)
-
                 effFlen = (
                     np.nan
                     if thisOffAxis == 0
-                    else centroidR / tan(thisOffAxis * pi / 180.0)
+                    else centroidX / tan(thisOffAxis * pi / 180.0)
                 )
                 _currentResults = (
                     thisOffAxis * u.deg,


### PR DESCRIPTION
I started investigating this issue by plotting the images. I added a argument to the validate_optics to allow for that.

I then ran the app with LST-1 and got the images attached. I noticed that there is a small shift of the centroid in the Y direction as well. So I decided to calculate the eff focal length with the radius of the centroid instead and it seems to have fixed the calculation. See attached the new eff focal length plot. 
[validate_optics_LST-1_images.pdf](https://github.com/gammasim/gammasim-tools/files/8251883/validate_optics_LST-1_images.pdf)
[validate_optics_LST-1_eff_flen.pdf](https://github.com/gammasim/gammasim-tools/files/8251884/validate_optics_LST-1_eff_flen.pdf)


Now the question is where this shift in Y comes from and whether it is supposed to exist or not. We should continue digging to understand that.