### PR TITLE
Deprecated parameter reporting

### DIFF
--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -43,6 +43,9 @@ class ModelParameter:
         MongoDB configuration.
     label: str
         Instance label. Important for output file naming.
+    ignore_software_version: bool
+        If True, ignore software version checks for deprecated parameters.
+        Useful for documentation generation.
 
     """
 
@@ -55,6 +58,7 @@ class ModelParameter:
         collection="telescopes",
         db=None,
         label=None,
+        ignore_software_version=False,
     ):
         self._logger = logging.getLogger(__name__)
         self.io_handler = io_handler.IOHandler()
@@ -67,6 +71,7 @@ class ModelParameter:
         self.collection = collection
         self.label = label
         self.model_version = model_version
+        self.ignore_software_version = ignore_software_version
         self.site = names.validate_site_name(site) if site is not None else None
         self.name = (
             names.validate_array_element_name(array_element_name)
@@ -416,7 +421,9 @@ class ModelParameter:
         for par_name in parameter_list:
             if par_name in (parameter_schema := names.model_parameters()):
                 schema.validate_deprecation_and_version(
-                    data=parameter_schema[par_name], software_name=software_name
+                    data=parameter_schema[par_name],
+                    software_name=software_name,
+                    ignore_software_version=self.ignore_software_version,
                 )
 
     def change_parameter(self, par_name, value):

--- a/src/simtools/model/site_model.py
+++ b/src/simtools/model/site_model.py
@@ -24,6 +24,8 @@ class SiteModel(ModelParameter):
         Model version or list of model versions (in which case only the first one is used).
     label: str, optional
         Instance label. Important for output file naming.
+    ignore_software_version: bool, optional
+        If True, ignore software version checks for deprecated parameters.
     """
 
     def __init__(
@@ -32,6 +34,7 @@ class SiteModel(ModelParameter):
         mongo_db_config: dict,
         model_version: str,
         label: str | None = None,
+        ignore_software_version: bool = False,
     ):
         """Initialize SiteModel."""
         self._logger = logging.getLogger(__name__)
@@ -43,6 +46,7 @@ class SiteModel(ModelParameter):
             db=None,
             label=label,
             collection="sites",
+            ignore_software_version=ignore_software_version,
         )
 
     def get_reference_point(self) -> dict:

--- a/src/simtools/model/telescope_model.py
+++ b/src/simtools/model/telescope_model.py
@@ -32,6 +32,8 @@ class TelescopeModel(ModelParameter):
         Model version.
     label: str, optional
         Instance label. Important for output file naming.
+    ignore_software_version: bool, optional
+        If True, ignore software version checks for deprecated parameters.
     """
 
     def __init__(
@@ -41,6 +43,7 @@ class TelescopeModel(ModelParameter):
         mongo_db_config: dict,
         model_version: str,
         label: str | None = None,
+        ignore_software_version: bool = False,
     ):
         """Initialize TelescopeModel."""
         super().__init__(
@@ -50,6 +53,7 @@ class TelescopeModel(ModelParameter):
             model_version=model_version,
             db=None,
             label=label,
+            ignore_software_version=ignore_software_version,
         )
 
         self._logger = logging.getLogger(__name__)

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -544,6 +544,7 @@ class ReadParameters:
             model_version=self.model_version,
             label="reports",
             mongo_db_config=self.db_config,
+            ignore_software_version=True,
         )
 
         output_filename = Path(self.output_path / (telescope_model.name + ".md"))


### PR DESCRIPTION
Pipeline on gitlab was failing during the schema validation:
```
ValueError: pedestal_events: version 0.23.1.dev40+g2e798ecff of simtools does not match <0.21.0.
```

Added the option to ignore simtool version while creating documentation.