### PR TITLE
Remove CAMERA_RADIUS_CURV

### DIFF
--- a/applications/validate_camera_efficiency.py
+++ b/applications/validate_camera_efficiency.py
@@ -35,7 +35,7 @@
     .. code-block:: console
 
         python applications/validate_camera_efficiency.py --site North \
-            --telescope MST-NectarCam-D --model_version prod4
+            --telescope MST-NectarCam-D --model_version prod5
 
     .. todo::
 

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -13,10 +13,8 @@ import simtools.config as cfg
 import simtools.io_handler as io
 import simtools.util.general as gen
 from simtools import visualize
-from simtools.model.model_parameters import CAMERA_RADIUS_CURV
 from simtools.model.telescope_model import TelescopeModel
 from simtools.util import names
-from simtools.util.model import getCameraName
 
 __all__ = ["CameraEfficiency"]
 
@@ -237,9 +235,6 @@ class CameraEfficiency:
             )
             mirrorReflectivity = "ref_astri_2017-06_T0.dat"
 
-        # Camera name
-        cameraName = getCameraName(self._telescopeModel.name)
-
         # cmd -> Command to be run at the shell
         cmd = str(self._simtelSourcePath.joinpath("sim_telarray/bin/testeff"))
         cmd += " -nm -nsb-extra"
@@ -248,7 +243,6 @@ class CameraEfficiency:
             self._telescopeModel.getParameterValue("atmospheric_transmission")
         )
         cmd += " -flen {}".format(focalLength * 0.01)  # focal length in meters
-        cmd += " -fcur {}".format(CAMERA_RADIUS_CURV[cameraName])
         cmd += " {} {}".format(pixelShapeCmd, pixelDiameter)
         if mirrorClass == 1:
             cmd += " -fmir {}".format(self._telescopeModel.getParameterValue("mirror_list"))
@@ -494,6 +488,7 @@ class CameraEfficiency:
             np.sum(self._results["N4"])
             * self._telescopeModel.camera.getPixelActiveSolidAngle()
             * self._telescopeModel.getOnAxisEffOpticalArea().to("m2").value
+            / self._telescopeModel.getTelescopeTransmissionParameters()[0]
         )
 
         # NSB input spectrum is from Benn&Ellison

--- a/simtools/model/model_parameters.py
+++ b/simtools/model/model_parameters.py
@@ -41,14 +41,3 @@ MODEL_PARS = {
     "min_photoelectrons": {"type": int, "names": []},
     "parabolic_dish": {"type": int, "names": []},
 }
-
-CAMERA_RADIUS_CURV = {
-    "SST": 4.566,
-    "1M": 5.6,
-    "ASTRI": 4.3,
-    "GCT": 4.566,
-    "FlashCam": 19.2,
-    "NectarCam": 19.2,
-    "SCT": 11.16,
-    "LST": 56,
-}

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -241,6 +241,7 @@ class RayTracing:
                         "useRandomFocalLength": self.config.useRandomFocalLength,
                     },
                     singleMirrorMode=self.config.singleMirrorMode,
+                    forceSimulate=force,
                 )
                 simtel.run(test=test, force=force)
 

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -173,16 +173,13 @@ class SimtelRunner:
 
         if test:
             self._logger.info("Running (test) with command:{}".format(command))
-            os.system(command)
+            self._runSimtelAndCheckOutput(command)
         else:
             self._logger.info("Running ({}x) with command:{}".format(self.RUNS_PER_SET, command))
-            os.system(command)
+            self._runSimtelAndCheckOutput(command)
 
             for _ in range(self.RUNS_PER_SET - 1):
-                sysOutput = os.system(command)
-
-        if self._simtelFailed(sysOutput):
-            self._raiseSimtelError()
+                self._runSimtelAndCheckOutput(command)
 
         self._checkRunResult(runNumber=runNumber)
 
@@ -208,6 +205,14 @@ class SimtelRunner:
 
         self._logger.error(msg)
         raise SimtelExecutionError(msg)
+
+    def _runSimtelAndCheckOutput(self, command):
+        """
+        Run the sim_telarray command and check the exit code.
+        """
+        sysOutput = os.system(command)
+        if self._simtelFailed(sysOutput):
+            self._raiseSimtelError()
 
     def _shallRun(self, runNumber=None):
         self._logger.debug(

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -179,12 +179,12 @@ class SimtelRunner:
             os.system(command)
 
             for _ in range(self.RUNS_PER_SET - 1):
-                os.system(command)
+                sysOutput = os.system(command)
 
         # TODO: fix the fact any ray tracing simulations are failing and
         # uncomment this
-        # if self._simtelFailed(sysOutput):
-        #     self._raiseSimtelError()
+        if self._simtelFailed(sysOutput):
+            self._raiseSimtelError()
 
         self._checkRunResult(runNumber=runNumber)
 

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -181,8 +181,6 @@ class SimtelRunner:
             for _ in range(self.RUNS_PER_SET - 1):
                 sysOutput = os.system(command)
 
-        # TODO: fix the fact any ray tracing simulations are failing and
-        # uncomment this
         if self._simtelFailed(sysOutput):
             self._raiseSimtelError()
 

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -166,7 +166,7 @@ class SimtelRunner:
             raise RuntimeError(msg)
 
         if not self._shallRun(runNumber) and not force:
-            self._logger.debug("Skipping because output exists and force = False")
+            self._logger.info("Skipping because output exists and force = False")
             return
 
         command = self._makeRunCommand(inputFile=inputFile, runNumber=runNumber)

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -185,7 +185,7 @@ class SimtelRunner:
 
     @staticmethod
     def _simtelFailed(sysOutput):
-        return sysOutput != "0"
+        return sysOutput != 0
 
     def _raiseSimtelError(self):
         """
@@ -193,7 +193,7 @@ class SimtelRunner:
         are collected and printed.
         """
         if hasattr(self, "_logFile"):
-            logLines = gen.collectFinalLines(self._logFile, 10)
+            logLines = gen.collectFinalLines(self._logFile, 30)
             msg = (
                 "Simtel Error - See below the relevant part of the simtel log file.\n"
                 + "===== from simtel log file ======\n"

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -97,7 +97,6 @@ class SimtelRunnerRayTracing(SimtelRunner):
 
         # File location
         self._baseDirectory = io.getOutputDirectory(self._filesLocation, self.label, "ray-tracing")
-        self._baseDirectory.mkdir(parents=True, exist_ok=True)
 
         self._singleMirrorMode = singleMirrorMode
 

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -244,7 +244,7 @@ class SimtelRunnerRayTracing(SimtelRunner):
         """Check if the photon list is valid,"""
         nLines = 0
         with open(self._photonsFile, "r") as ff:
-            for line in ff:
+            for _ in ff:
                 nLines += 1
                 if nLines > 100:
                     break

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -138,5 +138,5 @@ def test_calc_nsb_rate(telescope_model, camera_efficiency, results_file):
     camera_efficiency._readResults()
     telescope_model.exportModelFiles()
     assert camera_efficiency.calcNsbRate()[0] == pytest.approx(
-        0.2366432742
+        0.24421390533203186
     )  # Value for Prod5 LST-1


### PR DESCRIPTION
The parameter itself is simply not necessary. To make a long story short, it's not the camera radius curvature but the mirror. It is used in testeff to calculate the effective mirror area, but instead of using that effective mirror area, we use the one derived from detailed ray tracing. Therefore, this parameter can simply be removed.

On the way there, a few other issues were "discovered" and fixed with the PR.