### PR TITLE
Remove config.yml from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Local config.yml
-config.yml
-
 # Produced files
 simtools-files
 telarray_rand.conf.used


### PR DESCRIPTION
Motivation: very often local changes in config.yml lead to execution failures. As changes do not appear when running `git status`, there are often over looked and lead to long error searches.

(note the wrong name of the branch)