### PR TITLE
Add configurable containment radius to derive_mirror_rnda; setting workflow with association IDs

### DIFF
--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -138,6 +138,19 @@ def plotMeasuredDistribution(file, **kwargs):
     ax.hist(data, **kwargs)
 
 
+def efficiency_interval(value):
+    """
+    Argument parser check that value is an efficiency in the interval [0,1]
+
+    """
+    fvalue = float(value)
+    if fvalue < 0. or fvalue > 1.:
+        raise argparse.ArgumentTypeError(
+            "{} outside of allowed [0,1] interval".format(value))
+
+    return fvalue
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
@@ -169,7 +182,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--containment_fraction",
         help="Containment fraction for diameter calculation (in interval 0,1)",
-        type=float, required=False,
+        type=efficiency_interval, required=False,
         default=0.8,
     )
     parser.add_argument(

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -5,7 +5,8 @@
     -------
     This application derives the parameter mirror_reflection_random_angle \
     (mirror roughness, also called rnda here) \
-    for a given set of measured D80 of individual mirrors. The mean value of the measured D80 \
+    for a given set of measured photon containment diameter (e.g. 80\% containment, D80)
+    of individual mirrors.  The mean value of the measured containment diameters \
     in cm is required and its sigma can be given optionally but will only be used for plotting. \
 
     The individual mirror focal length can be taken into account if a mirror list which contains \
@@ -17,11 +18,11 @@
     from the :ref:`Model Parameters DB` \
     (or alternatively one may want to set it using the argument rnda).\
     Secondly, ray tracing simulations are performed for single mirror configurations for each \
-    mirror given in the mirror_list. The mean simulated D80 for all the mirrors is compared with \
-    the mean measured D80. A new value of rnda is then defined based on the sign of \
-    the difference between measured and simulated D80 and a new set of simulations \
-    is performed. This process repeat until the sign of the difference changes, \
-    meaning that the two final values of rnda brackets the optimal. These \
+    mirror given in the mirror_list. The mean simulated containment diameter for all the mirrors \
+    is compared with the mean measured containment diameter. A new value of rnda is then defined \
+    based on the sign of the difference between measured and simulated containment diameters and a \
+    new set of simulations is performed. This process repeat until the sign of the \
+    difference changes, meaning that the two final values of rnda brackets the optimal. These \
     two values are used to find the optimal one by a linear \
     interpolation. Finally, simulations are performed by using the the interpolated value \
     of rnda, which is defined as the desired optimal.
@@ -29,8 +30,8 @@
     A option no_tuning can be used if one only wants to simulate one value of rnda and compare \
     the results with the measured ones.
 
-    The results of the tuning are plotted. See examples of the D80 vs rnda plot, on the left, \
-    and the D80 distributions, on the right.
+    The results of the tuning are plotted. See examples of the containment diameter \
+    D80 vs rnda plot, on the left, and the D80 distributions, on the right. \
 
     .. _deriva_rnda_plot:
     .. image:: images/derive_mirror_rnda_North-MST-FlashCam-D.png
@@ -38,16 +39,22 @@
     .. image:: images/derive_mirror_rnda_North-MST-FlashCam-D_D80-distributions.png
       :width: 49 %
 
+    This application uses the following simulation software tools:
+        - sim_telarray/bin/sim_telarray
+        - sim_telarray/bin/rx (optional)
+
     Command line arguments
     ----------------------
     telescope (str, required)
         Telescope name (e.g. North-LST-1, South-SST-D, ...)
     model_version (str, optional)
         Model version (default=prod4)
-    mean_d80 (float, required)
-        Mean of measured D80 [cm]
-    sig_d80 (float, optional)
-        Std dev of measured D80 [cm]
+    containment_mean (float, required)
+        Mean of measured containment diameter [cm]
+    containment_sigma (float, optional)
+        Std dev of measured containment diameter [cm]
+    containment_fraction (float, required)
+        Containment fractio for diameter calculation (typically 0.8)
     rnda (float, optional)
         Starting value of mirror_reflection_random_angle. If not given, the value from the \
         default model will be used.
@@ -80,7 +87,7 @@
     .. code-block:: console
 
         python applications/derive_mirror_rnda.py --site North --telescope MST-FlashCam-D \
-            --mean_d80 1.4 --sig_d80 0.16 \
+            --containment_mean 1.4 --containment_sigma 0.16 --containment_fraction 0.8 \
             --mirror_list mirror_MST_focal_lengths.dat --d80_list mirror_MST_D80.dat \
             --rnda 0.0075
 
@@ -89,10 +96,10 @@
 
     .. code-block:: console
 
-        Measured D80:
+        Measured Containment Diameter (80% containment):
         Mean = 1.400 cm, StdDev = 0.160 cm
 
-        Simulated D80:
+        Simulated Containment Diameter (80% containment):
         Mean = 1.401 cm, StdDev = 0.200 cm
 
         mirror_random_reflection_angle
@@ -150,10 +157,20 @@ if __name__ == "__main__":
         default="Current",
     )
     parser.add_argument(
-        "--mean_d80", help="Mean of measured D80 [cm]", type=float, required=True
+        "--containment_mean",
+        help="Mean of measured containment diameter [cm]",
+        type=float, required=True
     )
     parser.add_argument(
-        "--sig_d80", help="Std dev of measured D80 [cm]", type=float, required=False
+        "--containment_sigma",
+        help="Std dev of measured containment diameter [cm]",
+        type=float, required=False
+    )
+    parser.add_argument(
+        "--containment_fraction",
+        help="Containment fraction for diameter calculation (in interval 0,1)",
+        type=float, required=False,
+        default=0.8,
     )
     parser.add_argument(
         "--d80_list",
@@ -195,12 +212,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--no_tuning",
-        help="Turn off the tuning - A single case will be simulated and plotted.",
+        help="no tuning of random_reflection_rangle - A single case will be simulated and plotted.",
         action="store_true",
     )
     parser.add_argument(
         "--test",
-        help="Test option will be faster by simulating only 10 mirrors.",
+        help="Test option for faster simulations of only 10 mirrors.",
         action="store_true",
     )
     parser.add_argument(
@@ -213,6 +230,7 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    containment_fraction_percent = int(args.containment_fraction*100)
     label = "derive_mirror_rnda"
 
     logger = logging.getLogger()
@@ -234,6 +252,8 @@ if __name__ == "__main__":
     if args.random_flen is not None:
         tel.changeParameter("random_focal_length", str(args.random_flen))
 
+
+
     def run(rnda, plot=False):
         """Runs the simulations for one given value of rnda"""
         tel.changeParameter("mirror_reflection_random_angle", str(rnda))
@@ -246,7 +266,7 @@ if __name__ == "__main__":
         ray.simulate(test=False, force=True)  # force has to be True, always
         ray.analyze(force=True)
 
-        # Plotting D80 histograms
+        # Plotting containment histograms
         if plot:
             plt.figure(figsize=(8, 6), tight_layout=True)
             ax = plt.gca()
@@ -309,12 +329,12 @@ if __name__ == "__main__":
         stop = False
         meanD80, sigD80 = run(rndaStart)
         rnda = rndaStart
-        signDelta = np.sign(meanD80 - args.mean_d80)
+        signDelta = np.sign(meanD80 - args.containment_mean)
         collectResults(rnda, meanD80, sigD80)
         while not stop:
             newRnda = rnda - (0.1 * rndaStart * signDelta)
             meanD80, sigD80 = run(newRnda)
-            newSignDelta = np.sign(meanD80 - args.mean_d80)
+            newSignDelta = np.sign(meanD80 - args.containment_mean)
             stop = newSignDelta != signDelta
             signDelta = newSignDelta
             rnda = newRnda
@@ -324,7 +344,7 @@ if __name__ == "__main__":
         resultsRnda, resultsMean, resultsSig = gen.sortArrays(
             resultsRnda, resultsMean, resultsSig
         )
-        rndaOpt = np.interp(x=args.mean_d80, xp=resultsMean, fp=resultsRnda)
+        rndaOpt = np.interp(x=args.containment_mean, xp=resultsMean, fp=resultsRnda)
     else:
         rndaOpt = rndaStart
 
@@ -332,14 +352,15 @@ if __name__ == "__main__":
     meanD80, sigD80 = run(rndaOpt, plot=True)
 
     # Printing results to stdout
-    print("\nMeasured D80:")
-    if args.sig_d80 is not None:
+    print("\nMeasured D{:}:".format(containment_fraction_percent))
+    if args.containment_sigma is not None:
         print(
-            "Mean = {:.3f} cm, StdDev = {:.3f} cm".format(args.mean_d80, args.sig_d80)
+            "Mean = {:.3f} cm, StdDev = {:.3f} cm".format(
+                args.containment_mean, args.containment_sigma)
         )
     else:
-        print("Mean = {:.3f} cm".format(args.mean_d80))
-    print("\nSimulated D80:")
+        print("Mean = {:.3f} cm".format(args.containment_mean))
+    print("\nSimulated D{:}:".format(containment_fraction_percent))
     print("Mean = {:.3f} cm, StdDev = {:.3f} cm".format(meanD80, sigD80))
     print("\nmirror_random_reflection_angle")
     print("Previous value = {:.6f}".format(rndaStart))
@@ -349,7 +370,7 @@ if __name__ == "__main__":
     plt.figure(figsize=(8, 6), tight_layout=True)
     ax = plt.gca()
     ax.set_xlabel(r"mirror$\_$random$\_$reflection$\_$angle")
-    ax.set_ylabel(r"$D_{80}$ [cm]")
+    ax.set_ylabel(f"containment diameter $D_{{{containment_fraction_percent}}}$ [cm]")
 
     if not args.no_tuning:
         ax.errorbar(
@@ -367,24 +388,26 @@ if __name__ == "__main__":
         color="r",
         marker="o",
         linestyle="none",
-        label="rnda = {:.6f} (D80 = {:.3f} +/- {:.3f} cm)".format(
-            rndaOpt, meanD80, sigD80
+        label="rnda = {:.6f} (D{:} = {:.3f} +/- {:.3f} cm)".format(
+            rndaOpt, int(args.containment_fraction*100), meanD80, sigD80
         ),
     )
 
     xlim = ax.get_xlim()
-    ax.plot(xlim, [args.mean_d80, args.mean_d80], color="k", linestyle="-")
-    if args.sig_d80 is not None:
+    ax.plot(xlim, [args.containment_mean, args.containment_mean], color="k", linestyle="-")
+    if args.containment_sigma is not None:
         ax.plot(
             xlim,
-            [args.mean_d80 + args.sig_d80, args.mean_d80 + args.sig_d80],
+            [args.containment_mean + args.containment_sigma,
+             args.containment_mean + args.containment_sigma],
             color="k",
             linestyle=":",
             marker=",",
         )
         ax.plot(
             xlim,
-            [args.mean_d80 - args.sig_d80, args.mean_d80 - args.sig_d80],
+            [args.containment_mean - args.containment_sigma,
+             args.containment_mean - args.containment_sigma],
             color="k",
             linestyle=":",
             marker=",",

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -79,7 +79,10 @@
 
     .. code-block:: console
 
-        python applications/derive_mirror_rnda.py --site North --telescope MST-FlashCam-D --mean_d80 1.4 --sig_d80 0.16 --mirror_list mirror_MST_focal_lengths.dat --d80_list mirror_MST_D80.dat --rnda 0.0075
+        python applications/derive_mirror_rnda.py --site North --telescope MST-FlashCam-D \
+            --mean_d80 1.4 --sig_d80 0.16 \
+            --mirror_list mirror_MST_focal_lengths.dat --d80_list mirror_MST_D80.dat \
+            --rnda 0.0075
 
 
     Expected output:
@@ -142,9 +145,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m",
         "--model_version",
-        help="Model version (default=prod4)",
+        help="Model version (default=Current)",
         type=str,
-        default="prod4",
+        default="Current",
     )
     parser.add_argument(
         "--mean_d80", help="Mean of measured D80 [cm]", type=float, required=True

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -246,7 +246,12 @@ class RayTracing:
 
     # END of simulate
 
-    def analyze(self, export=True, force=False, useRX=False, noTelTransmission=False):
+    def analyze(self,
+                export=True,
+                force=False,
+                useRX=False,
+                noTelTransmission=False,
+                containment_fraction=0.8):
         """
         Analyze RayTracing, meaning read simtel files, compute psfs and eff areas and store the
         results in _results.
@@ -263,6 +268,9 @@ class RayTracing:
             calculations are done internally, by the module psf_analysis.
         noTelTransmission: bool
             If True, the telescope transmission is not applied.
+        containment_fraction: float
+            Containment fraction for PSF containment calculation. Allowed values are in the
+            inverval [0,1]
         """
 
         doAnalyze = not self._fileResults.exists() or force
@@ -314,15 +322,17 @@ class RayTracing:
                     continue
 
                 if useRX:
-                    d80_cm, centroidX, centroidY, effArea = self._processRX(photonsFile)
-                    d80_deg = d80_cm * cmToDeg
-                    image.setPSF(d80_cm, fraction=0.8, unit="cm")
+                    containment_diameter_cm, centroidX, centroidY, effArea = \
+                        self._processRX(photonsFile)
+                    containment_diameter_deg = containment_diameter_cm * cmToDeg
+                    image.setPSF(containment_diameter_cm,
+                                 fraction=containment_fraction, unit="cm")
                     image.centroidX = centroidX
                     image.centroidY = centroidY
                     image.setEffectiveArea(effArea * telTransmission)
                 else:
-                    d80_cm = image.getPSF(0.8, "cm")
-                    d80_deg = image.getPSF(0.8, "deg")
+                    containment_diameter_cm = image.getPSF(containment_fraction, "cm")
+                    containment_diameter_deg = image.getPSF(containment_fraction, "deg")
                     centroidX = image.centroidX
                     centroidY = image.centroidY
                     effArea = image.getEffectiveArea() * telTransmission
@@ -334,8 +344,8 @@ class RayTracing:
                 )
                 _currentResults = (
                     thisOffAxis * u.deg,
-                    d80_cm * u.cm,
-                    d80_deg * u.deg,
+                    containment_diameter_cm * u.cm,
+                    containment_diameter_deg * u.deg,
                     effArea * u.m * u.m,
                     effFlen * u.cm,
                 )
@@ -358,33 +368,36 @@ class RayTracing:
 
     # END of analyze
 
-    def _processRX(self, file):
+    def _processRX(self, file, containment_fraction=0.8):
         """
-        Process sim_telarray photon list with rx binary and return the results (d80, centroids and
-        eff area).
+        Process sim_telarray photon list with rx binary and return the results
+        (containment_diameter_cm, centroids and eff area).
 
         Parameters
         ----------
         file: str or Path
             Photon list file.
+        containment_fraction: float
+            Containment fraction for PSF containment calculation. Allowed values are in the
+            inverval [0,1]
 
         Returns
         -------
-        (d80_cm, xMean, yMean, effArea)
+        (containment_diameter_cm, xMean, yMean, effArea)
         """
         # Use -n to disable the cog optimization
         rxOutput = subprocess.check_output(
-            "{}/sim_telarray/bin/rx -f 0.8 -v < {}".format(
-                self._simtelSourcePath, file
+            "{}/sim_telarray/bin/rx -f {:.2f} -v < {}".format(
+                self._simtelSourcePath, containment_fraction, file
             ),
             shell=True,
         )
         rxOutput = rxOutput.split()
-        d80_cm = 2 * float(rxOutput[0])
+        containment_diameter_cm = 2 * float(rxOutput[0])
         xMean = float(rxOutput[1])
         yMean = float(rxOutput[2])
         effArea = float(rxOutput[5])
-        return d80_cm, xMean, yMean, effArea
+        return containment_diameter_cm, xMean, yMean, effArea
 
     def exportResults(self):
         """Export results to a csv file."""

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -161,10 +161,15 @@ class SimtelRunnerRayTracing(SimtelRunner):
             if self._singleMirrorMode:
                 file.write("# mirrorNumber = {}\n\n".format(self.config.mirrorNumber))
 
-        # Filling in star file with a single star.
+        # Filling in star file with a single light source.
+        # Parameters defining light source:
+        # - azimuth
+        # - elevation
+        # - flux
+        # - distance of light source
         with self._starsFile.open("w") as file:
             file.write(
-                "0. {} 1.0 {}".format(
+                "0. {} 1.0 {}\n".format(
                     90.0 - self.config.zenithAngle, self.config.sourceDistance
                 )
             )


### PR DESCRIPTION
This is an 'intermediate' PR adding items (sorry, quite different):

1. allow to config the containment_fraction for the spot size determination on the command line:
e.g., the 80% containment radius is set by:
```
--containment_fraction 0.8
```
The variable `d80` has been renamed to containment_radius in the code to reflect this change.

Further changes are planned for the plotting part, so please do not worry about d80 appearing there. 

2. changed the default telescope model to `Current`
3. for settings workflows, do not apply numerical checks for columns of type 'string' (e.g. columns with the mirror panel IDs). This is done in a function called `_column_status`.
