### PR TITLE
Make testeff execution a simtel_runner

### DIFF
--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -184,7 +184,9 @@ class CameraEfficiency:
         simtel = SimtelRunnerCameraEfficiency(
             simtel_source_path=self._simtel_source_path,
             telescope_model=self._telescope_model,
+            zenith_angle=self.config.zenith_angle,
             file_simtel=self._file_simtel,
+            file_log=self._file_log,
             label=self.label,
         )
         simtel.run(test=self.test, force=force)

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -335,9 +335,9 @@ class CameraEfficiency:
         masts_factor = self._results["masts"][0]
         fill_factor = self._telescope_model.camera.get_camera_fill_factor()
 
-        tel_effeciency = fill_factor * (c4_sum / (masts_factor * c1_sum))
+        tel_efficiency = fill_factor * (c4_sum / (masts_factor * c1_sum))
 
-        return tel_effeciency
+        return tel_efficiency
 
     def calc_camera_efficiency(self):
         """
@@ -356,18 +356,18 @@ class CameraEfficiency:
         c4x_sum = np.sum(c4x_reduced_wl)
         fill_factor = self._telescope_model.camera.get_camera_fill_factor()
 
-        cam_effeciency_no_gaps = c4x_sum / c1_sum
-        cam_effeciency = cam_effeciency_no_gaps * fill_factor
+        cam_efficiency_no_gaps = c4x_sum / c1_sum
+        cam_efficiency = cam_efficiency_no_gaps * fill_factor
 
-        return cam_effeciency
+        return cam_efficiency
 
-    def calc_tot_efficiency(self, tel_effeciency):
+    def calc_tot_efficiency(self, tel_efficiency):
         """
         Calculate the telescope total efficiency including gaps (as defined in A-PERF-2020).
 
         Parameters
         ----------
-        tel_effeciency: float
+        tel_efficiency: float
             The telescope efficiency as calculated by calc_tel_efficiency()
         """
 
@@ -381,9 +381,9 @@ class CameraEfficiency:
         masts_factor = self._results["masts"][0]
         fill_factor = self._telescope_model.camera.get_camera_fill_factor()
 
-        tel_effeciency_nsb = fill_factor * (n4_sum / (masts_factor * n1_sum))
+        tel_efficiency_nsb = fill_factor * (n4_sum / (masts_factor * n1_sum))
 
-        return tel_effeciency / np.sqrt(tel_effeciency_nsb)
+        return tel_efficiency / np.sqrt(tel_efficiency_nsb)
 
     def calc_reflectivity(self):
         """

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -5,6 +5,7 @@ from pydoc import locate
 
 import astropy.io.ascii
 import numpy as np
+from astropy import units as u
 from astropy.table import Table
 
 import simtools.util.general as gen
@@ -341,6 +342,31 @@ class TelescopeModel:
         Value of the parameter
         """
         par_info = self.get_parameter(par_name)
+        return par_info["Value"]
+
+    def get_parameter_value_with_unit(self, par_name):
+        """
+        Get the value of an existing parameter of the model as an Astropy Quantity with its unit.
+        If no unit is provided in the model, the value is returned without a unit.
+
+        Parameters
+        ----------
+        par_name: str
+            Name of the parameter.
+
+        Raises
+        ------
+        InvalidParameter
+            If par_name does not match any parameter in this model.
+
+        Returns
+        -------
+        Astropy quantity with the value of the parameter multiplied by its unit.
+        If no unit is provided in the model, the value is returned without a unit.
+        """
+        par_info = self.get_parameter(par_name)
+        if "units" in par_info:
+            return par_info["Value"] * u.Unit(par_info["units"])
         return par_info["Value"]
 
     def add_parameter(self, par_name, value, is_file=False, is_aplicable=True):

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -153,7 +153,7 @@ class SimtelRunner:
             self._logger.error(msg)
             raise RuntimeError(msg)
 
-        if not self._shall_run(run_number) and not force:
+        if not self._shall_run(run_number=run_number) and not force:
             self._logger.info("Skipping because output exists and force = False")
             return
 

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -160,10 +160,10 @@ class SimtelRunner:
         command = self._make_run_command(input_file=input_file, run_number=run_number)
 
         if test:
-            self._logger.info("Running (test) with command:{}".format(command))
+            self._logger.info("Running (test) with command: {}".format(command))
             self._run_simtel_and_check_output(command)
         else:
-            self._logger.debug("Running ({}x) with command:{}".format(self.RUNS_PER_SET, command))
+            self._logger.debug("Running ({}x) with command: {}".format(self.RUNS_PER_SET, command))
             self._run_simtel_and_check_output(command)
 
             for _ in range(self.RUNS_PER_SET - 1):
@@ -202,7 +202,7 @@ class SimtelRunner:
         if self._simtel_failed(sys_output):
             self._raise_simtel_error()
 
-    def _shall_run(self, run_number=None):
+    def _shall_run(self, **kwargs):
         self._logger.debug(
             "shall_run is being called from the base class - returning False -"
             + "it should be implemented in the sub class"

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -298,10 +298,10 @@ class SimtelRunnerArray(SimtelRunner):
 
         return command
 
-    def _check_run_result(self, run_number):
+    def _check_run_result(self, **kwargs):
         # Checking run
         output_file = self.get_file_name(
-            file_type="output", **self.get_info_for_file_name(run_number)
+            file_type="output", **self.get_info_for_file_name(kwargs["run_number"])
         )
         if not output_file.exists():
             msg = "sim_telarray output file does not exist."

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -254,26 +254,29 @@ class SimtelRunnerArray(SimtelRunner):
 
         return _resources
 
-    def _shall_run(self, run_number=None):
+    def _shall_run(self, **kwargs):
         """Tells if simulations should be run again based on the existence of output files."""
         output_file = self.get_file_name(
-            file_type="output", **self.get_info_for_file_name(run_number)
+            file_type="output", **self.get_info_for_file_name(kwargs["run_number"])
         )
         return not output_file.exists()
 
-    def _make_run_command(self, input_file, run_number=1):
+    def _make_run_command(self, **kwargs):
         """
         Builds and returns the command to run simtel_array.
 
         Attributes
         ----------
-        input_file: str
-            Full path of the input CORSIKA file
-        run_number: int
-            run number
+        kwargs: dict
+            The dictionary must include the following parameters (unless listed as optional):
+                input_file: str
+                    Full path of the input CORSIKA file
+                run_number: int (optional)
+                    run number
 
         """
 
+        run_number = kwargs["run_number"] if "run_number" in kwargs else 1
         info_for_file_name = self.get_info_for_file_name(run_number)
         self._log_file = self.get_file_name(file_type="log", **info_for_file_name)
         histogram_file = self.get_file_name(file_type="histogram", **info_for_file_name)
@@ -290,7 +293,7 @@ class SimtelRunnerArray(SimtelRunner):
         command += super()._config_option("output_file", output_file)
         command += super()._config_option("random_state", "auto")
         command += super()._config_option("show", "all")
-        command += " " + str(input_file)
+        command += " " + str(kwargs["input_file"])
         command += " > " + str(self._log_file) + " 2>&1"
 
         return command

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -1,0 +1,188 @@
+import logging
+
+from simtools.simtel.simtel_runner import SimtelRunner
+
+__all__ = ["SimtelRunnerCameraEfficiency"]
+
+
+class SimtelRunnerCameraEfficiency(SimtelRunner):
+    """
+    SimtelRunnerCameraEfficiency is the interface with the testeff tool of sim_telarray
+    to perform camera efficiency simulations.
+
+    Attributes
+    ----------
+    label: str, optional
+        Instance label.
+    telescope_model: TelescopeModel
+        Instance of the TelescopeModel class.
+    config: namedtuple
+        Contains the configurable parameters (zenith_angle).
+    """
+
+    def __init__(
+        self,
+        telescope_model,
+        label=None,
+        simtel_source_path=None,
+        file_simtel=None,
+    ):
+        """
+        SimtelRunner.
+
+        Parameters
+        ----------
+        telescope_model: str
+            Instance of TelescopeModel class.
+        label: str, optional
+            Instance label. Important for output file naming.
+        simtel_source_path: str (or Path)
+            Location of sim_telarray installation.
+        file_simtel: str (or Path)
+            location of the sim_telarray testeff tool output file
+        """
+        self._logger = logging.getLogger(__name__)
+        self._logger.debug("Init SimtelRunnerCameraEfficiency")
+
+        super().__init__(label=label, simtel_source_path=simtel_source_path)
+
+        self.telescope_model = telescope_model
+        self.label = label if label is not None else self.telescope_model.label
+
+        self._file_simtel = file_simtel
+
+    def _shall_run(self, **kwargs):
+        """Tells if simulations should be run again based on the existence of output files."""
+        return self._file_simtel.exists()
+
+    def _make_run_command(self, **kwargs):
+        """
+        Prepare the command used to run testeff
+        """
+
+        self._logger.debug("Preparing the command to run testeff")
+
+        # Processing camera pixel features
+        pixel_shape = self._telescope_model.camera.get_pixel_shape()
+        pixel_shape_cmd = "-hpix" if pixel_shape in [1, 3] else "-spix"
+        pixel_diameter = self._telescope_model.camera.get_pixel_diameter()
+
+        # Processing focal length
+        focal_length = self._telescope_model.get_parameter_value("effective_focal_length")
+        if focal_length == 0.0:
+            self._logger.warning("Using focal_length because effective_focal_length is 0")
+            focal_length = self._telescope_model.get_parameter_value("focal_length")
+
+        # Processing mirror class
+        mirror_class = 1
+        if self._telescope_model.has_parameter("mirror_class"):
+            mirror_class = self._telescope_model.get_parameter_value("mirror_class")
+
+        # Processing camera transmission
+        camera_transmission = 1
+        if self._telescope_model.has_parameter("camera_transmission"):
+            camera_transmission = self._telescope_model.get_parameter_value("camera_transmission")
+
+        # Processing camera filter
+        # A special case is testeff does not support 2D distributions
+        camera_filter_file = self._telescope_model.get_parameter_value("camera_filter")
+        if self._telescope_model.is_file_2D("camera_filter"):
+            camera_filter_file = self._get_one_dim_distribution(
+                "camera_filter", "camera_filter_incidence_angle"
+            )
+
+        # Processing mirror reflectivity
+        # A special case is testeff does not support 2D distributions
+        mirror_reflectivity = self._telescope_model.get_parameter_value("mirror_reflectivity")
+        if mirror_class == 2:
+            mirror_reflectivity_secondary = mirror_reflectivity
+        if self._telescope_model.is_file_2D("mirror_reflectivity"):
+            mirror_reflectivity = self._get_one_dim_distribution(
+                "mirror_reflectivity", "primary_mirror_incidence_angle"
+            )
+            mirror_reflectivity_secondary = super()._get_one_dim_distribution(
+                "mirror_reflectivity", "secondary_mirror_incidence_angle"
+            )
+
+        command = str(self._simtel_source_path.joinpath("sim_telarray/bin/testeff"))
+        command += " -nm -nsb-extra"
+        command += f" -alt {self._telescope_model.get_parameter_value('altitude')}"
+        command += f" -fatm {self._telescope_model.get_parameter_value('atmospheric_transmission')}"
+        command += f" -flen {focal_length * 0.01}"  # focal length in meters
+        command += f" {pixel_shape_cmd} {pixel_diameter}"
+        if mirror_class == 1:
+            command += f" -fmir {self._telescope_model.get_parameter_value('mirror_list')}"
+        command += f" -fref {mirror_reflectivity}"
+        if mirror_class == 2:
+            command += " -m2"
+            command += f" -fref2 {mirror_reflectivity_secondary}"
+        command += f" -teltrans {self._telescope_model.get_telescope_transmission_parameters()[0]}"
+        command += f" -camtrans {camera_transmission}"
+        command += f" -fflt {camera_filter_file}"
+        command += (
+            f" -fang {self._telescope_model.camera.get_lightguide_efficiency_angle_file_name()}"
+        )
+        command += (
+            f" -fwl {self._telescope_model.camera.get_lightguide_efficiency_wavelength_file_name()}"
+        )
+        command += f" -fqe {self._telescope_model.get_parameter_value('quantum_efficiency')}"
+        command += " 200 1000"  # lmin and lmax
+        command += " 300 26"  # Xmax, ioatm (Konrad always uses 26)
+        command += f" {self.config.zenith_angle}"
+        command += f" 2>{self._file_log}"
+        command += f" >{self._file_simtel}"
+
+        # Moving to sim_telarray directory before running
+        command = f"cd {self._simtel_source_path.joinpath('sim_telarray')} && {command}"
+
+        return command
+
+    def _check_run_result(self, run_number=None):
+        # Checking run
+        if not self._file_simtel.exists():
+            msg = "Camera efficiency simulation results file does not exist"
+            self._logger.error(msg)
+            raise RuntimeError(msg)
+        else:
+            self._logger.debug("Everything looks fine with output file.")
+
+    def _get_one_dim_distribution(self, two_dim_parameter, weighting_distribution_parameter):
+        """
+        Calculate an average one-dimensional curve for testeff from the two-dimensional curve.
+        The two-dimensional distribution is provided in two_dim_parameter. The distribution
+        of weights to use for averaging the two-dimensional distribution is given in
+        weighting_distribution_parameter.
+
+        Returns
+        -------
+        one_dim_file: Path
+            The file path and name with the new one-dimensional distribution
+        """
+        incidence_angle_distribution_file = self._telescope_model.get_parameter_value(
+            weighting_distribution_parameter
+        )
+        incidence_angle_distribution = self._telescope_model.read_incidence_angle_distribution(
+            incidence_angle_distribution_file
+        )
+        self._logger.warning(
+            f"The {' '.join(two_dim_parameter.split('_'))} distribution "
+            "is a 2D one which testeff does not support. "
+            "Instead of using the 2D distribution, the two dimensional distribution "
+            "will be averaged, using the photon incidence angle distribution as weights. "
+            "The incidence angle distribution is taken "
+            f"from the file - {incidence_angle_distribution_file})."
+        )
+        two_dim_distribution = self._telescope_model.read_two_dim_wavelength_angle(
+            self._telescope_model.get_parameter_value(two_dim_parameter)
+        )
+        distribution_to_export = self._telescope_model.calc_average_curve(
+            two_dim_distribution, incidence_angle_distribution
+        )
+        new_file_name = (
+            f"weighted_average_1D_{self._telescope_model.get_parameter_value(two_dim_parameter)}"
+        )
+        one_dim_file = self._telescope_model.export_table_to_model_directory(
+            new_file_name, distribution_to_export
+        )
+
+        return one_dim_file

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -26,6 +26,8 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         label=None,
         simtel_source_path=None,
         file_simtel=None,
+        file_log=None,
+        zenith_angle=None,
     ):
         """
         SimtelRunner.
@@ -40,16 +42,20 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
             Location of sim_telarray installation.
         file_simtel: str (or Path)
             location of the sim_telarray testeff tool output file
+        zenith_angle: float
+            The zenith angle given in the config to CameraEfficiency
         """
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init SimtelRunnerCameraEfficiency")
 
         super().__init__(label=label, simtel_source_path=simtel_source_path)
 
-        self.telescope_model = telescope_model
+        self._telescope_model = telescope_model
         self.label = label if label is not None else self.telescope_model.label
 
         self._file_simtel = file_simtel
+        self._file_log = file_log
+        self.zenith_angle = zenith_angle
 
     def _shall_run(self, **kwargs):
         """Tells if simulations should be run again based on the existence of output files."""
@@ -100,7 +106,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
             mirror_reflectivity = self._get_one_dim_distribution(
                 "mirror_reflectivity", "primary_mirror_incidence_angle"
             )
-            mirror_reflectivity_secondary = super()._get_one_dim_distribution(
+            mirror_reflectivity_secondary = self._get_one_dim_distribution(
                 "mirror_reflectivity", "secondary_mirror_incidence_angle"
             )
 
@@ -128,7 +134,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         command += f" -fqe {self._telescope_model.get_parameter_value('quantum_efficiency')}"
         command += " 200 1000"  # lmin and lmax
         command += " 300 26"  # Xmax, ioatm (Konrad always uses 26)
-        command += f" {self.config.zenith_angle}"
+        command += f" {self.zenith_angle}"
         command += f" 2>{self._file_log}"
         command += f" >{self._file_simtel}"
 

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -74,10 +74,10 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         pixel_diameter = self._telescope_model.camera.get_pixel_diameter()
 
         # Processing focal length
-        focal_length = self._telescope_model.get_parameter_value("effective_focal_length")
+        focal_length = self._telescope_model.get_parameter_value_with_unit("effective_focal_length")
         if focal_length == 0.0:
             self._logger.warning("Using focal_length because effective_focal_length is 0")
-            focal_length = self._telescope_model.get_parameter_value("focal_length")
+            focal_length = self._telescope_model.get_parameter_value_with_unit("focal_length")
 
         # Processing mirror class
         mirror_class = 1
@@ -114,7 +114,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         command += " -nm -nsb-extra"
         command += f" -alt {self._telescope_model.get_parameter_value('altitude')}"
         command += f" -fatm {self._telescope_model.get_parameter_value('atmospheric_transmission')}"
-        command += f" -flen {focal_length * 0.01}"  # focal length in meters
+        command += f" -flen {focal_length.to('m').value}"
         command += f" {pixel_shape_cmd} {pixel_diameter}"
         if mirror_class == 1:
             command += f" -fmir {self._telescope_model.get_parameter_value('mirror_list')}"

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -143,7 +143,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
 
         return command
 
-    def _check_run_result(self, run_number=None):
+    def _check_run_result(self, **kwargs):
         # Checking run
         if not self._file_simtel.exists():
             msg = "Camera efficiency simulation results file does not exist"

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -59,7 +59,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
 
     def _shall_run(self, **kwargs):
         """Tells if simulations should be run again based on the existence of output files."""
-        return self._file_simtel.exists()
+        return not self._file_simtel.exists()
 
     def _make_run_command(self, **kwargs):
         """

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -117,6 +117,9 @@ class SimtelRunnerRayTracing(SimtelRunner):
         Here we define and write some information into these files. Log files are always required.
         """
 
+        # This file is not actually needed and does not exist in gammasim-tools.
+        # However, we need to provide the name of a CORSIKA input file to sim_telarray
+        # so it is set up here.
         self._corsika_file = self._simtel_source_path.joinpath("run9991.corsika.gz")
 
         # Loop to define and remove existing files.

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -226,10 +226,12 @@ class SimtelRunnerRayTracing(SimtelRunner):
 
         return command
 
-    def _check_run_result(self, run_number=None):
+    def _check_run_result(self, **kwargs):
         # Checking run
         if not self._is_photon_list_file_ok():
-            self._logger.error("Photon list is empty.")
+            msg = "Photon list is empty."
+            self._logger.error(msg)
+            raise RuntimeError(msg)
         else:
             self._logger.debug("Everything looks fine with output file.")
 

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -164,11 +164,11 @@ class SimtelRunnerRayTracing(SimtelRunner):
                     )
                 )
 
-    def _shall_run(self, run_number=None):
+    def _shall_run(self, **kwargs):
         """Tells if simulations should be run again based on the existence of output files."""
         return not self._is_photon_list_file_ok()
 
-    def _make_run_command(self, input_file, run_number=None):
+    def _make_run_command(self, **kwargs):
         """Return the command to run simtel_array."""
 
         if self._single_mirror_mode:

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -5,6 +5,7 @@ import logging
 
 import numpy as np
 import pytest
+from astropy import units as u
 
 import simtools.util.general as gen
 from simtools.model.telescope_model import InvalidParameter, TelescopeModel
@@ -39,6 +40,14 @@ def telescope_model_from_config_file(lst_config_file):
         config_file_name=lst_config_file,
     )
     return tel_model
+
+
+def test_get_parameter_value_with_unit(telescope_model_lst):
+
+    tel_model = telescope_model_lst
+
+    assert isinstance(tel_model.get_parameter_value_with_unit("effective_focal_length"), u.Quantity)
+    assert not isinstance(tel_model.get_parameter_value_with_unit("num_gains"), u.Quantity)
 
 
 def test_handling_parameters(telescope_model_lst):

--- a/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
@@ -13,6 +13,8 @@ logger.setLevel(logging.DEBUG)
 
 @pytest.fixture
 def camera_efficiency_sst(telescope_model_sst, simtel_path):
+
+    telescope_model_sst.export_model_files()
     camera_efficiency_sst = CameraEfficiency(
         telescope_model=telescope_model_sst, simtel_source_path=simtel_path, test=True
     )
@@ -31,20 +33,40 @@ def simtel_runner_camera_efficiency(camera_efficiency_sst, telescope_model_sst, 
 
 
 def test_shall_run(simtel_runner_camera_efficiency):
+    """
+    Testing here that the file does not exist because no simulations
+    are run in unit tests. This function is tested for the positive case
+    in the integration tests.
+    """
+
     assert not simtel_runner_camera_efficiency._shall_run()
 
 
 def test_make_run_command(simtel_runner_camera_efficiency):
 
-    # command = simtel_runner_camera_efficiency._make_run_command()
+    command = simtel_runner_camera_efficiency._make_run_command()
 
-    # FIXME - check that the command is as expected
-    assert True
+    assert "alt 2147.0 -fatm atm_trans_2147_1_10_2_0_2147.dat" in command
+    assert "-flen 2.15191 -spix 0.62" in command
+    assert "weighted_average_1D_ref_astri-2d_2018-01-17.dat -m2" in command
+    assert "-teltrans 0.92362" in command
+    assert "weighted_average_1D_transmission_astri_window_new.dat" in command
+    assert "-fqe PDE_V_4.4V_LVR5_ext.txt" in command
 
 
-def test_get_one_dim_distribution(telescope_model_sst, simtel_runner_camera_efficiency):
+def test_check_run_result(simtel_runner_camera_efficiency):
+    """
+    Testing here that the file does not exist because no simulations
+    are run in unit tests. This function is tested for the positive case
+    in the integration tests.
+    """
 
-    telescope_model_sst.export_model_files()
+    with pytest.raises(RuntimeError):
+        simtel_runner_camera_efficiency._check_run_result()
+
+
+def test_get_one_dim_distribution(simtel_runner_camera_efficiency):
+
     camera_filter_file = simtel_runner_camera_efficiency._get_one_dim_distribution(
         "camera_filter", "camera_filter_incidence_angle"
     )

--- a/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+import logging
+
+import pytest
+
+from simtools.camera_efficiency import CameraEfficiency
+from simtools.simtel.simtel_runner_camera_efficiency import SimtelRunnerCameraEfficiency
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture
+def camera_efficiency_sst(telescope_model_sst, simtel_path):
+    camera_efficiency_sst = CameraEfficiency(
+        telescope_model=telescope_model_sst, simtel_source_path=simtel_path, test=True
+    )
+    return camera_efficiency_sst
+
+
+@pytest.fixture
+def simtel_runner_camera_efficiency(camera_efficiency_sst, telescope_model_sst, simtel_path):
+    simtel_runner_camera_efficiency = SimtelRunnerCameraEfficiency(
+        simtel_source_path=simtel_path,
+        telescope_model=telescope_model_sst,
+        file_simtel=camera_efficiency_sst._file_simtel,
+        label="test-simtel-runner-camera-efficiency",
+    )
+    return simtel_runner_camera_efficiency
+
+
+def test_shall_run(simtel_runner_camera_efficiency):
+    assert not simtel_runner_camera_efficiency._shall_run()
+
+
+def test_make_run_command(simtel_runner_camera_efficiency):
+
+    # command = simtel_runner_camera_efficiency._make_run_command()
+
+    # FIXME - check that the command is as expected
+    assert True
+
+
+def test_get_one_dim_distribution(telescope_model_sst, simtel_runner_camera_efficiency):
+
+    telescope_model_sst.export_model_files()
+    camera_filter_file = simtel_runner_camera_efficiency._get_one_dim_distribution(
+        "camera_filter", "camera_filter_incidence_angle"
+    )
+    assert camera_filter_file.exists()

--- a/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
@@ -39,13 +39,14 @@ def test_shall_run(simtel_runner_camera_efficiency):
     in the integration tests.
     """
 
-    assert not simtel_runner_camera_efficiency._shall_run()
+    assert simtel_runner_camera_efficiency._shall_run()
 
 
 def test_make_run_command(simtel_runner_camera_efficiency):
 
     command = simtel_runner_camera_efficiency._make_run_command()
 
+    assert "testeff" in command
     assert "alt 2147.0 -fatm atm_trans_2147_1_10_2_0_2147.dat" in command
     assert "-flen 2.15191 -spix 0.62" in command
     assert "weighted_average_1D_ref_astri-2d_2018-01-17.dat -m2" in command

--- a/tests/unit_tests/simtel/test_simtel_runner_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_ray_tracing.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import logging
+
+import astropy.units as u
+import pytest
+
+from simtools.ray_tracing import RayTracing
+from simtools.simtel.simtel_runner_ray_tracing import SimtelRunnerRayTracing
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+
+@pytest.fixture
+def ray_tracing_sst(telescope_model_sst, simtel_path):
+
+    # telescope_model_sst.export_model_files()
+
+    config_data = {
+        "source_distance": 10 * u.km,
+        "zenith_angle": 20 * u.deg,
+        "off_axis_angle": [0, 2] * u.deg,
+    }
+
+    ray_tracing_sst = RayTracing(
+        telescope_model=telescope_model_sst,
+        simtel_source_path=simtel_path,
+        config_data=config_data,
+        label="test-simtel-runner-ray-tracing",
+    )
+
+    return ray_tracing_sst
+
+
+@pytest.fixture
+def simtel_runner_ray_tracing(ray_tracing_sst, telescope_model_sst, simtel_path):
+    simtel_runner_ray_tracing = SimtelRunnerRayTracing(
+        simtel_source_path=simtel_path,
+        telescope_model=telescope_model_sst,
+        config_data={
+            "zenith_angle": ray_tracing_sst.config.zenith_angle * u.deg,
+            "source_distance": ray_tracing_sst._source_distance * u.km,
+            "off_axis_angle": 0 * u.deg,
+            "mirror_number": 0,
+            "use_random_focal_length": ray_tracing_sst.config.use_random_focal_length,
+        },
+        single_mirror_mode=ray_tracing_sst.config.single_mirror_mode,
+        label="test-simtel-runner-ray-tracing",
+    )
+    return simtel_runner_ray_tracing
+
+
+def test_load_required_files(simtel_runner_ray_tracing):
+
+    simtel_runner_ray_tracing._load_required_files(force_simulate=False)
+
+    # This file is not actually needed and does not exist in gammasim-tools.
+    # However, its name is needed too provide the name of a CORSIKA input file to sim_telarray
+    # so here we check the it does not actually exist.
+    assert not simtel_runner_ray_tracing._corsika_file.exists()
+    assert simtel_runner_ray_tracing._photons_file.exists()
+    assert simtel_runner_ray_tracing._stars_file.exists()
+
+
+def test_shall_run(simtel_runner_ray_tracing):
+    """
+    Testing here that the file does not exist because no simulations
+    are run in unit tests. This function is tested for the positive case
+    in the integration tests.
+    """
+
+    assert simtel_runner_ray_tracing._shall_run()
+
+
+def test_make_run_command(simtel_runner_ray_tracing):
+
+    command = simtel_runner_ray_tracing._make_run_command()
+
+    assert "bin/sim_telarray" in command
+    assert "model/CTA-South-SST-D-2020-06-28_test-telescope-model-sst.cfg" in command
+    assert "altitude=2147.0 -C telescope_theta=20.0 -C star_photons=100000" in command
+    assert "log-South-SST-D-d10.0-za20.0-off0.000_test-simtel-runner-ray-tracing.log" in command
+
+
+def test_check_run_result(simtel_runner_ray_tracing):
+    """
+    Testing here that the file does not exist because no simulations
+    are run in unit tests. This function is tested for the positive case
+    in the integration tests.
+    """
+
+    with pytest.raises(RuntimeError):
+        simtel_runner_ray_tracing._check_run_result()
+
+
+def test_is_photon_list_file_ok(simtel_runner_ray_tracing):
+    """
+    Testing here that the file does not exist because no simulations
+    are run in unit tests. This function is tested for the positive case
+    in the integration tests.
+    """
+    assert not simtel_runner_ray_tracing._is_photon_list_file_ok()
+
+    # Now add manually entries to the photons file to test the function works as expected
+    simtel_runner_ray_tracing._load_required_files(force_simulate=False)
+    with simtel_runner_ray_tracing._photons_file.open("a") as file:
+        file.writelines(150 * [f"{1}\n"])
+
+    assert simtel_runner_ray_tracing._is_photon_list_file_ok()

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -129,12 +129,3 @@ def test_calc_nsb_rate(telescope_model_lst, camera_efficiency_lst, results_file)
     assert camera_efficiency_lst.calc_nsb_rate()[0] == pytest.approx(
         0.24421390533203186
     )  # Value for Prod5 LST-1
-
-
-def test_get_one_dim_distribution(telescope_model_sst, camera_efficiency_sst):
-
-    telescope_model_sst.export_model_files()
-    camera_filter_file = camera_efficiency_sst._get_one_dim_distribution(
-        "camera_filter", "camera_filter_incidence_angle"
-    )
-    assert camera_filter_file.exists()


### PR DESCRIPTION
The execution of testeff is now part of the simtel_runner class so it uses the same API with the same checks for failures. Added also tests for `simtel_runner_ray_tracing.py`. This PR closes #37 and #208.