### PR TITLE
Prototype for setting workflow

### DIFF
--- a/applications/set_quantum_efficiency_from_external.py
+++ b/applications/set_quantum_efficiency_from_external.py
@@ -23,8 +23,8 @@
     .. code-block:: console
 
         python ./set_quantum_efficiency_from_external.py \
-            --workflow_schema set_quantum_efficiency_from_external.yml \
-            --input_meta qe_R12992-100-05b.usermeta.yml \
+            --workflow_schema_file set_quantum_efficiency_from_external.yml \
+            --input_meta_file qe_R12992-100-05b.usermeta.yml \
 
 
 """
@@ -35,6 +35,33 @@ import logging
 import simtools.config as cfg
 import simtools.io_handler as io
 import simtools.util.general as gen
+import simtools.util.input_validation as validator
+
+def transformInput(
+    workflow_schema_file,
+    input_meta_file):
+    """
+    data transformation for simulation model data
+
+    includes:
+    -
+    - schema validation
+    - data validation
+    - data cleaning
+    - data conversion to standard units
+    - metadata enrichment
+    """
+
+    input_meta = gen.collectDataFromYamlOrDict(
+        input_meta_file,
+        None)
+    _schema_validator = validator.SchemaValidator(
+        workflow_schema_file,
+        input_meta)
+    _schema_validator.validate()
+
+    return None, None
+
 
 if __name__ == "__main__":
 
@@ -45,14 +72,14 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-w",
-        "--workflow_schema",
+        "--workflow_schema_file",
         help="workflow description",
         type=str,
         required=True,
     )
     parser.add_argument(
         "-m",
-        "--input_meta",
+        "--input_meta_file",
         help="User-provided meta data file (yml)",
         type=str,
         required=True,
@@ -76,9 +103,9 @@ if __name__ == "__main__":
     logger.info("Outputdirectory {}".format(outputDir))
 
     # validate, transform, clean, enrich user metadata and data
-#    output_meta, output_data = transformInput(
-#        args.workflow_schema,
-#        args.input_meta)
+    output_meta, output_data = transformInput(
+        args.workflow_schema_file,
+        args.input_meta_file)
 
     # write model data in the format expected
 #    writeModelData(

--- a/applications/set_quantum_efficiency_from_external.py
+++ b/applications/set_quantum_efficiency_from_external.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python3
+
+"""
+    Summary
+    -------
+    Setting workflow for photodetector / quantum efficiency
+
+
+    Command line arguments
+    ----------------------
+    workflow_schema (str, required)
+        Workflow description (yml format)
+    input_meta (str, required)
+        User-provided meta data file (yml format)
+    input_data (str, required)
+        User-provided data file (ecsv format)
+    verbosity (str, optional)
+        Log level to print (default=INFO).
+
+    Example
+    -------
+
+    Runtime 1 min
+
+    .. code-block:: console
+
+        python ./set_quantum_efficiency_from_external.py \
+            --workflow_schema set_quantum_efficiency_from_external.yml \
+            --input_meta qe_R12992-100-05b.meta.yml \
+            --input_data qe_R12992-100-05b.meta.ecsv
+
+
+"""
+
+import argparse
+import logging
+
+import simtools.config as cfg
+import simtools.io_handler as io
+import simtools.util.general as gen
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Setting workflow for photodetector / quantum efficiency. "
+        )
+    )
+    parser.add_argument(
+        "-w",
+        "--workflow_schema",
+        help="workflow description",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "-m",
+        "--input_meta",
+        help="User-provided meta data file (yml)",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "-d",
+        "--input_data",
+        help="User-provided data file (ecsv)",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        dest="logLevel",
+        action="store",
+        default="info",
+        help="Log level to print (default is INFO)",
+    )
+
+    args = parser.parse_args()
+    label = "set_quantum_efficiency_from_external"
+
+    logger = logging.getLogger()
+    logger.setLevel(gen.getLogLevelFromUser(args.logLevel))
+
+    outputDir = io.getApplicationOutputDirectory(cfg.get("outputLocation"), label)
+    logger.info("Outputdirectory {}".format(outputDir))
+
+    # validate, transform, clean, enrich user metadata and data
+#    output_meta, output_data = transformInput(
+#        args.workflow_schema,
+#        args.input_meta,
+#        args.input_data)
+
+    # write model data in the format expected 
+#    writeModelData(
+#        output_meta,
+#        output_data)

--- a/applications/set_quantum_efficiency_from_external.py
+++ b/applications/set_quantum_efficiency_from_external.py
@@ -12,8 +12,6 @@
         Workflow description (yml format)
     input_meta (str, required)
         User-provided meta data file (yml format)
-    input_data (str, required)
-        User-provided data file (ecsv format)
     verbosity (str, optional)
         Log level to print (default=INFO).
 
@@ -26,8 +24,7 @@
 
         python ./set_quantum_efficiency_from_external.py \
             --workflow_schema set_quantum_efficiency_from_external.yml \
-            --input_meta qe_R12992-100-05b.meta.yml \
-            --input_data qe_R12992-100-05b.meta.ecsv
+            --input_meta qe_R12992-100-05b.usermeta.yml \
 
 
 """
@@ -61,13 +58,6 @@ if __name__ == "__main__":
         required=True,
     )
     parser.add_argument(
-        "-d",
-        "--input_data",
-        help="User-provided data file (ecsv)",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
         "-v",
         "--verbosity",
         dest="logLevel",
@@ -88,10 +78,9 @@ if __name__ == "__main__":
     # validate, transform, clean, enrich user metadata and data
 #    output_meta, output_data = transformInput(
 #        args.workflow_schema,
-#        args.input_meta,
-#        args.input_data)
+#        args.input_meta)
 
-    # write model data in the format expected 
+    # write model data in the format expected
 #    writeModelData(
 #        output_meta,
 #        output_data)

--- a/simtools/tests/test_input_validation.py
+++ b/simtools/tests/test_input_validation.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+import pytest
+import logging
+
+import simtools.util.input_validation as validator
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+def test__validate_data_type_datetime():
+
+    date_validator = validator.SchemaValidator(None, None)
+
+    date_key = 'CREATION_TIME'
+    date_schema1 = {'type': 'datetime'}
+
+    # tests should succeed
+    date_validator._validate_data_type(
+        date_schema1, date_key, '2018-03-01 12:00:00')
+
+    # tests should fail
+    date_data1 = '2018-03-01 12:00'
+    with pytest.raises(
+        ValueError,
+        match=r"invalid date format. Expected %Y-%m-%d %H:%M:%S; Found 2018-03-01 12:00"):
+            date_validator._validate_data_type(date_schema1, date_key, date_data1)
+
+
+def test__validate_data_type_email():
+
+    date_validator = validator.SchemaValidator(None, None)
+
+    email_key = 'EMAIL'
+    email_schema1 = {'type': 'email'}
+
+    # tests should suceed
+    date_validator._validate_data_type(
+        email_schema1, email_key, 'me@blabla.de')
+
+    # tests should fail
+    with pytest.raises(
+        ValueError,
+        match=r"invalid email format in field EMAIL: me-blabla.de"):
+            date_validator._validate_data_type(email_schema1, email_key, 'me-blabla.de')
+
+# TODO
+# several missing tests

--- a/simtools/util/input_validation.py
+++ b/simtools/util/input_validation.py
@@ -1,0 +1,109 @@
+import datetime
+import logging
+
+import simtools.util.general as gen
+
+class SchemaValidator:
+    """
+    Validate a dictionary against a reference schema
+
+    """
+
+    def __init__(self, reference_schema_file, data_dict):
+        """
+        Initalize validation class and read required
+        reference schema
+
+        Parameters:
+        -----------
+        reference_schema: dict
+            reference schema
+        data_dict: dict
+            dictionary to be validated
+
+        """
+
+        self._logger = logging.getLogger(__name__)
+
+        self._reference_schema = gen.collectDataFromYamlOrDict(
+            reference_schema_file, None)
+        self.data_dict = data_dict
+
+    def validate(self):
+        """
+        Schema validation
+
+        """
+        self._validate_schema(
+            self._reference_schema,
+            self.data_dict)
+
+    def _validate_data_type(self, schema, key, data_field):
+        """
+        Validate data type against the expected data type
+        from schema
+
+        Raises value error if data types are inconsistent
+        """
+
+        if schema['type'] == 'datetime':
+            format = "%Y-%m-%d %H:%M:%S"
+            print('AAAA', data_field)
+            try:
+                datetime.datetime.strptime(data_field, format)
+            except:
+                raise ValueError(
+                    'invalid date format. Expected {}; Found {}'.format(
+                        format, data_field))
+            self._logger.debug('checking {} for datetime'.format(key))
+
+        # TODO
+        self._logger.debug('data type checking to be fixed {}'.format(schema['type']))
+        return None
+
+        if not str(type(data_field)) is schema['type']:
+            raise ValueError(
+                'invalid data type for key {}. Expected: {}, Found: {}'.format(
+                    key, schema['type'], type(data_field)))
+
+    def _check_if_field_is_optional(self, key, value):
+        """
+        Check if data field is labeled as not required in
+        the reference schema
+
+        Assume that any field which is not label as required
+        is optional
+
+        Raises value error if required field is missing
+
+        """
+
+        if isinstance(value, dict) \
+                and 'required' in value \
+                and value['required']:
+            raise ValueError(
+                'required data field {} not found')
+
+        self._logger.debug(
+            'checking optional key {}'.format(key))
+
+    def _validate_schema(
+            self,
+            ref_schema,
+            data_dict):
+        """
+        Validate schema for data types and required fields
+
+        """
+
+        for key, value in ref_schema.items():
+            if data_dict and key in data_dict:
+                _this_data = data_dict[key]
+            else:
+                self._check_if_field_is_optional(key, value)
+                return None
+            if isinstance(value, dict) and 'type' in value:
+                self._validate_data_type(
+                    value, key, _this_data)
+            else:
+                self._validate_schema(value, _this_data)


### PR DESCRIPTION
Prototype for a setting workflow which should allow to:

- submit data and metadata using a yaml / ecsv file
- test metadata schema against a reference scheme, as seen e.g. [here](https://gitlab.cta-observatory.org/cta-computing/dpps/simulationpipeline/prototypes/notes/simulation-project-metadata-and-formats/-/blob/setting_workflow/SetParameterFromExternal.userinput-schema.yml)
- input data validation and if necessary transformation

Implemented on the example of `set_quantum_efficiency_from_external.py` (very likely could be a generic setting workflow; example of qe meta is [here](https://gitlab.cta-observatory.org/cta-computing/dpps/simulationpipeline/prototypes/notes/simulation-project-metadata-and-formats/-/blob/setting_workflow/quantum_efficiency/qe_R12992-100-05b.usermeta.yml)).

Will need a lot of refinements.



