### PR TITLE
Argparser implementation

### DIFF
--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -58,6 +58,9 @@
     rnda (float, optional)
         Starting value of mirror_reflection_random_angle. If not given, the value from the \
         default model will be used.
+    2f_measurement (file, optional)
+        File with results from 2f measurements including mirror panel raddii and spot size \
+        measurements
     d80_list (file, optional)
         File with single column list of measured D80 [cm]. It is used only for plotting the D80 \
         distributions. If given, the measured distribution will be plotted on the top of the \
@@ -196,6 +199,13 @@ if __name__ == "__main__":
         type=str,
         required=False,
     )
+    parser.add_argument(
+        "--2f_measurement",
+        help="Results from 2f measurements for each mirror panel radius and spot size",
+        type=str,
+        required=False,
+    )
+
     parser.add_argument(
         "--use_random_flen",
         help=(
@@ -349,7 +359,7 @@ if __name__ == "__main__":
         rndaOpt = rndaStart
 
     # Running the final simulation for rndaOpt
-    meanD80, sigD80 = run(rndaOpt, plot=True)
+    meanD80, sigD80 = run(rndaOpt, plot=False)
 
     # Printing results to stdout
     print("\nMeasured D{:}:".format(containment_fraction_percent))

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -119,7 +119,6 @@
 
 import logging
 import matplotlib.pyplot as plt
-import argparse
 
 import numpy as np
 import astropy.units as u
@@ -129,6 +128,7 @@ import simtools.util.general as gen
 import simtools.io_handler as io
 from simtools.ray_tracing import RayTracing
 from simtools.model.telescope_model import TelescopeModel
+import simtools.util.commandline_parser as argparser
 
 # from simtools.visualize import setStyle
 
@@ -141,37 +141,10 @@ def plotMeasuredDistribution(file, **kwargs):
     ax.hist(data, **kwargs)
 
 
-def efficiency_interval(value):
-    """
-    Argument parser check that value is an efficiency in the interval [0,1]
-
-    """
-    fvalue = float(value)
-    if fvalue < 0. or fvalue > 1.:
-        raise argparse.ArgumentTypeError(
-            "{} outside of allowed [0,1] interval".format(value))
-
-    return fvalue
-
-
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-s", "--site", help="North or South", type=str, required=True)
-    parser.add_argument(
-        "-t",
-        "--telescope",
-        help="Telescope model name (e.g. LST-1, SST-D, ...)",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "-m",
-        "--model_version",
-        help="Model version (default=Current)",
-        type=str,
-        default="Current",
-    )
+    parser = argparser.CommandLineParser()
+    parser.initialize_telescope_model_arguments()
     parser.add_argument(
         "--containment_mean",
         help="Mean of measured containment diameter [cm]",
@@ -185,7 +158,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--containment_fraction",
         help="Containment fraction for diameter calculation (in interval 0,1)",
-        type=efficiency_interval, required=False,
+        type=argparser.CommandLineParser.efficiency_interval, required=False,
         default=0.8,
     )
     parser.add_argument(
@@ -238,19 +211,7 @@ if __name__ == "__main__":
         help="no tuning of random_reflection_rangle - A single case will be simulated and plotted.",
         action="store_true",
     )
-    parser.add_argument(
-        "--test",
-        help="Test option for faster simulations of only 10 mirrors.",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        dest="logLevel",
-        action="store",
-        default="info",
-        help="Log level to print (default is INFO).",
-    )
+    parser.initialize_default_arguments()
 
     args = parser.parse_args()
     containment_fraction_percent = int(args.containment_fraction*100)

--- a/applications/set_model_parameter_from_external.py
+++ b/applications/set_model_parameter_from_external.py
@@ -39,12 +39,12 @@
 
 """
 
-import argparse
 import logging
 
 import simtools.util.general as gen
 import simtools.util.validate_schema as vs
 import simtools.util.validate_data as ds
+import simtools.util.commandline_parser as argparser
 import simtools.util.workflow_configuration as workflow_config
 import simtools.util.write_model_data as writer
 
@@ -96,16 +96,8 @@ def parse():
 
     """
 
-    parser = argparse.ArgumentParser(
-        description=("Setting workflow model parameter data")
-    )
-    parser.add_argument(
-        "-c",
-        "--workflow_config_file",
-        help="workflow configuration",
-        type=str,
-        required=True,
-    )
+    parser = argparser.CommandLineParser("Setting workflow model parameter data")
+    parser.initialize_workflow_arguments()
     parser.add_argument(
         "-m",
         "--input_meta_file",
@@ -120,30 +112,7 @@ def parse():
         type=str,
         required=True,
     )
-    parser.add_argument(
-        "-p",
-        "--product_directory",
-        help="Directory for data products (output)",
-        type=str,
-        default='',
-        required=False,
-    )
-    parser.add_argument(
-        "-r",
-        "--reference_schema_directory",
-        help="Directory with reference schema",
-        type=str,
-        default=None,
-        required=False
-    )
-    parser.add_argument(
-        "-v",
-        "--verbosity",
-        dest="logLevel",
-        action="store",
-        default="info",
-        help="Log level to print (default is INFO)",
-    )
+    parser.initialize_default_arguments()
     return parser.parse_args()
 
 

--- a/simtools/util/commandline_parser.py
+++ b/simtools/util/commandline_parser.py
@@ -4,12 +4,15 @@ import argparse
 class CommandLineParser(argparse.ArgumentParser):
     """
     Command line parser for application and workflows
+    Wrapper around standard python argparse.ArgumentParser
 
     """
 
     def initialize_default_arguments(self):
         """
         Initialize default arguments used for all applications
+        (e.g., verbosity or test flag)
+
 
         """
 
@@ -32,6 +35,7 @@ class CommandLineParser(argparse.ArgumentParser):
     def initialize_workflow_arguments(self):
         """
         Initialize default arguments for workflow configuration parameters
+        and product data model
 
         """
 
@@ -51,9 +55,8 @@ class CommandLineParser(argparse.ArgumentParser):
             required=False,
         )
         self.add_argument(
-            "-r",
-            "--reference_schema_directory",
-            help="Directory with reference schema",
+            "--toplevel_metadata_schema",
+            help="Toplevel metadata reference schema",
             type=str,
             default=None,
             required=False
@@ -61,7 +64,8 @@ class CommandLineParser(argparse.ArgumentParser):
 
     def initialize_telescope_model_arguments(self):
         """
-        Initialize default arguments for telescope model definition
+        Initialize default arguments for site and telescope model
+        definition
 
         """
 
@@ -90,7 +94,19 @@ class CommandLineParser(argparse.ArgumentParser):
     @staticmethod
     def efficiency_interval(value):
         """
-        Argument parser check that value is an efficiency in the interval [0,1]
+        Argument parser type to check that value is an efficiency
+        in the interval [0,1]
+
+        Parameters
+        ----------
+        value: float
+            value provided through the command line
+
+        Raises
+        ------
+        argparse.ArgumentTypeError
+            When value is outside of the interval [0,1]
+
 
         """
         fvalue = float(value)

--- a/simtools/util/commandline_parser.py
+++ b/simtools/util/commandline_parser.py
@@ -1,0 +1,60 @@
+import argparse
+import logging
+
+
+class CommandLineParser(argparse.ArgumentParser):
+    """
+    Command line parser for application and workflows
+
+    """
+
+    def initialize_default_arguments(self):
+        """
+        Initialize default arguments used for all applications
+
+        """
+
+        self.add_argument(
+            "-v",
+            "--verbosity",
+            dest="logLevel",
+            action="store",
+            default="info",
+            help="Log level to print (default is INFO)",
+        )
+
+    def initialize_workflow_arguments(self):
+        """
+        Initialize default arguments for workflow configuration parameters
+
+        """
+
+        self.add_argument(
+            "-c",
+            "--workflow_config_file",
+            help="Workflow configuration file",
+            type=str,
+            required=True,
+        )
+        self.add_argument(
+            "-p",
+            "--product_directory",
+            help="Directory for data products (output)",
+            type=str,
+            default='',
+            required=False,
+        )
+        self.add_argument(
+            "-r",
+            "--reference_schema_directory",
+            help="Directory with reference schema",
+            type=str,
+            default=None,
+            required=False
+        )
+
+    def initialize_telescope_model_arguments(self):
+        """
+        Initialize default arguments for telescope model definition
+
+        """

--- a/simtools/util/commandline_parser.py
+++ b/simtools/util/commandline_parser.py
@@ -1,5 +1,4 @@
 import argparse
-import logging
 
 
 class CommandLineParser(argparse.ArgumentParser):
@@ -15,12 +14,19 @@ class CommandLineParser(argparse.ArgumentParser):
         """
 
         self.add_argument(
+            "--test",
+            help="Test option for faster execution during development",
+            action="store_true",
+            required=False,
+        )
+        self.add_argument(
             "-v",
             "--verbosity",
             dest="logLevel",
             action="store",
             default="info",
             help="Log level to print (default is INFO)",
+            required=False,
         )
 
     def initialize_workflow_arguments(self):
@@ -58,3 +64,38 @@ class CommandLineParser(argparse.ArgumentParser):
         Initialize default arguments for telescope model definition
 
         """
+
+        self.add_argument(
+            "-s",
+            "--site",
+            help="North or South",
+            type=str,
+            required=True
+        )
+        self.add_argument(
+            "-t",
+            "--telescope",
+            help="Telescope model name (e.g. LST-1, SST-D, ...)",
+            type=str,
+            required=True,
+        )
+        self.add_argument(
+            "-m",
+            "--model_version",
+            help="Model version (default=Current)",
+            type=str,
+            default="Current",
+        )
+
+    @staticmethod
+    def efficiency_interval(value):
+        """
+        Argument parser check that value is an efficiency in the interval [0,1]
+
+        """
+        fvalue = float(value)
+        if fvalue < 0. or fvalue > 1.:
+            raise argparse.ArgumentTypeError(
+                "{} outside of allowed [0,1] interval".format(value))
+
+        return fvalue

--- a/simtools/util/workflow_configuration.py
+++ b/simtools/util/workflow_configuration.py
@@ -1,0 +1,55 @@
+import logging
+
+import simtools.util.general as gen
+
+class WorkflowConfiguration:
+    """
+    Workflow configuration class
+
+    """
+
+    def __init__(self):
+        """
+        Initialize workflow configuration class
+
+        """
+
+        self._logger = logging.getLogger(__name__)
+        self.configuration = {}
+
+    def collect_configuration(self,
+                              workflow_config_file,
+                              reference_schema_directory=None):
+        """
+        Collect configuration parameter into a single dict
+        (simplifies processing)
+
+        Parameters:
+        -----------
+        workflow_config_file
+            configuration file describing this workflow
+        reference_schema_directory
+            directory to reference schema
+
+        Return:
+        -------
+        workflow_config: dict
+            workflow configuration
+
+        """
+
+        _workflow_config = gen.collectDataFromYamlOrDict(
+            workflow_config_file, None)
+        self._logger.debug("Reading workflow configuration from {}".format(
+            workflow_config_file))
+
+        if reference_schema_directory:
+            try:
+                _workflow_config['CTASIMPIPE']['DATAMODEL']['SCHEMADIRECTORY'] = \
+                    reference_schema_directory
+            except KeyError as error:
+                self._logger.error("Workflow configuration incomplete")
+                raise KeyError from error
+
+        self.configuration = _workflow_config
+        return self.configuration


### PR DESCRIPTION
First 'suggestion' of an expansion of the argparser: @orelgueta - please have a very quick look at the general idea and give me feedback. There are still a lot of docstrings missing, but I would like to get some feedback.

Updates:
- new CommandLineParser as argparse.ArgumentParser Child
- allows to define default command line arguments which are the same for all applications (e.g., -v) without duplicating too much code (and therefore avoiding that the same functionality requires different command line options in different applications)
- allows generic implementation of functionality like the [0,1] interval checking (efficiency_interval)

Really a minor updates with minimum code changes.

(and please ignore the `--2f_measurement` option and the workflow configuration class, I mixed up again two branches)