### PR TITLE
Remove layout files from db

### DIFF
--- a/applications/print_array_elements.py
+++ b/applications/print_array_elements.py
@@ -29,20 +29,13 @@
 
     Example:
 
-    Get the array element list from the DBs.
-
-    .. code-block:: console
-
-        python applications/get_file_from_db.py --file_name telescope_positions-South-4MST.ecsv
-
     Run the application:
 
     .. code-block:: console
 
         python applications/print_array_elements.py \
-            --array_element_list telescope_positions-South-4MST.ecsv \
+            --array_element_list tests/resources/telescope_positions-South-4MST.ecsv \
             --compact corsika
-
 
     Expected final print-out message:
 

--- a/applications/print_array_elements.py
+++ b/applications/print_array_elements.py
@@ -41,11 +41,11 @@
 
     .. code-block:: console
 
-        telescope_name pos_x pos_y altitude
-        MST-01      70.00      70.00    2148.00
-        MST-02     -70.00     -70.00    2238.00
-        MST-03      70.00     -70.00    2138.00
-        MST-04     -70.00     -70.00    2180.00
+    telescope_name pos_x pos_y altitude
+    MST-01      -0.02      -0.00    2162.00
+    MST-02       1.43     151.02    2163.00
+    MST-03      -1.47    -151.02    2169.00
+    MST-04     150.72      73.57    2159.00
 
 
 

--- a/data/layout/telescope_positions-South-1LST.ecsv
+++ b/data/layout/telescope_positions-South-1LST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-1MST.ecsv
+++ b/data/layout/telescope_positions-South-1MST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-1SST.ecsv
+++ b/data/layout/telescope_positions-South-1SST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-4LST.ecsv
+++ b/data/layout/telescope_positions-South-4LST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-4MST.ecsv
+++ b/data/layout/telescope_positions-South-4MST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-4SST.ecsv
+++ b/data/layout/telescope_positions-South-4SST.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}

--- a/data/layout/telescope_positions-South-TestLayout.ecsv
+++ b/data/layout/telescope_positions-South-TestLayout.ecsv
@@ -7,7 +7,7 @@
 # - {name: pos_z, unit: m, datatype: float32, description: telescope position upwards relative to the CORSIKA observation level.}
 # meta:
 #   data_type: positionfile
-#   description: "telescope positions for CTA South (Paranal)"
+#   description: "telescope positions for CTAO South"
 #   EPSG: 32719
 #   center_lon: !astropy.units.Quantity
 #     unit: &id001 !astropy.units.Unit {unit: deg}
@@ -62,7 +62,7 @@ LST-01     -20.64     -64.82      34.00
 LST-02      79.99      -0.77      29.00
 LST-03     -19.40      65.20      31.00
 LST-04    -120.03       1.15      33.00
-MST-01      -0.02      -0.00      24.00
+MST-01      -0.02      0.00      24.00
 MST-02       1.43     151.02      25.00
 MST-03      -1.47    -151.02      31.00
 MST-04     150.72      73.57      21.00

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,22 +192,6 @@ def telescope_model_sst(db, db_config, io_handler):
 
 
 @pytest.fixture
-def telescope_test_file(db, args_dict, io_handler):
-    test_file_name = "telescope_positions-North-TestLayout.ecsv"
-    db.export_file_db(
-        db_name="test-data",
-        dest=io_handler.get_output_directory(dir_type="model", test=True),
-        file_name=test_file_name,
-    )
-
-    cfg_file = gen.find_file(
-        test_file_name,
-        io_handler.get_output_directory(dir_type="model", test=True),
-    )
-    return cfg_file
-
-
-@pytest.fixture
 def layout_array_north_instance(io_handler, db_config):
     return LayoutArray(site="North", mongo_db_config=db_config, name="test_layout")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 from astropy import units as u
 
 import simtools.io_handler
-import simtools.util.general as gen
 from simtools import db_handler
 from simtools.configuration.configurator import Configurator
 from simtools.layout.layout_array import LayoutArray
@@ -240,32 +239,10 @@ def manual_corsika_dict_south():
 
 
 @pytest.fixture
-def telescope_north_test_file(db, args_dict, io_handler):
-    test_file_name = "telescope_positions-North-TestLayout.ecsv"
-    db.export_file_db(
-        db_name="test-data",
-        dest=io_handler.get_output_directory(dir_type="model", test=True),
-        file_name=test_file_name,
-    )
-
-    cfg_file = gen.find_file(
-        test_file_name,
-        io_handler.get_output_directory(dir_type="model", test=True),
-    )
-    return cfg_file
+def telescope_north_test_file():
+    return "data/layout/telescope_positions-North-TestLayout.ecsv"
 
 
 @pytest.fixture
-def telescope_south_test_file(db, args_dict, io_handler):
-    test_file_name = "telescope_positions-South-TestLayout.ecsv"
-    db.export_file_db(
-        db_name="test-data",
-        dest=io_handler.get_output_directory(dir_type="model", test=True),
-        file_name=test_file_name,
-    )
-
-    cfg_file = gen.find_file(
-        test_file_name,
-        io_handler.get_output_directory(dir_type="model", test=True),
-    )
-    return cfg_file
+def telescope_south_test_file():
+    return "data/layout/telescope_positions-South-TestLayout.ecsv"

--- a/tests/unit_tests/layout/test_layout_array.py
+++ b/tests/unit_tests/layout/test_layout_array.py
@@ -129,14 +129,14 @@ def test_initialize_corsika_telescope_from_file(
 
 def test_read_telescope_list_file(telescope_north_test_file, telescope_south_test_file, db_config):
 
-    pos_x_north = [-70.93, -35.27, 75.28, 30.91, -211.54, -153.26]
-    pos_y_north = [-52.07, 66.14, 50.49, -64.54, 5.66, 169.01]
-    pos_z_north = [43.00, 32.00, 28.70, 32.00, 50.3, 24.0]
-    description_north = "telescope positions for CTA North (La Palma)"
-    pos_x_south = [-20.643, 79.994, -19.396, -120.033, -0.017, -1.468]
-    pos_y_south = [-64.817, -0.768, 65.200, 1.151, -0.001, -151.221]
-    pos_z_south = [34.30, 29.40, 31.00, 33.10, 24.35, 31.00]
-    description_south = "telescope positions for CTA South (Paranal)"
+    pos_x_north = [-70.99, -35.38, 75.22, 30.78, -211.61, -153.34]
+    pos_y_north = [-52.08, 66.14, 50.45, -64.51, 5.67, 169.04]
+    pos_z_north = [43.00, 28.90, 24.40, 30.60, 46.50, 26.70]
+    description_north = "telescope positions for CTAO North"
+    pos_x_south = [-20.64, 79.99, -19.40, -120.03, -0.02, 1.43]
+    pos_y_south = [-64.82, -0.77, 65.20, 1.15, 0.00, 151.02]
+    pos_z_south = [34.00, 29.00, 31.00, 33.00, 24.00, 25.00]
+    description_south = "telescope positions for CTAO South"
 
     def test_one_site(test_file, pos_x, pos_y, pos_z, description):
         table = LayoutArray.read_telescope_list_file(test_file)
@@ -180,7 +180,7 @@ def test_initialize_layout_array_from_telescope_file(
         assert number_of_telescopes == layout_2.get_number_of_telescopes()
 
     test_one_site(layout_array_north_instance, telescope_north_test_file, 19, "North")
-    test_one_site(layout_array_south_instance, telescope_south_test_file, 99, "South")
+    test_one_site(layout_array_south_instance, telescope_south_test_file, 68, "South")
 
 
 def test_add_tel(
@@ -337,8 +337,8 @@ def test_altitude_from_corsika_z(
 
 def test_include_radius_into_telescope_table(telescope_north_test_file, telescope_south_test_file):
 
-    values_from_file_north = [20.190000534057617, -352.4599914550781, 62.29999923706055, 9.6]
-    values_from_file_south = [-151.949, 240.011, 27.00]
+    values_from_file_north = [20.29, -352.48, 60.00, 9.6]
+    values_from_file_south = [-149.32, 76.45, 28.00]
 
     def test_one_site(test_file, values_from_file):
         telescope_table = LayoutArray.read_telescope_list_file(test_file)
@@ -470,11 +470,11 @@ def test_try_set_coordinate(
     layout_array_south_instance,
     telescope_south_test_file,
 ):
-    manual_xx_north = [-70.93, -35.27, 75.28, 30.91, -211.54, -153.26]
-    manual_yy_north = [-52.07, 66.14, 50.49, -64.54, 5.66, 169.01]
+    manual_xx_north = [-70.99, -35.38, 75.22, 30.78, -211.61, -153.34]
+    manual_yy_north = [-52.08, 66.14, 50.45, -64.51, 5.67, 169.04]
 
-    manual_xx_south = [-20.643, 79.994, -19.396, -120.033, -0.017, -1.468]
-    manual_yy_south = [-64.817, -0.768, 65.200, 1.151, -0.001, -151.221]
+    manual_xx_south = [-20.64, 79.99, -19.40, -120.03, -0.02, 1.43]
+    manual_yy_south = [-64.82, -0.77, 65.20, 1.15, 0.00, 151.02]
 
     def test_one_site(instance, test_file, manual_xx, manual_yy):
         table = LayoutArray.read_telescope_list_file(test_file)

--- a/tests/unit_tests/layout/test_layout_array.py
+++ b/tests/unit_tests/layout/test_layout_array.py
@@ -18,8 +18,8 @@ def north_layout_center_data_dict():
     return {
         "center_lon": -17.8920302 * u.deg,
         "center_lat": 28.7621661 * u.deg,
-        "center_easting": 217611 * u.m,
-        "center_northing": 3185066 * u.m,
+        "center_easting": 217611.227 * u.m,
+        "center_northing": 3185066.278 * u.m,
         "EPSG": 32628,
         "center_alt": 2177 * u.m,
     }
@@ -30,8 +30,8 @@ def south_layout_center_data_dict():
     return {
         "center_lon": -70.316345 * u.deg,
         "center_lat": -24.683429 * u.deg,
-        "center_easting": 366822 * u.m,
-        "center_northing": 7269466 * u.m,
+        "center_easting": 366822.017 * u.m,
+        "center_northing": 7269466.999 * u.m,
         "EPSG": 32719,
         "center_alt": 2162.35 * u.m,
     }

--- a/tests/unit_tests/layout/test_layout_array.py
+++ b/tests/unit_tests/layout/test_layout_array.py
@@ -103,8 +103,12 @@ def test_initialize_coordinate_systems(
         assert _E.value == pytest.approx(easting, 1.0)
         assert _N.value == pytest.approx(northing, 1.0)
 
-    test_one_site(north_layout_center_data_dict, layout_array_north_instance, 217611.0, 3185066.0)
-    test_one_site(south_layout_center_data_dict, layout_array_south_instance, 366822.0, 7269466.0)
+    test_one_site(
+        north_layout_center_data_dict, layout_array_north_instance, 217611.227, 3185066.278
+    )
+    test_one_site(
+        south_layout_center_data_dict, layout_array_south_instance, 366822.017, 7269466.999
+    )
 
 
 def test_initialize_corsika_telescope_from_file(

--- a/tests/unit_tests/layout/test_layout_array.py
+++ b/tests/unit_tests/layout/test_layout_array.py
@@ -269,8 +269,8 @@ def test_converting_center_coordinates_north(layout_array_north_four_LST_instanc
     assert _lon.value == pytest.approx(-17.8920302)
 
     _east, _north, _ = layout._array_center.get_coordinates("utm")
-    assert _north.value == pytest.approx(3185066.0)
-    assert _east.value == pytest.approx(217611.0)
+    assert _north.value == pytest.approx(3185066.278)
+    assert _east.value == pytest.approx(217611.227)
 
     assert layout._array_center.get_altitude().value == pytest.approx(2177.0)
 

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -47,8 +47,8 @@ def position_for_testing():
         "altitude": 2.177 * u.km,
         "center_lon": -17.8920302 * u.deg,
         "center_lat": 28.7621661 * u.deg,
-        "utm_east": 217611 * u.m,
-        "utm_north": 3185066 * u.m,
+        "utm_east": 217611.227 * u.m,
+        "utm_north": 3185066.278 * u.m,
     }
 
 


### PR DESCRIPTION
Closes #449
I implemented the changes we have discussed two weeks ago, mostly on the tests and then deleted from the DB the three layout files to avoid duplication. The files are now used from their respective locations:

`tests/resources/telescope_positions-South-4MST.ecsv`
`data/layout/telescope_positions-North-TestLayout.ecsv`
`data/layout/telescope_positions-South-TestLayout.ecsv`