### PR TITLE
Add option to require workflow config as argument

### DIFF
--- a/applications/set_model_parameter_from_external.py
+++ b/applications/set_model_parameter_from_external.py
@@ -67,7 +67,8 @@ def parse(label):
         type=str,
         required=True,
     )
-    parser.initialize_default_arguments()
+    parser.initialize_default_arguments(
+        require_workflow_config=True)
     return parser.parse_args()
 
 

--- a/simtools/util/commandline_parser.py
+++ b/simtools/util/commandline_parser.py
@@ -16,7 +16,8 @@ class CommandLineParser(argparse.ArgumentParser):
 
     """
 
-    def initialize_default_arguments(self):
+    def initialize_default_arguments(self,
+                                     require_workflow_config=False):
         """
         Initialize default arguments used by all applications
         (e.g., verbosity or test flag)
@@ -34,7 +35,7 @@ class CommandLineParser(argparse.ArgumentParser):
             "--workflow_config_file",
             help="Workflow configuration file",
             type=str,
-            required=False,
+            required=require_workflow_config,
         )
         self.add_argument(
             "--test",


### PR DESCRIPTION
This is a temporary solution, as we probably require later on that all applications require a workflow configuration file (I expect that this will finally replace the config.yml files). 

For now, this small changes helps when running this application.