### PR TITLE
Use sorted versions in docs_read_parameters

### DIFF
--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -16,6 +16,7 @@ from simtools.db import db_handler
 from simtools.io import ascii_handler, io_handler
 from simtools.model.telescope_model import TelescopeModel
 from simtools.utils import names
+from simtools.version import sort_versions
 from simtools.visualization import plot_pixels, plot_tables
 
 logger = logging.getLogger()
@@ -265,7 +266,7 @@ class ReadParameters:
                     "value": data["value"],
                     "parameter_version": param_version,
                     "file_flag": data["file_flag"],
-                    "model_version": ", ".join(data["model_versions"]),
+                    "model_version": ", ".join(sort_versions(data["model_versions"])),
                 }
                 for param_version, data in version_grouped.items()
             ]

--- a/src/simtools/version.py
+++ b/src/simtools/version.py
@@ -106,3 +106,25 @@ def semver_to_int(version_string):
     release = v.release + (0,) * (3 - len(v.release))
     major, minor, patch = release[:3]
     return major * 10000 + minor * 100 + patch
+
+
+def sort_versions(version_list, reverse=False):
+    """
+    Sort a list of semantic version strings.
+
+    Parameters
+    ----------
+    version_list : list of str
+        List of semantic version strings (e.g., ["5.0.0", "6.0.2", "5.1.0"])
+    reverse : bool, optional
+        Sort in descending order if True (default False)
+
+    Returns
+    -------
+    list of str
+        Sorted list of version strings.
+    """
+    try:
+        return [str(v) for v in sorted(map(Version, version_list), reverse=reverse)]
+    except InvalidVersion as exc:
+        raise ValueError(f"Invalid version in list: {version_list}") from exc

--- a/tests/unit_tests/reporting/test_docs_read_parameters.py
+++ b/tests/unit_tests/reporting/test_docs_read_parameters.py
@@ -303,7 +303,7 @@ def test__group_model_versions_by_parameter_version(io_handler, db_config):
                 "value": "4.5",
                 "parameter_version": "1.0.0",
                 "file_flag": False,
-                "model_version": "6.0.0, 5.0.0",
+                "model_version": "5.0.0, 6.0.0",
             }
         ],
     }
@@ -385,7 +385,7 @@ def test__compare_parameter_across_versions(io_handler, db_config):
         ],
     )
     qe_comparison = comparison_data.get("quantum_efficiency")
-    assert qe_comparison["parameter_version" == "1.0.0"]["model_version"] == "6.0.0, 5.0.0"
+    assert qe_comparison["parameter_version" == "1.0.0"]["model_version"] == "5.0.0, 6.0.0"
 
     position_comparison = comparison_data.get("array_element_position_ground")
     assert position_comparison[0]["model_version"] != position_comparison[1]["model_version"]

--- a/tests/unit_tests/test_version.py
+++ b/tests/unit_tests/test_version.py
@@ -118,3 +118,28 @@ def test_semver_to_int():
 
     with pytest.raises(ValueError, match=r"Invalid version: not_a.version"):
         version.semver_to_int("not_a.version")
+
+
+def test_sort_versions():
+    version_list = ["5.0.0", "6.0.2", "5.1.0", "6.0.0", "5.0.1"]
+
+    # Test ascending order (default)
+    result = version.sort_versions(version_list)
+    expected = ["5.0.0", "5.0.1", "5.1.0", "6.0.0", "6.0.2"]
+    assert result == expected
+
+    # Test descending order
+    result = version.sort_versions(version_list, reverse=True)
+    expected = ["6.0.2", "6.0.0", "5.1.0", "5.0.1", "5.0.0"]
+    assert result == expected
+
+    # Test empty list
+    assert version.sort_versions([]) == []
+
+    # Test single version
+    assert version.sort_versions(["1.0.0"]) == ["1.0.0"]
+
+    # Test invalid version
+    invalid_versions = ["1.0.0", "not_a_version", "2.0.0"]
+    with pytest.raises(ValueError, match=r"Invalid version in list"):
+        version.sort_versions(invalid_versions)


### PR DESCRIPTION
This PR fixes occasional (!!) failures of unit tests of type:

```
______________________________________________________________ test__compare_parameter_across_versions ______________________________________________________________
[gw1] linux -- Python 3.12.9 /workdir/env/bin/python3.12

io_handler = <simtools.io.io_handler.IOHandler object at 0xffff672e7680>
db_config = {'db_api_authentication_database': 'admin', 'db_api_port': 27017, 'db_api_pw': 'password', 'db_api_user': 'api', ...}

    def test__compare_parameter_across_versions(io_handler, db_config):
        args = {"site": "North", "telescope": "LSTN-01"}
        output_path = io_handler.get_output_directory(
            label="reports", sub_dir=f"parameters/{args['telescope']}"
        )
        read_parameters = ReadParameters(db_config=db_config, args=args, output_path=output_path)

        mock_data = {
            "5.0.0": {
                "quantum_efficiency": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "1.0.0",
                    "value": QE_FILE_NAME,
                    "unit": None,
                    "file": True,
                },
                "array_element_position_ground": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "1.0.0",
                    "value": [-70.93, -52.07, 43.0],
                    "unit": "m",
                    "file": False,
                },
            },
            "6.0.0": {
                "quantum_efficiency": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "1.0.0",
                    "value": QE_FILE_NAME,
                    "unit": None,
                    "file": True,
                },
                "array_element_position_ground": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "2.0.0",
                    "value": [-70.91, -52.35, 45.0],
                    "unit": "m",
                    "file": False,
                },
                "only_prod6_param": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "1.0.0",
                    "value": 70.45,
                    "unit": "m",
                    "file": False,
                },
                "none_valued_param": {
                    "instrument": "LSTN-01",
                    "site": "North",
                    "parameter_version": "1.0.0",
                    "value": None,
                    "unit": None,
                    "file": False,
                },
            },
        }

        comparison_data = read_parameters._compare_parameter_across_versions(
            mock_data,
            [
                "quantum_efficiency",
                "array_element_position_ground",
                "only_prod6_param",
                "none_valued_param",
            ],
        )
        qe_comparison = comparison_data.get("quantum_efficiency")
>       assert qe_comparison["parameter_version" == "1.0.0"]["model_version"] == "6.0.0, 5.0.0"
E       AssertionError: assert '5.0.0, 6.0.0' == '6.0.0, 5.0.0'
E
E         - 6.0.0, 5.0.0
E         + 5.0.0, 6.0.0

tests/unit_tests/reporting/test_docs_read_parameters.py:388: AssertionError
====================================================================== short test summary info ======================================================================
FAILED tests/unit_tests/reporting/test_docs_read_parameters.py::test__compare_parameter_across_versions - AssertionError: assert '5.0.0, 6.0.0' == '6.0.0, 5.0.0'
```

Solution is to sort model versions before writing them. For that, introduce a generic function to sort model versions in simtools.versions (to be used in other places as well).

