### PR TITLE
Reduce footprint of conda image by >800MB 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,13 @@
 # A conda environment with all useful package for gammasim-tools developers
 name: gammasim-tools-dev
+channels:
+  - conda-forge
 dependencies:
   - python=3.9
   - pyyaml
   - numpy
   - astropy
-  - matplotlib
+  - matplotlib-base
   - sphinx
   - pre-commit
   - pytest


### PR DESCRIPTION
The footprint of the conda packages is insane and slows down installation and tests.

Two quick changes, which should not have any impact on any results / running:

- change to conda-forge (numpy does not install the 800MB large mkl library)
- change to matploblib-base removes the >150 MB large QT installation, which we don't use)

Related to PR in the container section.