### PR TITLE
Improve job submission options

### DIFF
--- a/applications/production.py
+++ b/applications/production.py
@@ -7,10 +7,16 @@
 
     The simulations are split into two stages: showers and array.
     Shower simulations are performed with CORSIKA and array simulations \
-    with sim_telarray.
+    with sim_telarray. Note that either shower or array simulations are \
+    submitted (so typically you first run shower simulations, and then the \
+    array simulations).
 
     A configuration file is required. See tests/resources/prodConfigTest.yml \
     for an example.
+
+    The workload management system used is given in the configuration file. \
+    Allowed systems are qsub (using gridengine), condor_submit \
+    (using HTcondor), and seriell_script (running the script locally).
 
     Command line arguments
     ----------------------
@@ -41,6 +47,8 @@
     .. code-block:: console
 
         python applications/production.py -t simulate -p tests/resources/prodConfigTest.yml --test
+
+    Running shower simulations.
 """
 
 import logging

--- a/applications/production.py
+++ b/applications/production.py
@@ -244,8 +244,7 @@ def main():
     if not args.showers_only:
         arraySimulators = dict()
         for primary, configData in arrayConfigs.items():
-            aa = ArraySimulator(label=label, configData=configData)
-            arraySimulators[primary] = aa
+            arraySimulators[primary] = ArraySimulator(label=label, configData=configData)
         # Running Arrays
         for primary, array in arraySimulators.items():
 

--- a/applications/production.py
+++ b/applications/production.py
@@ -228,7 +228,7 @@ def main():
 
             if args.task == "simulate":
                 print("Running ShowerSimulator for primary {}".format(primary))
-                shower.submit()
+                shower.submit(test=args.test)
 
             elif args.task == "list":
                 print(
@@ -251,7 +251,7 @@ def main():
             inputList = showerSimulators[primary].getListOfOutputFiles()
             if args.task == "simulate":
                 print("Running ArraySimulator for primary {}".format(primary))
-                array.submit(inputFileList=inputList)
+                array.submit(inputFileList=inputList, test=args.test)
 
             elif args.task == "lists":
                 print(

--- a/applications/production.py
+++ b/applications/production.py
@@ -205,7 +205,7 @@ def proccessSimulationConfigFile(configFile, primaryConfig, logger):
     return label, configShowers, configArrays
 
 
-if __name__ == "__main__":
+def main():
 
     args = parse(description=("Air shower and array simulations"))
 
@@ -273,3 +273,6 @@ if __name__ == "__main__":
             elif args.task == 'resources':
                 print('Printing computing resources report for primary {}'.format(primary))
                 array.printResourcesReport(inputList)
+
+if __name__ == "__main__":
+    main()

--- a/applications/production.py
+++ b/applications/production.py
@@ -274,5 +274,6 @@ def main():
                 print('Printing computing resources report for primary {}'.format(primary))
                 array.printResourcesReport(inputList)
 
+
 if __name__ == "__main__":
     main()

--- a/applications/production.py
+++ b/applications/production.py
@@ -98,7 +98,7 @@ def parse(description=None):
             "iron",
         ],
     )
-    group = parser.add_mutually_exclusive_group()
+    group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--array_only",
         help="Simulates only array detection, no showers",

--- a/applications/production.py
+++ b/applications/production.py
@@ -16,7 +16,7 @@
 
     The workload management system used is given in the configuration file. \
     Allowed systems are qsub (using gridengine), condor_submit \
-    (using HTcondor), and seriell_script (running the script locally).
+    (using HTcondor), and local (running the script locally).
 
     Command line arguments
     ----------------------
@@ -217,8 +217,6 @@ def main():
     label, showerConfigs, arrayConfigs = proccessSimulationConfigFile(
         args.productionconfig, args.primary, logger)
 
-    submitCommand = "more " if args.test else None
-
     # ShowerSimulators
     showerSimulators = dict()
     for primary, configData in showerConfigs.items():
@@ -230,7 +228,7 @@ def main():
 
             if args.task == "simulate":
                 print("Running ShowerSimulator for primary {}".format(primary))
-                shower.submit(submitCommand=submitCommand)
+                shower.submit()
 
             elif args.task == "list":
                 print(
@@ -243,19 +241,18 @@ def main():
                 shower.printResourcesReport()
 
     # ArraySimulators
-    arraySimulators = dict()
-    for primary, configData in arrayConfigs.items():
-        aa = ArraySimulator(label=label, configData=configData)
-        arraySimulators[primary] = aa
-
     if not args.showers_only:
+        arraySimulators = dict()
+        for primary, configData in arrayConfigs.items():
+            aa = ArraySimulator(label=label, configData=configData)
+            arraySimulators[primary] = aa
         # Running Arrays
         for primary, array in arraySimulators.items():
 
             inputList = showerSimulators[primary].getListOfOutputFiles()
             if args.task == "simulate":
                 print("Running ArraySimulator for primary {}".format(primary))
-                array.submit(inputFileList=inputList, submitCommand=submitCommand)
+                array.submit(inputFileList=inputList)
 
             elif args.task == "lists":
                 print(

--- a/applications/sim_showers_for_trigger_rates.py
+++ b/applications/sim_showers_for_trigger_rates.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     else:
         logger.info("Test flag is on - it will not submit any job.")
         logger.info("This is an example of the run script:")
-        showerSimulator.submit(runList=[1], submitCommand="more ")
+        showerSimulator.submit(runList=[1], test=args.test)
 
     # Exporting the list of output/log/input files into the application folder
     outputFileList = outputDir.joinpath("outputFiles_{}.list".format(args.primary))

--- a/simtools/array_simulator.py
+++ b/simtools/array_simulator.py
@@ -257,9 +257,7 @@ class ArraySimulator:
             job_manager.submit(
                 run_script=runScript,
                 run_out_file=self._simtelRunner.getSubLogFile(
-                    run=run, mode='out'),
-                run_error_file=self._simtelRunner.getSubLogFile(
-                    run=run, mode='err')
+                    run=run, mode='')
             )
 
             self._fillResults(file, run)

--- a/simtools/array_simulator.py
+++ b/simtools/array_simulator.py
@@ -276,7 +276,7 @@ class ArraySimulator:
                 run=run, inputFile=file, extraCommands=extraCommands
             )
 
-            job_manager = JobManager(submitCommand=subCmd)
+            job_manager = JobManager(submitCommand=subCmd, test=test)
             job_manager.submit(
                 run_script=runScript,
                 run_out_file=self._simtelRunner.getSubLogFile(

--- a/simtools/array_simulator.py
+++ b/simtools/array_simulator.py
@@ -13,6 +13,7 @@ import simtools.util.general as gen
 from simtools.model.array_model import ArrayModel
 from simtools.simtel.simtel_histograms import SimtelHistograms
 from simtools.simtel.simtel_runner_array import SimtelRunnerArray
+from simtools.job_submission.job_manager import JobManager
 
 
 __all__ = ["ArraySimulator"]
@@ -210,7 +211,13 @@ class ArraySimulator:
 
             self._fillResults(file, run)
 
-    def submit(self, inputFileList, submitCommand=None, extraCommands=None, test=False):
+    def submit(
+            self,
+            inputFileList,
+            submitCommand=None,
+            extraCommands=None,
+            test=False
+    ):
         """
         Submit a run script as a job. The submit command can be given by \
         submitCommand or it will be taken from the config.yml file.
@@ -225,6 +232,7 @@ class ArraySimulator:
             Extra commands to be added to the run script before the run command,
         test: bool
             If True, job is not submitted.
+
         """
 
         subCmd = (
@@ -233,6 +241,9 @@ class ArraySimulator:
         self._logger.info("Submission command: {}".format(subCmd))
 
         inputFileList = self._makeInputList(inputFileList)
+        self._logger.info(
+            "Submitting run scripts for {} runs".format(len(inputFileList))
+        )
 
         self._logger.info("Starting submission")
         for file in inputFileList:
@@ -241,23 +252,15 @@ class ArraySimulator:
             runScript = self._simtelRunner.getRunScript(
                 run=run, inputFile=file, extraCommands=extraCommands
             )
-            thisSubCmd = copy(subCmd)
 
-            # Checking for log files in sub command and replacing them
-            if 'log_out' in subCmd:
-                logOutFile = self._simtelRunner.getSubLogFile(run=run, mode='out')
-                thisSubCmd = thisSubCmd.replace('log_out', str(logOutFile))
-
-            if 'log_err' in subCmd:
-                logErrFile = self._simtelRunner.getSubLogFile(run=run, mode='err')
-                thisSubCmd = thisSubCmd.replace('log_err', str(logErrFile))
-
-            self._logger.info('Run {} - Submitting script {}'.format(run, runScript))
-
-            shellCommand = thisSubCmd + ' ' + str(runScript)
-            self._logger.debug(shellCommand)
-            if not test:
-                os.system(shellCommand)
+            job_manager = JobManager(submitCommand=subCmd)
+            job_manager.submit(
+                run_script=runScript,
+                run_out_file=self._simtelRunner.getSubLogFile(
+                    run=run, mode='out'),
+                run_error_file=self._simtelRunner.getSubLogFile(
+                    run=run, mode='err')
+            )
 
             self._fillResults(file, run)
 

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -332,7 +332,7 @@ class CorsikaRunner:
 
         runtime = None
         with open(subLogFile, 'r') as file:
-            for line in file:
+            for line in reversed(list(file)):
                 if 'RUNTIME' in line:
                     runtime = int(line.split()[1])
                     break

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -330,6 +330,9 @@ class CorsikaRunner:
         runNumber = self._validateRunNumber(runNumber)
         subLogFile = self.getSubLogFile(runNumber=runNumber, mode='out')
 
+        self._logger.info("Reading resources from {}".format(
+            subLogFile))
+
         runtime = None
         with open(subLogFile, 'r') as file:
             for line in reversed(list(file)):

--- a/simtools/job_submission/job_manager.py
+++ b/simtools/job_submission/job_manager.py
@@ -82,6 +82,8 @@ class JobManager:
             raise MissingWorkloadManager
         elif self.submitCommand.find("seriell_script") >= 0:
             return
+        elif self.submitCommand.find("more") >= 0:
+            return
 
         raise MissingWorkloadManager
 
@@ -119,6 +121,23 @@ class JobManager:
             self._submit_HTcondor()
         elif self.submitCommand.find("seriell_script") >= 0:
             self._submit_seriell_script()
+        elif self.submitCommand.find("more") >= 0:
+            self._submit_for_testing()
+
+    def _submit_for_testing(self):
+        """
+        Print submit script to screen for testing
+
+        """
+
+        self._logger.info('Testing script')
+
+        shellCommand = 'more ' + self.run_script
+
+        if not self.test:
+            os.system(shellCommand)
+        else:
+            self._logger.info('Testing (submit_for_testing)')
 
     def _submit_seriell_script(self):
         """

--- a/simtools/job_submission/job_manager.py
+++ b/simtools/job_submission/job_manager.py
@@ -54,7 +54,7 @@ class JobManager:
             self.test_submission_system()
         except MissingWorkloadManager:
             self._logger.error(
-                "Requested worklow manager not found: {}".format(
+                "Requested workflow manager not found: {}".format(
                     self.submitCommand))
             raise
 
@@ -72,11 +72,13 @@ class JobManager:
 
         if self.submitCommand is None:
             return
-        elif (self.submitCommand.find("qsub") >= 0
-                and not gen.program_is_executable('qsub')):
+        elif self.submitCommand.find("qsub") >= 0:
+            if gen.program_is_executable('qsub'):
+                return
             raise MissingWorkloadManager
-        elif (self.submitCommand.find("condor_submit") >= 0
-                and not gen.program_is_executable('condor_submit')):
+        elif self.submitCommand.find("condor_submit") >= 0:
+            if gen.program_is_executable('condor_submit'):
+                return
             raise MissingWorkloadManager
         elif self.submitCommand.find("seriell_script") >= 0:
             return

--- a/simtools/job_submission/job_manager.py
+++ b/simtools/job_submission/job_manager.py
@@ -1,0 +1,117 @@
+import logging
+import os
+from copy import copy
+
+import simtools.util.general as gen
+
+__all__ = ["JobManager"]
+
+class MissingWorkloadManager(Exception):
+    pass
+
+class JobManager:
+    """
+    JobManager provides an interface to workload managers
+    like gridengine or HTCondor.
+
+    Attributes
+    ----------
+
+    Methods
+    -------
+
+    """
+
+    def __init__(
+        self,
+        label=None,
+        submitCommand=None,
+        test=False
+    ):
+        self._logger = logging.getLogger(__name__)
+        self.label = label
+        self.submitCommand = submitCommand
+        self.test = test
+
+        try:
+            self.test_submission_system()
+        except MissingWorkloadManager:
+            self._logger.error(
+                "Requested worklow manager not found: {}".format(
+                    self.submitCommand))
+            raise
+
+    def test_submission_system(self):
+        """
+        Check the requested workload manager exist on the
+        system this script is executed
+
+        Raises
+        ------
+        MissingWorkloadManager
+            if workflow manager is not found
+
+        """
+
+        if (self.submitCommand.find("qsub") >= 0
+                and not gen.program_is_executable('qsub')):
+            raise MissingWorkloadManager
+
+    def submit(
+        self,
+        run_script=None,
+        run_out_file=None,
+        run_error_file=None,
+    ):
+        """
+        Submit a job described by a shell script
+
+        Parameters
+        ----------
+        run_script: string
+            Shell script descring the job to be submitted
+        run_out_file: string
+            Redirect output stream to this file
+        run_error_file: string
+            Redirect error stream to this file
+
+        """
+        self.run_script = run_script
+        self.run_out_file = run_out_file
+        self.run_error_file = run_error_file
+
+        if self.submitCommand.find("qsub") >= 0:
+            self._submit_gridengine()
+
+    def _submit_gridengine(self):
+        """
+        Submit a job described by a shell script to gridengine
+
+        Parameters
+        ----------
+        run_script: string
+            Shell script descring the job to be submitted
+        run_out_file: string
+            Redirect output stream to this file
+        run_error_file: string
+            Redirect error stream to this file
+
+        """
+
+        thisSubCmd = copy(self.submitCommand)
+        if 'log_out' in thisSubCmd:
+            thisSubCmd = thisSubCmd.replace(
+                'log_out', str(self.run_out_file))
+        if 'log_err' in thisSubCmd:
+            thisSubCmd = thisSubCmd.replace(
+                'log_err', str(self.run_error_file))
+
+        self._logger.info(
+            'Submitting script {} to gridengine'.format(self.run_script))
+
+        shellCommand = thisSubCmd + ' ' + str(self.run_script)
+        self._logger.debug(shellCommand)
+        if not self.test:
+            os.system(shellCommand)
+        else:
+            self._logger.info('Testing')

--- a/simtools/job_submission/job_manager.py
+++ b/simtools/job_submission/job_manager.py
@@ -104,7 +104,7 @@ class JobManager:
 
         """
         self.run_script = str(run_script)
-        self.run_out_file = str(run_out_file).replace(".log", "-log")
+        self.run_out_file = str(run_out_file).replace(".log", "")
 
         self._logger.info(
             'Submitting script {}'.format(self.run_script))

--- a/simtools/shower_simulator.py
+++ b/simtools/shower_simulator.py
@@ -242,9 +242,7 @@ class ShowerSimulator:
             job_manager.submit(
                 run_script=runScript,
                 run_out_file=self._corsikaRunner.getSubLogFile(
-                    runNumber=run, mode='out'),
-                run_error_file=self._corsikaRunner.getSubLogFile(
-                    runNumber=run, mode='err')
+                    runNumber=run, mode='')
             )
 
     def makeResourcesReport(self):

--- a/simtools/shower_simulator.py
+++ b/simtools/shower_simulator.py
@@ -119,7 +119,10 @@ class ShowerSimulator:
     # End of init
 
     def _loadShowerConfigData(self, showerConfigData):
-        """Validate showerConfigData and store the relevant data in variables."""
+        """
+        Validate showerConfigData and store the relevant data in variables.
+
+        """
 
         # Copying showerConfigData to corsikaConfigData
         # Few keys will be removed before passing it to CorsikaRunner
@@ -248,9 +251,9 @@ class ShowerSimulator:
         runtime = list()
         nEvents = None
         for run in self.runs:
-            if self._corsikaRunner.hasSubLogFile(runNumber=run):
-                nEvents, thisRuntime = self._corsikaRunner.getResources(runNumber=run)
-                runtime.append(thisRuntime)
+           if self._corsikaRunner.hasSubLogFile(runNumber=run):
+               nEvents, thisRuntime = self._corsikaRunner.getResources(runNumber=run)
+               runtime.append(thisRuntime)
 
         meanRuntime = np.mean(runtime)
 

--- a/simtools/shower_simulator.py
+++ b/simtools/shower_simulator.py
@@ -9,6 +9,7 @@ import simtools.io_handler as io
 from simtools.corsika.corsika_runner import CorsikaRunner
 from simtools.util import names
 from simtools.util.general import collectDataFromYamlOrDict
+from simtools.job_submission.job_manager import JobManager
 
 __all__ = ["ShowerSimulator"]
 
@@ -193,7 +194,11 @@ class ShowerSimulator:
             os.system(runScript)
 
     def submit(
-        self, runList=None, runRange=None, submitCommand=None, extraCommands=None
+            self, runList=None,
+            runRange=None,
+            submitCommand=None,
+            extraCommands=None,
+            test=False
     ):
         """
         Submit a run script as a job. The submit command can be given by \
@@ -205,11 +210,13 @@ class ShowerSimulator:
             List of run numbers to be simulated.
         runRange: list
             List of len 2 with the limits of the range for runs to be simulated.
+        submitCommand: str
+            Command to be used before the script name.
+        extraCommands: str or list of str
+            Extra commands to be added to the run script before the run command,
+        test: bool
+            If True, job is not submitted.
 
-        Raises
-        ------
-        InvalidRunsToSimulate
-            If runs in runList or runRange are invalid.
         """
 
         subCmd = (
@@ -228,22 +235,14 @@ class ShowerSimulator:
                 runNumber=run, extraCommands=extraCommands
             )
 
-            thisSubCmd = copy(subCmd)
-
-            # Checking for log files in sub command and replacing them
-            if 'log_out' in subCmd:
-                logOutFile = self._corsikaRunner.getSubLogFile(runNumber=run, mode='out')
-                thisSubCmd = thisSubCmd.replace('log_out', str(logOutFile))
-
-            if 'log_err' in subCmd:
-                logErrFile = self._corsikaRunner.getSubLogFile(runNumber=run, mode='err')
-                thisSubCmd = thisSubCmd.replace('log_err', str(logErrFile))
-
-            self._logger.info('Run {} - Submitting script {}'.format(run, runScript))
-
-            shellCommand = thisSubCmd + ' ' + str(runScript)
-            self._logger.debug(shellCommand)
-            os.system(shellCommand)
+            job_manager = JobManager(submitCommand=subCmd)
+            job_manager.submit(
+                run_script=runScript,
+                run_out_file=self._corsikaRunner.getSubLogFile(
+                    runNumber=run, mode='out'),
+                run_error_file=self._corsikaRunner.getSubLogFile(
+                    runNumber=run, mode='err')
+            )
 
     def makeResourcesReport(self):
         runtime = list()

--- a/simtools/shower_simulator.py
+++ b/simtools/shower_simulator.py
@@ -238,7 +238,7 @@ class ShowerSimulator:
                 runNumber=run, extraCommands=extraCommands
             )
 
-            job_manager = JobManager(submitCommand=subCmd)
+            job_manager = JobManager(submitCommand=subCmd, test=test)
             job_manager.submit(
                 run_script=runScript,
                 run_out_file=self._corsikaRunner.getSubLogFile(

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -194,6 +194,9 @@ class SimtelRunnerArray(SimtelRunner):
 
         subLogFile = self.getSubLogFile(run=run, mode='out')
 
+        self._logger.info('Reading resources from {}'.format(
+            subLogFile))
+
         runtime = None
         with open(subLogFile, 'r') as file:
             for line in reversed(list(file)):

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -444,7 +444,7 @@ def program_is_executable(program):
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 
-    fpath, fname = os.path.split(program)
+    fpath, _ = os.path.split(program)
     if fpath:
         if is_exe(program):
             return program

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -3,6 +3,7 @@ import copy
 from collections import namedtuple
 import re
 import mmap
+import os
 
 import astropy.units as u
 from astropy.io.misc import yaml
@@ -430,3 +431,27 @@ def separateArgsAndConfigData(expectedArgs, **kwargs):
             configData[key] = value
 
     return args, configData
+
+
+def program_is_executable(program):
+    """
+    Checks if program exists and is executable
+
+    Follows https://stackoverflow.com/questions/377017/
+
+    """
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -949,7 +949,9 @@ def corsikaSubLogFileName(arrayName, site, primary, run, mode, label=None):
     '''
     name = 'log-sub-corsika-run{}-{}-{}-{}'.format(run, arrayName, site, primary)
     name += '_{}'.format(label) if label is not None else ''
-    name += '-' + mode + '.log'
+    name += '.log'
+    if len(mode)>0:
+        name += "." + mode
     return name
 
 
@@ -1095,5 +1097,7 @@ def simtelSubLogFileName(run, primary, arrayName, site, zenith, azimuth, mode, l
         arrayName
     )
     name += '_{}'.format(label) if label is not None else ''
-    name += '-' + mode + '.log'
+    name += '.log'
+    if len(mode)>0:
+        name += "." + mode
     return name

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -949,9 +949,10 @@ def corsikaSubLogFileName(arrayName, site, primary, run, mode, label=None):
     """
     name = 'log-sub-corsika-run{}-{}-{}-{}'.format(run, arrayName, site, primary)
     name += '_{}'.format(label) if label is not None else ''
-    name += '.log'
-    if len(mode)>0:
-        name += "." + mode
+    if len(mode) > 0:
+        name += "-log." + mode
+    else:
+        name += '.log'
     return name
 
 
@@ -1097,7 +1098,8 @@ def simtelSubLogFileName(run, primary, arrayName, site, zenith, azimuth, mode, l
         arrayName
     )
     name += '_{}'.format(label) if label is not None else ''
-    name += '.log'
-    if len(mode)>0:
-        name += "." + mode
+    if len(mode) > 0:
+        name += "-log." + mode
+    else:
+        name += '.log'
     return name

--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -950,7 +950,7 @@ def corsikaSubLogFileName(arrayName, site, primary, run, mode, label=None):
     name = 'log-sub-corsika-run{}-{}-{}-{}'.format(run, arrayName, site, primary)
     name += '_{}'.format(label) if label is not None else ''
     if len(mode) > 0:
-        name += "-log." + mode
+        name += "." + mode
     else:
         name += '.log'
     return name
@@ -1099,7 +1099,7 @@ def simtelSubLogFileName(run, primary, arrayName, site, zenith, azimuth, mode, l
     )
     name += '_{}'.format(label) if label is not None else ''
     if len(mode) > 0:
-        name += "-log." + mode
+        name += "." + mode
     else:
         name += '.log'
     return name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,6 +156,7 @@ def set_simtools(db_connection, simtelpath, tmp_test_directory, configuration_pa
     config_dict['simtelPath'] = str(simtelpath)
     config_dict['useMongoDB'] = True
     config_dict['mongoDBConfigFile'] = str(db_connection)
+    config_dict['submissionCommand'] = 'local'
 
     write_configuration_test_file(config_file, config_dict)
     cfg.setConfigFileName(config_file)

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -159,7 +159,7 @@ APP_LIST = {
             "--model_version", "prod4"
         ]
     ],
-    "production:showers_only": [
+    "production::showers_only": [
         [
             "-p", "./tests/resources/prodConfigTest.yml",
             "-t", "simulate",
@@ -167,7 +167,7 @@ APP_LIST = {
             "--test"
         ]
     ],
-    "production:array_only": [
+    "production::array_only": [
         [
             "-p", "./tests/resources/prodConfigTest.yml",
             "-t", "simulate",

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -159,10 +159,19 @@ APP_LIST = {
             "--model_version", "prod4"
         ]
     ],
-    "production": [
+    "production:showers_only": [
         [
             "-p", "./tests/resources/prodConfigTest.yml",
             "-t", "simulate",
+            "--showers_only",
+            "--test"
+        ]
+    ],
+    "production:array_only": [
+        [
+            "-p", "./tests/resources/prodConfigTest.yml",
+            "-t", "simulate",
+            "--array_only",
             "--test"
         ]
     ],

--- a/tests/unit_tests/job_submission/test_job_manager.py
+++ b/tests/unit_tests/job_submission/test_job_manager.py
@@ -1,0 +1,19 @@
+import logging
+import pytest
+
+import simtools.job_submission.job_manager as jm
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture
+def label():
+    return "test-shower-simulator"
+
+
+def test_test_submission_system(label):
+    job_manager_1 = jm.JobManager(submitCommand=None)
+    job_manager_2 = jm.JobManager(submitCommand="seriell_script")
+    with pytest.raises(jm.MissingWorkloadManager):
+        job_manager_fail_1 = jm.JobManager(submitCommand='abc')

--- a/tests/unit_tests/job_submission/test_job_manager.py
+++ b/tests/unit_tests/job_submission/test_job_manager.py
@@ -14,6 +14,6 @@ def label():
 
 def test_test_submission_system(label):
     jm.JobManager(submitCommand=None)
-    jm.JobManager(submitCommand="seriell_script")
+    jm.JobManager(submitCommand="local")
     with pytest.raises(jm.MissingWorkloadManager):
         jm.JobManager(submitCommand='abc')

--- a/tests/unit_tests/job_submission/test_job_manager.py
+++ b/tests/unit_tests/job_submission/test_job_manager.py
@@ -13,7 +13,7 @@ def label():
 
 
 def test_test_submission_system(label):
-    job_manager_1 = jm.JobManager(submitCommand=None)
-    job_manager_2 = jm.JobManager(submitCommand="seriell_script")
+    jm.JobManager(submitCommand=None)
+    jm.JobManager(submitCommand="seriell_script")
     with pytest.raises(jm.MissingWorkloadManager):
-        job_manager_fail_1 = jm.JobManager(submitCommand='abc')
+        jm.JobManager(submitCommand='abc')

--- a/tests/unit_tests/test_array_simulator.py
+++ b/tests/unit_tests/test_array_simulator.py
@@ -94,7 +94,7 @@ def test_run(array_simulator, corsikaFile):
 def test_submitting(array_simulator, corsikaFile):
 
     array_simulator.submit(
-        inputFileList=corsikaFile, submitCommand="more "
+        inputFileList=corsikaFile, submitCommand="local"
     )
     # TODO - add a test here
 
@@ -102,7 +102,7 @@ def test_submitting(array_simulator, corsikaFile):
 def test_list_of_files(array_simulator, corsikaFile):
 
     array_simulator.submit(
-        inputFileList=corsikaFile, submitCommand="more ", test=True
+        inputFileList=corsikaFile, submitCommand="local", test=True
     )
 
     array_simulator.printListOfOutputFiles()

--- a/tests/unit_tests/test_shower_simulator.py
+++ b/tests/unit_tests/test_shower_simulator.py
@@ -113,7 +113,7 @@ def test_no_corsika_data(cfg_setup, showerConfigData, label):
 
 def test_submitting(showerSimulator):
 
-    showerSimulator.submit(runList=[2], submitCommand="more ")
+    showerSimulator.submit(runList=[2], submitCommand="local")
 
     run_script = showerSimulator._corsikaRunner.getRunScriptFile(runNumber=2)
 
@@ -122,7 +122,7 @@ def test_submitting(showerSimulator):
 
 def test_runs_range(showerSimulator):
 
-    showerSimulator.submit(runRange=[4, 8], submitCommand="more ")
+    showerSimulator.submit(runRange=[4, 8], submitCommand="local")
 
     run_range = np.arange(4, 8)
     for run in run_range:

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -68,3 +68,11 @@ def test_validate_config_data(cfg_setup):
 
     # Testing dict par
     assert validatedData.dictPar["bleh"] == 500
+
+
+def test_program_is_executable():
+
+    # (assumpe 'ls' exist on any system the test is running)
+    assert gen.program_is_executable('ls') is not None
+    assert gen.program_is_executable(
+        'this_program_probably_does_not_exist') is None


### PR DESCRIPTION
This PR adds additional options for running small productions on local workload system (see also issue #135) and removes duplicated code.

New class [simtools/job_submission/job_manager.py](simtools/job_submission/job_manager.py), e.g.:
```
subCmd="qsub -o log_out -e log_err"
# (could also be subCmd="condor_submit" when using HTCondor)
job_manager = JobManager(submitCommand=subCmd)
job_manager.submit(runScript, run_out_file)
```

I've put this classes into a new directory, in the expectation that we might expand this functionality in future and separate it into different classes (e.g., by getting more status information from the workload managers).

To use HTCondor, set 
```
submissionCommand: 'condor_submit '
```
in `config.yml`. 
Almost everything is identical compared to using gridengine. HTCondor provides as well a job information file (ending sublogfile.job with information about the job host and resources required. 

When using HTcondor, use `condor_q` to see your list of running jobs. 

To run a production without workload management system locally, set
```
submissionCommand: 'seriell_script '
```

