### PR TITLE
Consistent naming of simtelpath

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -3,7 +3,7 @@ name: CI-integrationtests
 # Execute integration tests for applications
 #
 env:
-  SIMTELPATH: ${{ github.workspace }}/
+  SIMTEL_PATH: ${{ github.workspace }}/
   DB_SERVER: ${{ secrets.DB_SERVER }}
   DB_API_USER: ${{ secrets.DB_API_USER }}
   DB_API_PW: ${{ secrets.DB_API_PW }}
@@ -65,8 +65,8 @@ jobs:
 
       - name: run sim_telarray
         run: |
-          echo "${SIMTELPATH}"
-          ls "${SIMTELPATH}"
+          echo "${SIMTEL_PATH}"
+          ls "${SIMTEL_PATH}"
 
       - name: Integration tests
         shell: bash -l {0}

--- a/applications/compare_cumulative_psf.py
+++ b/applications/compare_cumulative_psf.py
@@ -146,7 +146,7 @@ def main():
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtelpath"],
+        simtel_source_path=args_dict["simtel_path"],
         source_distance=args_dict["src_distance"] * u.km,
         zenith_angle=args_dict["zenith"] * u.deg,
         off_axis_angle=[0.0 * u.deg],

--- a/applications/derive_mirror_rnda.py
+++ b/applications/derive_mirror_rnda.py
@@ -351,7 +351,7 @@ def main():
             telescope_model=tel,
             single_mirror_mode=True,
             mirror_numbers=list(range(1, 10)) if args_dict["test"] else "all",
-            simtel_source_path=args_dict.get("simtelpath", None),
+            simtel_source_path=args_dict.get("simtel_path", None),
             use_random_focal_length=args_dict["use_random_flen"],
         )
         ray.simulate(test=False, force=True)  # force has to be True, always

--- a/applications/production.py
+++ b/applications/production.py
@@ -215,7 +215,7 @@ def main():
         shower_simulators[primary] = Simulator(
             label=label,
             simulator="corsika",
-            simulator_source_path=args_dict["simtelpath"],
+            simulator_source_path=args_dict["simtel_path"],
             config_data=config_data,
             submit_command=args_dict["submit_command"],
             test=args_dict["test"],
@@ -232,7 +232,7 @@ def main():
             array_simulators[primary] = Simulator(
                 label=label,
                 simulator="simtel",
-                simulator_source_path=args_dict["simtelpath"],
+                simulator_source_path=args_dict["simtel_path"],
                 config_data=config_data,
                 submit_command=args_dict["submit_command"],
                 mongo_db_config=db_config,

--- a/applications/sim_showers_for_trigger_rates.py
+++ b/applications/sim_showers_for_trigger_rates.py
@@ -148,7 +148,7 @@ def main():
     shower_simulator = Simulator(
         label=label,
         simulator="corsika",
-        simulator_source_path=args_dict.get("simtelpath", None),
+        simulator_source_path=args_dict.get("simtel_path", None),
         config_data=shower_config_data,
         submit_command=args_dict.get("submit_command", ""),
         test=args_dict["test"],

--- a/applications/tune_psf.py
+++ b/applications/tune_psf.py
@@ -238,7 +238,7 @@ def main():
 
         ray = RayTracing.from_kwargs(
             telescope_model=tel_model,
-            simtel_source_path=args_dict["simtelpath"],
+            simtel_source_path=args_dict["simtel_path"],
             source_distance=args_dict["src_distance"] * u.km,
             zenith_angle=args_dict["zenith"] * u.deg,
             off_axis_angle=[0.0 * u.deg],

--- a/applications/validate_camera_efficiency.py
+++ b/applications/validate_camera_efficiency.py
@@ -95,7 +95,7 @@ def main():
 
     ce = CameraEfficiency(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtelpath"],
+        simtel_source_path=args_dict["simtel_path"],
     )
     ce.simulate(force=True)
     ce.analyze(force=True)

--- a/applications/validate_optics.py
+++ b/applications/validate_optics.py
@@ -156,7 +156,7 @@ def main():
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtelpath"],
+        simtel_source_path=args_dict["simtel_path"],
         source_distance=args_dict["src_distance"] * u.km,
         zenith_angle=args_dict["zenith"] * u.deg,
         off_axis_angle=np.linspace(

--- a/simtools/util/commandline_parser.py
+++ b/simtools/util/commandline_parser.py
@@ -107,7 +107,7 @@ class CommandLineParser(argparse.ArgumentParser):
             required=False,
         )
         _job_group.add_argument(
-            "--simtelpath",
+            "--simtel_path",
             help="path pointing to sim_telarray installation",
             type=Path,
             required=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,23 +65,23 @@ def mock_settings_env_vars(tmp_test_directory):
 
 
 @pytest.fixture
-def simtelpath(mock_settings_env_vars):
-    simtelpath = Path(os.path.expandvars("$SIMTELPATH"))
-    if simtelpath.exists():
-        return simtelpath
+def simtel_path(mock_settings_env_vars):
+    simtel_path = Path(os.path.expandvars("$SIMTELPATH"))
+    if simtel_path.exists():
+        return simtel_path
     return ""
 
 
 @pytest.fixture
-def simtelpath_no_mock():
-    simtelpath = Path(os.path.expandvars("$SIMTELPATH"))
-    if simtelpath.exists():
-        return simtelpath
+def simtel_path_no_mock():
+    simtel_path = Path(os.path.expandvars("$SIMTELPATH"))
+    if simtel_path.exists():
+        return simtel_path
     return ""
 
 
 @pytest.fixture
-def args_dict(tmp_test_directory, simtelpath):
+def args_dict(tmp_test_directory, simtel_path):
 
     return Configurator().default_config(
         (
@@ -89,14 +89,14 @@ def args_dict(tmp_test_directory, simtelpath):
             str(tmp_test_directory),
             "--data_path",
             "./data/",
-            "--simtelpath",
-            str(simtelpath),
+            "--simtel_path",
+            str(simtel_path),
         ),
     )
 
 
 @pytest.fixture
-def args_dict_site(tmp_test_directory, simtelpath):
+def args_dict_site(tmp_test_directory, simtel_path):
 
     return Configurator().default_config(
         (
@@ -104,8 +104,8 @@ def args_dict_site(tmp_test_directory, simtelpath):
             str(tmp_test_directory),
             "--data_path",
             "./data/",
-            "--simtelpath",
-            str(simtelpath),
+            "--simtel_path",
+            str(simtel_path),
             "--site",
             "South",
             "--telescope",
@@ -117,11 +117,11 @@ def args_dict_site(tmp_test_directory, simtelpath):
 
 
 @pytest.fixture
-def configurator(tmp_test_directory, simtelpath):
+def configurator(tmp_test_directory, simtel_path):
 
     config = Configurator()
     config.default_config(
-        ("--output_path", str(tmp_test_directory), "--simtelpath", str(simtelpath))
+        ("--output_path", str(tmp_test_directory), "--simtel_path", str(simtel_path))
     )
     return config
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def mock_settings_env_vars(tmp_test_directory):
     with mock.patch.dict(
         os.environ,
         {
-            "SIMTELPATH": str(tmp_test_directory) + "/simtel",
+            "SIMTEL_PATH": str(tmp_test_directory) + "/simtel",
             "DB_API_USER": "db_user",
             "DB_API_PW": "12345",
             "DB_API_PORT": "42",
@@ -66,7 +66,7 @@ def mock_settings_env_vars(tmp_test_directory):
 
 @pytest.fixture
 def simtel_path(mock_settings_env_vars):
-    simtel_path = Path(os.path.expandvars("$SIMTELPATH"))
+    simtel_path = Path(os.path.expandvars("$SIMTEL_PATH"))
     if simtel_path.exists():
         return simtel_path
     return ""
@@ -74,7 +74,7 @@ def simtel_path(mock_settings_env_vars):
 
 @pytest.fixture
 def simtel_path_no_mock():
-    simtel_path = Path(os.path.expandvars("$SIMTELPATH"))
+    simtel_path = Path(os.path.expandvars("$SIMTEL_PATH"))
     if simtel_path.exists():
         return simtel_path
     return ""

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -15,7 +15,7 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.mark.parametrize("telescope_model_name", ["sst-1M", "sst-ASTRI", "sst-GCT"])
-def test_ssts(telescope_model_name, db_config, simtelpath_no_mock, io_handler):
+def test_ssts(telescope_model_name, db_config, simtel_path_no_mock, io_handler):
     # Test with 3 SSTs
     version = "prod3"
     config_data = {
@@ -32,13 +32,13 @@ def test_ssts(telescope_model_name, db_config, simtelpath_no_mock, io_handler):
     )
 
     ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtelpath_no_mock, config_data=config_data
+        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
     )
     ray.simulate(test=True, force=True)
     ray.analyze(force=True)
 
 
-def test_rx(db_config, simtelpath_no_mock, io_handler):
+def test_rx(db_config, simtel_path_no_mock, io_handler):
     version = "current"
     label = "test-lst"
 
@@ -57,7 +57,7 @@ def test_rx(db_config, simtelpath_no_mock, io_handler):
     )
 
     ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtelpath_no_mock, config_data=config_data
+        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
     )
 
     ray.simulate(test=True, force=True)
@@ -95,7 +95,7 @@ def test_rx(db_config, simtelpath_no_mock, io_handler):
     plt.savefig(plot_file_area)
 
 
-def test_plot_image(db_config, simtelpath_no_mock, io_handler):
+def test_plot_image(db_config, simtel_path_no_mock, io_handler):
     version = "prod3"
     label = "test-astri"
     config_data = {
@@ -113,7 +113,7 @@ def test_plot_image(db_config, simtelpath_no_mock, io_handler):
     )
 
     ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtelpath_no_mock, config_data=config_data
+        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
     )
 
     ray.simulate(test=True, force=True)
@@ -132,7 +132,7 @@ def test_plot_image(db_config, simtelpath_no_mock, io_handler):
         plt.savefig(plot_file)
 
 
-def test_single_mirror(db_config, simtelpath_no_mock, io_handler, plot=False):
+def test_single_mirror(db_config, simtel_path_no_mock, io_handler, plot=False):
 
     # Test MST, single mirror PSF simulation
     version = "prod3"
@@ -147,7 +147,7 @@ def test_single_mirror(db_config, simtelpath_no_mock, io_handler, plot=False):
     )
 
     ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtelpath_no_mock, config_data=config_data
+        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
     )
     ray.simulate(test=True, force=True)
     ray.analyze(force=True)
@@ -164,7 +164,7 @@ def test_single_mirror(db_config, simtelpath_no_mock, io_handler, plot=False):
     plt.savefig(plot_file)
 
 
-def test_integral_curve(db_config, simtelpath_no_mock, io_handler):
+def test_integral_curve(db_config, simtel_path_no_mock, io_handler):
     version = "prod4"
     label = "lst_integral"
 
@@ -183,7 +183,7 @@ def test_integral_curve(db_config, simtelpath_no_mock, io_handler):
     )
 
     ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtelpath_no_mock, config_data=config_data
+        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
     )
 
     ray.simulate(test=True, force=True)

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -29,12 +29,12 @@ def corsika_config_data():
 
 
 @pytest.fixture
-def corsika_runner(corsika_config_data, io_handler, simtelpath):
+def corsika_runner(corsika_config_data, io_handler, simtel_path):
 
     corsika_runner = CorsikaRunner(
         site="south",
         layout_name="test-layout",
-        simtel_source_path=simtelpath,
+        simtel_source_path=simtel_path,
         label="test-corsika-runner",
         corsika_config_data=corsika_config_data,
     )

--- a/tests/unit_tests/simtel/test_simtel_runner.py
+++ b/tests/unit_tests/simtel/test_simtel_runner.py
@@ -11,9 +11,9 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
-def simtel_runner(simtelpath):
+def simtel_runner(simtel_path):
 
-    simtel_runner = SimtelRunner(simtel_source_path=simtelpath)
+    simtel_runner = SimtelRunner(simtel_source_path=simtel_path)
     return simtel_runner
 
 

--- a/tests/unit_tests/simtel/test_simtel_runner_array.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_array.py
@@ -33,10 +33,10 @@ def array_model(array_config_data, io_handler, db_config):
 
 
 @pytest.fixture
-def simtel_runner(array_model, simtelpath):
+def simtel_runner(array_model, simtel_path):
     simtel_runner = SimtelRunnerArray(
         array_model=array_model,
-        simtel_source_path=simtelpath,
+        simtel_source_path=simtel_path,
         config_data={
             "primary": "proton",
             "zenith_angle": 20 * u.deg,

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -13,17 +13,17 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
-def camera_efficiency_lst(telescope_model_lst, simtelpath):
+def camera_efficiency_lst(telescope_model_lst, simtel_path):
     camera_efficiency_lst = CameraEfficiency(
-        telescope_model=telescope_model_lst, simtel_source_path=simtelpath, test=True
+        telescope_model=telescope_model_lst, simtel_source_path=simtel_path, test=True
     )
     return camera_efficiency_lst
 
 
 @pytest.fixture
-def camera_efficiency_sst(telescope_model_sst, simtelpath):
+def camera_efficiency_sst(telescope_model_sst, simtel_path):
     camera_efficiency_sst = CameraEfficiency(
-        telescope_model=telescope_model_sst, simtel_source_path=simtelpath, test=True
+        telescope_model=telescope_model_sst, simtel_source_path=simtel_path, test=True
     )
     return camera_efficiency_sst
 
@@ -48,14 +48,14 @@ def results_file(db, io_handler):
     ).joinpath("camera-efficiency-North-LST-1-za20.0_validate_camera_efficiency.ecsv")
 
 
-def test_from_kwargs(telescope_model_lst, simtelpath):
+def test_from_kwargs(telescope_model_lst, simtel_path):
 
     tel_model = telescope_model_lst
     label = "test-from-kwargs"
     zenith_angle = 30 * u.deg
     ce = CameraEfficiency.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=simtelpath,
+        simtel_source_path=simtel_path,
         label=label,
         zenith_angle=zenith_angle,
         test=True,
@@ -63,10 +63,10 @@ def test_from_kwargs(telescope_model_lst, simtelpath):
     assert ce.config.zenith_angle == 30
 
 
-def test_validate_telescope_model(simtelpath):
+def test_validate_telescope_model(simtel_path):
 
     with pytest.raises(ValueError):
-        CameraEfficiency(telescope_model="bla_bla", simtel_source_path=simtelpath)
+        CameraEfficiency(telescope_model="bla_bla", simtel_source_path=simtel_path)
 
 
 def test_load_files(camera_efficiency_lst):

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -7,7 +7,7 @@ from simtools.model.telescope_model import TelescopeModel
 from simtools.ray_tracing import RayTracing
 
 
-def test_config_data_from_dict(db_config, simtelpath, io_handler):
+def test_config_data_from_dict(db_config, simtel_path, io_handler):
 
     label = "test-config-data"
     version = "prod5"
@@ -28,7 +28,7 @@ def test_config_data_from_dict(db_config, simtelpath, io_handler):
 
     ray = RayTracing(
         telescope_model=tel,
-        simtel_source_path=simtelpath,
+        simtel_source_path=simtel_path,
         config_data=config_data,
     )
 
@@ -36,7 +36,7 @@ def test_config_data_from_dict(db_config, simtelpath, io_handler):
     assert len(ray.config.off_axis_angle) == 2
 
 
-def test_from_kwargs(db, io_handler, simtelpath):
+def test_from_kwargs(db, io_handler, simtel_path):
 
     label = "test-from-kwargs"
 
@@ -64,7 +64,7 @@ def test_from_kwargs(db, io_handler, simtelpath):
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel,
-        simtel_source_path=simtelpath,
+        simtel_source_path=simtel_path,
         source_distance=source_distance,
         zenith_angle=zenith_angle,
         off_axis_angle=off_axis_angle,

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -70,12 +70,12 @@ def corsika_file():
 
 
 @pytest.fixture
-def array_simulator(label, array_config_data, io_handler, db_config, simtelpath):
+def array_simulator(label, array_config_data, io_handler, db_config, simtel_path):
 
     array_simulator = Simulator(
         label=label,
         simulator="simtel",
-        simulator_source_path=simtelpath,
+        simulator_source_path=simtel_path,
         config_data=array_config_data,
         mongo_db_config=db_config,
     )
@@ -83,12 +83,12 @@ def array_simulator(label, array_config_data, io_handler, db_config, simtelpath)
 
 
 @pytest.fixture
-def shower_simulator(label, shower_config_data, io_handler, simtelpath):
+def shower_simulator(label, shower_config_data, io_handler, simtel_path):
 
     shower_simulator = Simulator(
         label=label,
         simulator="corsika",
-        simulator_source_path=simtelpath,
+        simulator_source_path=simtel_path,
         config_data=shower_config_data,
     )
     return shower_simulator
@@ -282,13 +282,13 @@ def test_fill_results(array_simulator, shower_simulator, input_file_list):
 
 
 def test_print_histograms(
-    array_config_data, shower_simulator, input_file_list, db_config, simtelpath
+    array_config_data, shower_simulator, input_file_list, db_config, simtel_path
 ):
 
     _array_simulator = Simulator(
         label="simtel_test",
         simulator="simtel",
-        simulator_source_path=simtelpath,
+        simulator_source_path=simtel_path,
         config_data=array_config_data,
         mongo_db_config=db_config,
     )
@@ -311,7 +311,7 @@ def test_get_list_of_files(shower_simulator):
     assert len(shower_simulator.get_list_of_output_files(run_range=[1, 4])) == 14
 
 
-def test_no_corsika_data(shower_config_data, label, simtelpath, io_handler):
+def test_no_corsika_data(shower_config_data, label, simtel_path, io_handler):
 
     new_shower_config_data = copy(shower_config_data)
     new_shower_config_data.pop("data_directory", None)
@@ -319,7 +319,7 @@ def test_no_corsika_data(shower_config_data, label, simtelpath, io_handler):
         label=label,
         simulator="corsika",
         config_data=new_shower_config_data,
-        simulator_source_path=simtelpath,
+        simulator_source_path=simtel_path,
     )
     files = new_shower_simulator.get_list_of_output_files(run_list=[3])
 
@@ -335,13 +335,13 @@ def test_make_resources_report(array_simulator, input_file_list):
         array_simulator._make_resources_report(input_file_list)
 
 
-def test_get_runs_to_simulate(shower_config_data, simtelpath, io_handler):
+def test_get_runs_to_simulate(shower_config_data, simtel_path, io_handler):
 
     shower_simulator = Simulator(
         label="corsika-test",
         simulator="corsika",
         config_data=shower_config_data,
-        simulator_source_path=simtelpath,
+        simulator_source_path=simtel_path,
     )
     assert len(shower_simulator.runs) == len(
         shower_simulator._get_runs_to_simulate(run_list=None, run_range=None)


### PR DESCRIPTION
Discussed recently that we want to have a consistent naming of all path variables. `simtelpath` is the only one which is different and has now been changed `simtel_path` to be consistent with everything else.

Annoyingly, this is more than a 1 line change and also requires and update to the development container. Anyway, easy to implement.