### PR TITLE
Remove layout_array and telescope positions warnings

### DIFF
--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -554,20 +554,20 @@ class LayoutArray:
                 + " +axis=nwu +units=m +k_0=1.0"
             )
             crs_local = pyproj.CRS.from_proj4(proj4_string)
-            self._logger.info("Local Mercator projection: {}".format(crs_local))
+            self._logger.debug("Local Mercator projection: {}".format(crs_local))
             return crs_local
         else:
-            self._logger.warning("crs_local cannot be built because center lon and lat are missing")
+            self._logger.debug("crs_local cannot be built because center lon and lat are missing")
             return None
 
     def _getCrsUtm(self):
         """Get crs_utm"""
         if self._epsg is not None:
             crs_utm = pyproj.CRS.from_user_input(self._epsg)
-            self._logger.info("UTM system: {}".format(crs_utm))
+            self._logger.debug("UTM system: {}".format(crs_utm))
             return crs_utm
         else:
-            self._logger.warning("crs_utm cannot be built because center lon and lat are missing")
+            self._logger.debug("crs_utm cannot be built because EPSG definition is missing")
             return None
 
     @staticmethod

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -120,7 +120,6 @@ class TelescopePosition:
         """
 
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init TelescopePosition")
 
         self.name = name
         self._prodId = prodId
@@ -580,13 +579,11 @@ class TelescopePosition:
         """
 
         if crsLocal is None:
-            self._logger.warning("crsLocal is None - conversions will be impacted")
+            self._logger.debug("crsLocal is None - conversions will be impacted")
         if crsUtm is None:
-            self._logger.warning("crsUtm is None - conversions will be impacted")
+            self._logger.debug("crsUtm is None - conversions will be impacted")
         if wgs84 is None:
-            self._logger.warning("wgs84 is None - conversions will be impacted")
-
-        # Starting by local <-> UTM <-> Mercator
+            self._logger.debug("wgs84 is None - conversions will be impacted")
 
         if (
             self.hasLocalCoordinates()
@@ -604,9 +601,8 @@ class TelescopePosition:
         if self.hasUtmCoordinates() and not self.hasMercatorCoordinates() and crsUtm is not None:
             self.convertUtmToMercator(crsUtm, wgs84)
 
-        # Dealing with altitude <-> posZ
         if corsikaObsLevel is None or corsikaSphereCenter is None:
-            self._logger.warning(
+            self._logger.debug(
                 "Warning: telescope height might be incorrect du to "
                 "incomplete CORSIKA observation ({}) "
                 "or sphere centre information ({})".format(corsikaObsLevel, corsikaSphereCenter)
@@ -615,8 +611,3 @@ class TelescopePosition:
             self.convertCorsikaToAsl(corsikaObsLevel, corsikaSphereCenter)
         elif self.hasAltitude() and not self.hasLocalCoordinates():
             self.convertAslToCorsika(corsikaObsLevel, corsikaSphereCenter)
-        else:
-            # Nothing to be converted
-            pass
-
-    # End of convertAll

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -608,7 +608,7 @@ class TelescopePosition:
         if corsikaObsLevel is None or corsikaSphereCenter is None:
             self._logger.warning(
                 "Warning: telescope height might be incorrect du to "
-                "incomplete CORSIKA observation ({})"
+                "incomplete CORSIKA observation ({}) "
                 "or sphere centre information ({})".format(corsikaObsLevel, corsikaSphereCenter)
             )
         elif self.hasLocalCoordinates() and not self.hasAltitude():


### PR DESCRIPTION
This PR addresses PR #307 and removes the large number of warnings printout out by the `telescope_position.py` and `layout_array.py` modules. These warnings are now debug statements. Coordinate transformations are not taking place when the required information (e.g., centre of the array coordinates) are not given.