### PR TITLE
Add new field `production_table_name` to production table schema

### DIFF
--- a/docs/changes/1756.maintenance.md
+++ b/docs/changes/1756.maintenance.md
@@ -1,0 +1,1 @@
+Add new field `production_table_name` to production table schema.

--- a/src/simtools/schemas/production_tables.schema.yml
+++ b/src/simtools/schemas/production_tables.schema.yml
@@ -12,7 +12,11 @@ additionalProperties: false
 
 definitions:
   ProductionModelTable:
+    additionalProperties: false
     properties:
+      production_table_name:
+        type: string
+        description: Name of the production table.
       model_version:
         type: string
         description: Model version.
@@ -37,5 +41,6 @@ definitions:
           type: string
           description: Design model of a telescope
     required:
+      - production_table_name
       - model_version
       - parameters


### PR DESCRIPTION
Related to [simulation models merge request 77](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/77).

Two items:

- added `production_table_name` to corresponding schema
- added `additionalProperties: false` to the definitions (I thought it is enough to define this as global parameter in the json schema). This will fix to non-failure of the CI in [merge request 77](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/77)