### PR TITLE
Remove zstd from environment.yml file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - pyproj
-  - zstandard
   - conda-forge::eventio>=1.5.0
   - pyflakes
 


### PR DESCRIPTION
Remove zstd from the conda environment, as this is an error source on certain systems. 

It seems zstd is not used directly anywhere (indirectly in corsika_runner.py and simtel_runner_array).  For this, both simulation software package should be compiled with zstd).