### PR TITLE
Add temporary xfail to unit test in simulator_light_emission

### DIFF
--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -1012,6 +1012,7 @@ def test_photons_per_run_flasher_model_test_mode(tmp_path):
     flasher.get_parameter_value.assert_not_called()
 
 
+@pytest.mark.xfail(reason="see issue #1720")
 def test_photons_per_run_no_models(tmp_path):
     # When neither calibration nor flasher model is provided, default to 1e8
     tel = MagicMock()


### PR DESCRIPTION
The failing unit test described in #1720 leads main to fail (e.g., last night [here](https://github.com/gammasim/simtools/actions/runs/17630613356/job/50097203466)). 

As mentioned in #1720, there is no need to fix it, as #1733 is providing a refactoring of the light emission module. 

Add a temporary xfail statement here to the failing test to make sure that main is working correctly.