### PR TITLE
Change logging levels for simtel_runner

### DIFF
--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -163,7 +163,7 @@ class SimtelRunner:
             self._logger.info("Running (test) with command:{}".format(command))
             self._run_simtel_and_check_output(command)
         else:
-            self._logger.info("Running ({}x) with command:{}".format(self.RUNS_PER_SET, command))
+            self._logger.debug("Running ({}x) with command:{}".format(self.RUNS_PER_SET, command))
             self._run_simtel_and_check_output(command)
 
             for _ in range(self.RUNS_PER_SET - 1):


### PR DESCRIPTION
Addresses issue #90 and suppresses a lot of prints to the screen when running with default verbose options.

Closes #90 