### PR TITLE
Sphinx issues.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ release = version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    # "sphinx.ext.intersphinx",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,7 +139,7 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 #
 # html_theme = "sphinx_rtd_theme"
-html_theme = "classic"
+html_theme = "bizstyle"
 
 html_title = f"{project} v{version} Manual"
 
@@ -235,7 +235,7 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-# intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 
 # -- Raul: making sphinx add classes' __init__ always

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -70,7 +70,7 @@ release = version
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
+    # "sphinx.ext.intersphinx",
     "sphinx.ext.ifconfig",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
@@ -138,7 +138,8 @@ pygments_style = "sphinx"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+# html_theme = "sphinx_rtd_theme"
+html_theme = "classic"
 
 html_title = f"{project} v{version} Manual"
 
@@ -234,7 +235,7 @@ texinfo_documents = [
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+# intersphinx_mapping = {"https://docs.python.org/": None}
 
 
 # -- Raul: making sphinx add classes' __init__ always


### PR DESCRIPTION
/Closes #475

1. Sphinx theme `sphinx_rtd_theme` seems to be broken for newer sphinx versions (>=7). Suggest to not spend time on this but simply use another one (this is bizstyle now, see the [themes page](https://www.sphinx-doc.org/en/master/usage/theming.html#builtin-themes) or `make html` in your doc directory

2. The syntax of `intersphinx_mapping` is changing and has been adapted following the instructions from [here](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping).
