### PR TITLE
Set matplotlib logger to warning level

### DIFF
--- a/simtools/__init__.py
+++ b/simtools/__init__.py
@@ -1,3 +1,4 @@
 import logging
 
 logging.basicConfig(format="%(levelname)s::%(module)s(l%(lineno)s)::%(funcName)s::%(message)s")
+logging.getLogger("matplotlib").setLevel(logging.WARNING)


### PR DESCRIPTION
This suppresses the infinite debug messages from matplotlib. It's far from the ideal solution, but the other option is to rewrite our entire logging functionality. Honestly, it's not such a bad solution either. Closes #244.