### PR TITLE
Ignore the py23 deprecated warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,7 @@ norecursedirs=build docs/_build
 addopts  = -v
 testpaths =
     tests/unit_tests/
+
+; Ignore the warning about fontTools.misc.py23
+filterwarnings =
+    ignore:The py23 module has been deprecated:DeprecationWarning


### PR DESCRIPTION
Matplotlib depends on fontools which comes with this annoying deprecated warning. Apparently everyone (including matplotlib), simply adds an ignore hook to pytest to ignore this warning instead of fixing it. Since we anyway cannot do anything about it, I suggest to add the same ignore hook.