### PR TITLE
Fix usage of rx for ray tracing

### DIFF
--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -36,9 +36,7 @@ def test_ssts(set_simtools, telescopeModelName):
     ray.analyze(force=True)
 
 
-# TODO: issue #258
-@pytest.mark.skip(reason="ignore temporarily rx method")
-def test_rx(set_simtelarray):
+def test_rx(set_simtelarray, set_simtools):
     version = "current"
     label = "test-lst"
 


### PR DESCRIPTION
Address #258 and allow to use the rx tool for the determination of the containment radius.

Change call to rx using subprocess with `Shell=True`. 