### PR TITLE
Linter RSA error

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter@v8
         env:
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name != 'pull_request' }}
           VALIDATE_ENV: true
           VALIDATE_NATURAL_LANGUAGE: true
           VALIDATE_BASH: true


### PR DESCRIPTION
Fix Super-Linter failure on scheduled runs by enabling full codebase validation (VALIDATE_ALL_CODEBASE=true) when no Git diff is available.

Schedule linter runs fail, see e.g. [here](https://github.com/gammasim/simtools/actions/runs/18393483934/job/52408282778).

