### PR TITLE
Allow to print heights for non-telescope-type array elements

### DIFF
--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -376,7 +376,9 @@ class LayoutArray:
 
         """
 
-        if names.get_telescope_type(tel_name) is not None:
+        if (names.get_telescope_type(tel_name) is not None
+                and len(names.get_telescope_type(tel_name)) > 0):
+
             return self._corsika_telescope["corsika_sphere_center"][
                 names.get_telescope_type(tel_name)
             ]

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -368,6 +368,15 @@ APP_LIST = {
             "corsika",
         ],
     ],
+    "print_array_elements::print_compact_cors_telescopeheights": [
+        [
+            "--array_element_list",
+            "tests/resources/telescope_positions-North-utm.ecsv",
+            "--export",
+            "corsika",
+            "--use_corsika_telescope_height",
+        ],
+    ],
 }
 
 

--- a/tests/resources/telescope_positions-North-utm.ecsv
+++ b/tests/resources/telescope_positions-North-utm.ecsv
@@ -24,7 +24,34 @@
 #   corsika_obs_level: !astropy.units.Quantity
 #     unit: *id002
 #     value: 2158
+#   corsika_sphere_radius:
+#     LST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 12.5
+#     MST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 9.6
+#     SCT: !astropy.units.Quantity
+#       unit: *id002
+#       value: 7.15
+#     SST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 3.0
+#   corsika_sphere_center:
+#     LST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 16.0
+#     MST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 9.0
+#     SCT: !astropy.units.Quantity
+#       unit: *id002
+#       value: 6.1
+#     SST: !astropy.units.Quantity
+#       unit: *id002
+#       value: 3.25
 #   comments: |
+#       Prod6 sub-array from CTAO North
 #       UTM Zone 28N
 # schema: astropy-2.0
 asset_code sequence_number utm_east utm_north alt geo_code


### PR DESCRIPTION
Some telescope lists involve non-telescope array elements (e.g., positions of illuminators). The conversion from UTM to corsika coordinates and altitude did not work as a `corsika_sphere_center` entry was required.

- return `0. * u.m` as `corsika_sphere_center`  for non-telescope elements
- the test telescope list [tests/resources/telescope_positions-North-utm.ecsv](tests/resources/telescope_positions-North-utm.ecsv) missed the `corsika_sphere_center`  entries
-  added an integration test for this use case
