### PR TITLE
Remove requirement for python <=3.8 and increase test matrix to newer versions

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
       - name: checkout

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # A conda environment with all useful package for ctamclib developers
 name: gammasim-tools-dev
 dependencies:
-  - python<=3.8
+  - python
   - pyyaml
   - numpy
   - astropy


### PR DESCRIPTION
Added python 3.9 and 3.10 to test matrix.

Let's see if tests fail or if we really need the original requirement of python <=3.8