### PR TITLE
Improve linter CI to print file containing non-ascii characters.

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -34,13 +34,19 @@ jobs:
         with:
           python-version: "3.12"
 
-
       - name: Check for non-ASCII characters
         run: |
-          output=$(find . -type f \
-          \( -name "*.py" -o -name "*.rst" -o -name "*.yml" -o -name "*.toml" \) \
-          -exec perl -ne 'print if /[^[:ascii:]]/ && !/latin/i' {} \;)
-          if [ -n "$output" ]; then
+          found=0
+          while IFS= read -r file; do
+            matches=$(perl -ne 'print if /[^[:ascii:]]/ && !/latin/i' "$file")
+            if [ -n "$matches" ]; then
+              echo "File: $file"
+              echo "$matches"
+              found=1
+            fi
+          done < <(find . -type f \( -name "*.py" -o -name "*.rst" -o -name "*.yml" -o -name "*.toml" \))
+
+          if [ "$found" -eq 1 ]; then
             echo "Non-ASCII characters found in documentation."
             exit 1
           fi

--- a/docs/changes/1620.maintenance.md
+++ b/docs/changes/1620.maintenance.md
@@ -1,0 +1,1 @@
+Improve linter CI to print file containing non-ascii characters.


### PR DESCRIPTION
See [this workflow](https://github.com/gammasim/simtools/actions/runs/15968869300/job/45035296025) to confirm that this change works and the file name is printed.