### PR TITLE
Automatic extraction of version number and authors

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,7 +138,7 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "bizstyle"
+html_theme = "sphinx_rtd_theme"
 
 html_title = f"{project} v{version} Manual"
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-from astropy.io.misc import yaml
+import yaml
 
 import simtools.version
 
@@ -31,7 +31,7 @@ def get_authors_from_citation_file(file_name):
     """
     try:
         with open("../../CITATION.cff") as file:
-            citation = yaml.load(file)
+            citation = yaml.safe_load(file)
     except FileNotFoundError:
         raise
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,22 +15,51 @@
 import os
 import sys
 
+from astropy.io.misc import yaml
+
+import simtools.version
+
 sys.path.insert(0, os.path.abspath("../../simtools"))
 sys.path.insert(0, os.path.abspath("../../applications"))
 sys.path.insert(0, os.path.abspath("../.."))
+
+
+def get_authors_from_citation_file(file_name):
+    """
+    Read list of authors from CITATION.cff file
+
+    """
+    try:
+        with open("../../CITATION.cff") as file:
+            citation = yaml.load(file)
+    except FileNotFoundError:
+        raise
+
+    author = ""
+    try:
+        for person in citation["authors"]:
+            author = author + person["given-names"] + " " + person["family-names"]
+            author += " (" + person["affiliation"] + "), "
+    except KeyError:
+        pass
+    return author[:-1]
 
 
 # -- Project information -----------------------------------------------------
 
 project = "gammasim-tools"
 copyright = "2022, gammasim-tools developers"
-author = "Raul R Prado and Orel Gueta and Gernot Maier and Victor Barbosa Martins"
+author = get_authors_from_citation_file("../CITATION.cff")
+rst_epilog = """
+.. |author| replace:: {author}
+""".format(
+    author=author
+)
 
 # The short X.Y version
-version = ""
+version = str(simtools.version.__version__)
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
-
+release = version
 
 # -- General configuration ---------------------------------------------------
 
@@ -93,7 +122,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -109,7 +138,9 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "bizstyle"
+
+html_title = f"{project} v{version} Manual"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -131,7 +162,10 @@ html_static_path = []
 # 'searchbox.html']``.
 #
 # html_sidebars = {}
-
+html_sidebars = {
+    "**": ["globaltoc.html", "sourcelink.html", "searchbox.html"],
+    "using/windows": ["windowssidebar.html", "searchbox.html"],
+}
 
 # -- Options for HTMLHelp output ---------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,13 +22,15 @@ The design principles followed by gammasim-tools are:
 * maximizes the sharing of tools and algorithms with other DPPS subsystems (e.g., `ctapipe <https://github.com/cta-observatory/ctapipe>`_ and calibpipe);
 * I/O and reporting tools for the MC simulation model parameter and production database.
 
-Contact
+Authors
 =======
 
-* Raul R Prado (raul.prado@desy.de)
-* Orel Gueta (orel.gueta@desy.de)
-* Victor B. Martins (victor.barbosa.martins@desy.de)
-* Gernot Maier (gernot.maier@desy.de)
+|author|
+
+Citation
+========
+
+See citation file (`CITATION.cff <https://github.com/gammasim/gammasim-tools/blob/master/CITATION.cff>`_) on how to site this software.
 
 
 General Documentation


### PR DESCRIPTION
Ignore the name of this PR - we should change the theme later to something pretty (e.g., using the [numpydoc extensions](https://numpydoc.readthedocs.io/en/latest/index.html)).

Changes here are to automatize the following:

- read version number from `simtools.version`
- read authors from CITATION.cff file (note that these are filled both as html authors and are available in the RST files using `|author|`

Removed also `docs/_config.yml`, this is a file from previous implementations of the documentation and not used anywhere.