### PR TITLE
fix numpydoc warning

### DIFF
--- a/src/simtools/application_control.py
+++ b/src/simtools/application_control.py
@@ -49,8 +49,8 @@ def startup_application(parse_function, setup_io_handler=True, logger_name=None)
     io_handler_instance : io_handler.IOHandler or None
         IOHandler instance if setup_io_handler=True, None otherwise.
 
-    Example
-    -------
+    Examples
+    --------
     Basic usage in an application:
 
     .. code-block:: python
@@ -107,8 +107,8 @@ def get_application_label(file_path):
     str
         Application label (filename without extension).
 
-    Example
-    -------
+    Examples
+    --------
     .. code-block:: python
 
         def main():


### PR DESCRIPTION
Fix docstring to address warnings by numpydoc:

```
/workdir/env/lib64/python3.12/site-packages/numpydoc/docscrape.py:420: UserWarning: Unknown section Example in the docstring of get_application_label in /workdir/external/simtools/src/simtools/application_control.py.
  self[section] = content
/workdir/env/lib64/python3.12/site-packages/numpydoc/docscrape.py:420: UserWarning: Unknown section Example in the docstring of startup_application in /workdir/external/simtools/src/simtools/application_control.py.
  self[section] = content
```