### PR TITLE
Add some unit tests for model_data_writer

### DIFF
--- a/simtools/util/model_data_writer.py
+++ b/simtools/util/model_data_writer.py
@@ -61,15 +61,21 @@ class ModelDataWriter:
                 _file))
             raise
 
-    def write_metadata(self):
+    def write_metadata(self, ymlfile=None):
         """
         Write model metadata file
         (yaml file format)
 
+        Attributes
+        ----------
+        ymlfile str
+            name of output file (default=None)
+
         """
 
         try:
-            ymlfile = self.workflow_config.product_data_file_name('.yml')
+            if not ymlfile:
+                ymlfile = self.workflow_config.product_data_file_name('.yml')
             self._logger.info(
                 "Writing metadata to {}".format(ymlfile))
             with open(ymlfile, 'w', encoding='UTF-8') as file:
@@ -82,5 +88,5 @@ class ModelDataWriter:
                 ymlfile))
             raise
         except AttributeError:
-            self._logger.erro("No metadata defined for write")
+            self._logger.error("No metadata defined for writing")
             raise

--- a/simtools/util/tests/test_model_data_writer.py
+++ b/simtools/util/tests/test_model_data_writer.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+import logging
+import re
+import sys
+import pytest
+
+import simtools.util.model_data_writer as writer
+import simtools.util.workflow_description as workflow
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+def test_write_metadata():
+
+    # test writer with no workflow configuration
+    w_1 = writer.ModelDataWriter()
+    with pytest.raises(
+            AttributeError,
+            match=r"\'NoneType\' object has no attribute \'product_data_file_name\'"):
+        w_1.write_metadata()
+
+    # test writer with workflow configuration initialised, but not set
+    c_2 = workflow.WorkflowDescription()
+    w_2 = writer.ModelDataWriter(c_2)
+
+    with pytest.raises(
+            TypeError,
+            match=re.escape('can only concatenate str (not "NoneType") to str')):
+        w_2.write_metadata()
+
+    # TODO tests which actually write data
+
+def test_write_data():
+
+    # test writer with no workflow configuration
+    w_1 = writer.ModelDataWriter()
+    with pytest.raises(
+            AttributeError,
+            match=r"\'NoneType\' object has no attribute \'product_data_file_name\'"):
+        w_1.write_data(None)
+
+    # test writer with workflow configuration initialised, but not set
+    c_2 = workflow.WorkflowDescription()
+    w_2 = writer.ModelDataWriter(c_2)
+    with pytest.raises(
+            TypeError,
+            match=re.escape('can only concatenate str (not "NoneType") to str')):
+        w_2.write_data(None)
+
+    # TODO tests which actually write data

--- a/simtools/util/workflow_description.py
+++ b/simtools/util/workflow_description.py
@@ -244,8 +244,10 @@ class WorkflowDescription:
             else:
                 _filename += '-' + self.workflow_config['ACTIVITY']['NAME']
         except KeyError:
-            self._logger.error(
-                "Missing CTA:PRODUCT:ID in metadata")
+            self._logger.error("Missing CTA:PRODUCT:ID in metadata")
+            raise
+        except TypeError:
+            self._logger.error("Missing ACTIVITY:NAME in metadata")
             raise
 
         if not suffix:


### PR DESCRIPTION
Some basic unit tests for model_data_writer

Still missing are the tests for actually writing data (either writing actual files in the testing to tmp or using the mocking package)