### PR TITLE
Config keys should be lower case.

### DIFF
--- a/src/simtools/applications/run_application.py
+++ b/src/simtools/applications/run_application.py
@@ -180,7 +180,7 @@ def main():  # noqa: D103
             else:
                 logger.info(f"Skipping application: {config.get('application')}")
                 continue
-            config = gen.change_dict_keys_case(config, False)
+            config = gen.change_dict_keys_case(config, True)
             stdout, stderr = run_application(
                 config.get("application"), config.get("configuration"), logger
             )


### PR DESCRIPTION
This is a small bug fix related to the changes of the dictionary keys of the configuration files (see #1636). We want now lower case and not upper case dicts from `def change_dict_keys_case(data_dict, lower_case=True):`.