### PR TITLE
Setting 0.4.0-beta version by hand

### DIFF
--- a/simtools/version.py
+++ b/simtools/version.py
@@ -2,4 +2,4 @@
 # cleaner way of automatically retrieve the version. e.g.,
 # https://github.com/cta-observatory/ctapipe/blob/master/ctapipe/version.py
 
-__version__ = "0.1.0"
+__version__ = "0.4.0-dev"


### PR DESCRIPTION
Update the version number (see also issue #223).

The choice of `0.4.0-beta` indicates that this is code leading to 0.4.0 (as the currently released version is 0.3.0).

Obviously, this should somehow be automized in future.

(I am using the version number in the `submit_data_from_external.py`, and are getting confused by outdated numbers`)