### PR TITLE
Change metadata written to astropy tables to lower case.

### DIFF
--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -381,7 +381,7 @@ class ModelDataWriter:
 
         if metadata is not None:
             product_data.meta.update(
-                gen.change_dict_keys_case(metadata.get_top_level_metadata(), False)
+                gen.change_dict_keys_case(metadata.get_top_level_metadata(), True)
             )
 
         self._logger.info(f"Writing data to {self.product_data_file}")

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -67,7 +67,7 @@ def test_write(tmp_test_directory, args_dict_site):
     # check that table and metadata is good
     table = Table.read(w_1.product_data_file, format=ascii_format)
     assert "pixel" in table.colnames
-    assert "CTA" in table.meta.keys()
+    assert "cta" in table.meta.keys()
 
     w_1.product_data_format = "not_an_astropy_format"
     with pytest.raises(IORegistryError):


### PR DESCRIPTION
(title provides full description).

Additionally, I've searched through to code for `change_dict_keys_case` and I think we covered now all cases.