### PR TITLE
Check exit status and print log excerpt

### DIFF
--- a/applications/sim_showers_for_trigger_rates.py
+++ b/applications/sim_showers_for_trigger_rates.py
@@ -68,10 +68,10 @@ from pathlib import Path
 
 import astropy.units as u
 
-import simtools.util.general as gen
 from simtools import io_handler
 from simtools.configuration import configurator
 from simtools.simulator import Simulator
+from simtools.util import general as gen
 
 
 def _parse(label=None, description=None):

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -337,7 +337,7 @@ class CorsikaRunner:
             return self._corsika_data_dir.joinpath(run_dir).joinpath(f"{file_name}.zst")
         if file_type == "sub_log":
             suffix = ".log"
-            if "mode" in kwargs:
+            if kwargs.get("mode") and len(kwargs["mode"]) > 0:
                 suffix = f".{kwargs['mode']}"
             sub_log_file_dir = self._output_directory.joinpath("logs")
             sub_log_file_dir.mkdir(parents=True, exist_ok=True)

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -337,7 +337,7 @@ class CorsikaRunner:
             return self._corsika_data_dir.joinpath(run_dir).joinpath(f"{file_name}.zst")
         if file_type == "sub_log":
             suffix = ".log"
-            if kwargs.get("mode") and len(kwargs["mode"]) > 0:
+            if "mode" in kwargs and kwargs["mode"] != "":
                 suffix = f".{kwargs['mode']}"
             sub_log_file_dir = self._output_directory.joinpath("logs")
             sub_log_file_dir.mkdir(parents=True, exist_ok=True)

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -125,7 +125,7 @@ class JobManager:
             if sys_output != 0:
                 msg = gen.get_log_excerpt(log_file)
                 self._logger.error(msg)
-                raise JobExecutionError(msg)
+                raise JobExecutionError("See excerpt from log file above\n")
         else:
             self._logger.info("Testing (local)")
 

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -1,10 +1,11 @@
 import logging
 import os
 from copy import copy
+from pathlib import Path
 
 import simtools.util.general as gen
 
-__all__ = ["JobManager", "MissingWorkloadManager"]
+__all__ = ["JobManager", "MissingWorkloadManager", "JobExecutionError"]
 
 
 class MissingWorkloadManager(Exception):
@@ -88,6 +89,7 @@ class JobManager:
             Provided in order to print the log excerpt in case of run time error.
         """
         self.run_script = str(run_script)
+        run_out_file = Path(run_out_file)
         self.run_out_file = str(run_out_file.parent.joinpath(run_out_file.stem))
 
         self._logger.info(f"Submitting script {self.run_script}")

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -11,6 +11,10 @@ class MissingWorkloadManager(Exception):
     """Exception for missing work load manager."""
 
 
+class JobExecutionError(Exception):
+    """Exception for job execution error (usually CORSIKA or sim_telarray)."""
+
+
 class JobManager:
     """
     JobManager provides an interface to workload managers like gridengine or HTCondor.
@@ -69,20 +73,22 @@ class JobManager:
 
         raise MissingWorkloadManager
 
-    def submit(self, run_script=None, run_out_file=None):
+    def submit(self, run_script=None, run_out_file=None, log_file=None):
         """
         Submit a job described by a shell script.
 
         Parameters
         ----------
-        run_script: string
+        run_script: str
             Shell script descring the job to be submitted.
-        run_out_file: string
+        run_out_file: str or Path
             Redirect output/error/job stream to this file (out,err,job suffix).
-
+        log_file: str or Path
+            The log file of the actual simulator (CORSIKA or sim_telarray).
+            Provided in order to print the log excerpt in case of run time error.
         """
         self.run_script = str(run_script)
-        self.run_out_file = str(run_out_file).replace(".log", "")
+        self.run_out_file = str(run_out_file.parent.joinpath(run_out_file.stem))
 
         self._logger.info(f"Submitting script {self.run_script}")
         self._logger.info(f"Job output stream {self.run_out_file + '.out'}")
@@ -94,23 +100,30 @@ class JobManager:
         elif self.submit_command.find("condor_submit") >= 0:
             self._submit_htcondor()
         elif self.submit_command.find("local") >= 0:
-            self._submit_local()
+            self._submit_local(log_file)
 
-    def _submit_local(self):
+    def _submit_local(self, log_file):
         """
         Run a job script on the command line
         (no submission to a workload manager)
 
+        Parameters
+        ----------
+        log_file: str or Path
+            The log file of the actual simulator (CORSIKA or sim_telarray).
+            Provided in order to print the log excerpt in case of run time error.
         """
 
         self._logger.info("Running script locally")
 
-        shell_command = (
-            self.run_script + " > " + self.run_out_file + ".out" " 2> " + self.run_out_file + ".err"
-        )
+        shell_command = f"{self.run_script} > {self.run_out_file}.out 2> {self.run_out_file}.err"
 
         if not self.test:
-            os.system(shell_command)
+            sys_output = os.system(shell_command)
+            if sys_output != 0:
+                msg = gen.get_log_excerpt(log_file)
+                self._logger.error(msg)
+                raise JobExecutionError(msg)
         else:
             self._logger.info("Testing (local)")
 

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -203,13 +203,7 @@ class SimtelRunner:
         """
 
         if hasattr(self, "_log_file"):
-            log_lines = gen.collect_final_lines(self._log_file, 30)
-            msg = (
-                "Simtel Error - See below the relevant part of the simtel log file.\n"
-                + "===== from simtel log file ======\n"
-                + log_lines
-                + "================================="
-            )
+            msg = gen.get_log_excerpt(self._log_file)
         else:
             msg = "Simtel log file does not exist."
 

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -395,9 +395,11 @@ class Simulator:
             job_manager.submit(
                 run_script=run_script,
                 run_out_file=self._simulation_runner.get_file_name(
-                    file_type="sub_log",
+                    file_type="sub_log", **self._simulation_runner.get_info_for_file_name(run)
+                ),
+                log_file=self._simulation_runner.get_file_name(
+                    file_type="log",
                     **self._simulation_runner.get_info_for_file_name(run),
-                    mode="",
                 ),
             )
 

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -764,7 +764,7 @@ def get_log_excerpt(log_file, n_last_lines=30):
     """
 
     return (
-        "Runtime error - See below the relevant part of the log file.\n\n"
+        "\n\nRuntime error - See below the relevant part of the log file.\n\n"
         f"{log_file}\n"
         "====================================================================\n\n"
         f"{collect_final_lines(log_file, n_last_lines)}\n\n"

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -748,12 +748,14 @@ def rotate(rotation_angle, x, y):
 
 def get_log_excerpt(log_file, n_last_lines=30):
     """
-    Get an excerpt from a log file (last 30 lines).
+    Get an excerpt from a log file, namely the n_last_lines of the file.
 
     Parameters
     ----------
     log_file: str or Path
         Log file to get the excerpt from.
+    n_last_lines: int
+        Number of last lines of the file to get.
 
     Returns
     -------

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -25,6 +25,7 @@ __all__ = [
     "set_default_kwargs",
     "sort_arrays",
     "validate_config_data",
+    "get_log_excerpt",
 ]
 
 
@@ -745,7 +746,7 @@ def rotate(rotation_angle, x, y):
     return x_trans, y_trans
 
 
-def get_log_excerpt(log_file):
+def get_log_excerpt(log_file, n_last_lines=30):
     """
     Get an excerpt from a log file (last 30 lines).
 
@@ -764,6 +765,6 @@ def get_log_excerpt(log_file):
         "Runtime error - See below the relevant part of the log file.\n\n"
         f"{log_file}\n"
         "====================================================================\n\n"
-        f"{collect_final_lines(log_file, 30)}\n\n"
+        f"{collect_final_lines(log_file, n_last_lines)}\n\n"
         "====================================================================\n"
     )

--- a/simtools/util/general.py
+++ b/simtools/util/general.py
@@ -463,7 +463,7 @@ def collect_final_lines(file, n_lines):
         # As file is read completely, if there is still data in buffer, then its first line.
         if len(buffer) > 0:
             list_of_lines.append(buffer.decode()[::-1])
-    # return the reversed list
+
     return "".join(list(reversed(list_of_lines)))
 
 

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -125,6 +125,9 @@ def test_get_file_name(corsika_runner, io_handler):
     ) == sub_log_file_dir.joinpath(f"log_sub_{file_name}.out")
     with pytest.raises(ValueError):
         corsika_runner.get_file_name("foobar", **info_for_file_name, mode="out")
+    assert corsika_runner.get_file_name(
+        "sub_log", **info_for_file_name, mode=""
+    ) == sub_log_file_dir.joinpath(f"log_sub_{file_name}.log")
 
 
 def test_has_file(corsika_runner, corsika_file):


### PR DESCRIPTION
Check the exit status and print the log excerpt also when running using the `job_manager` (when running locally). A few other small improvements were included in this small PR.

Fixes #445 