### PR TITLE
Review xfailed and xpassed unit tests

### DIFF
--- a/docs/changes/1855.maintenance.md
+++ b/docs/changes/1855.maintenance.md
@@ -1,0 +1,1 @@
+Review and update all XPASS unit tests.

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -95,7 +95,7 @@ def get_model_parameter_schema_version(schema_version=None):
 
 
 def validate_dict_using_schema(
-    data, schema_file=None, json_schema=None, ignore_software_version=False
+    data, schema_file=None, json_schema=None, ignore_software_version=False, offline=False
 ):
     """
     Validate a data dictionary against a schema.
@@ -136,15 +136,22 @@ def validate_dict_using_schema(
     except jsonschema.exceptions.ValidationError as exc:
         _logger.error(f"Validation failed using schema: {json_schema} for data: {data}")
         raise exc
+
+    if not offline:
+        _validate_meta_schema_url(data)
+
+    _logger.debug(f"Successful validation of data using schema ({json_schema.get('name')})")
+    return data
+
+
+def _validate_meta_schema_url(data):
+    """Validate meta_schema_url if present in data."""
     if (
         isinstance(data, dict)
         and data.get("meta_schema_url")
         and not gen.url_exists(data["meta_schema_url"])
     ):
         raise FileNotFoundError(f"Meta schema URL does not exist: {data['meta_schema_url']}")
-
-    _logger.debug(f"Successful validation of data using schema ({json_schema.get('name')})")
-    return data
 
 
 def _retrieve_yaml_schema_from_uri(uri):

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -73,11 +73,28 @@ def test_validate_dict_using_schema(tmp_test_directory, caplog):
     # sample data dictionary to be validated
     data = {"name": "John", "age": 30}
 
-    schema.validate_dict_using_schema(data, schema_file)
+    schema.validate_dict_using_schema(data, schema_file, offline=True)
 
     invalid_data = {"name": "Alice", "age": "Thirty"}
     with pytest.raises(jsonschema.exceptions.ValidationError):
         schema.validate_dict_using_schema(invalid_data, schema_file)
+
+
+@pytest.mark.xfail(reason="No network connection")
+def test_validate_dict_using_schema_remote(tmp_test_directory):
+    sample_schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
+        "meta_schema_url": "string",
+        "required": ["name", "age"],
+    }
+
+    schema_file = Path(tmp_test_directory) / "schema.yml"
+    with open(schema_file, "w", encoding="utf-8") as f:
+        yaml.dump(sample_schema, f)
+
+    # sample data dictionary to be validated
+    data = {"name": "John", "age": 30}
 
     # with valid meta_schema_url
     data["meta_schema_url"] = "https://github.com/gammasim/simtools"
@@ -88,14 +105,15 @@ def test_validate_dict_using_schema(tmp_test_directory, caplog):
         schema.validate_dict_using_schema(data, schema_file)
 
 
-@pytest.mark.xfail(reason="No network connection")
 def test_validate_schema_astropy_units(caplog):
     success_string = "Successful validation of data using schema"
 
-    _dict_1 = ascii_handler.collect_data_from_file(file_name="tests/resources/num_gains.schema.yml")
+    _dict_1 = ascii_handler.collect_data_from_file(
+        file_name=MODEL_PARAMETER_SCHEMA_PATH / "num_gains.schema.yml"
+    )
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
 
@@ -103,13 +121,13 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1["data"][0]["unit"] = "m"
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "cm"
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
 
@@ -117,13 +135,13 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1["data"][0]["unit"] = "cm/s"
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "km/ s"
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
 
@@ -131,13 +149,13 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1["data"][0]["unit"] = "dimensionless"
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = ""
     with caplog.at_level(logging.DEBUG):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
     assert success_string in caplog.text
 
@@ -145,7 +163,7 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1["data"][0]["unit"] = "not_a_unit"
     with pytest.raises(ValueError, match="'not_a_unit' is not a valid Unit"):
         schema.validate_dict_using_schema(
-            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA
+            data=_dict_1, schema_file=MODEL_PARAMETER_DESCRIPTION_METASCHEMA, offline=True
         )
 
 

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -14,15 +14,6 @@ from simtools.model.model_parameter import InvalidModelParameterError
 logger = logging.getLogger()
 
 
-@pytest.mark.xfail(reason="Missing ray_tracing for prod6 in Derived-DB")
-def test_get_on_axis_eff_optical_area(telescope_model_lst):
-    tel_model = telescope_model_lst
-
-    assert tel_model.get_on_axis_eff_optical_area().value == pytest.approx(
-        365.48310154491
-    )  # Value for LST -1
-
-
 # depends on prod5; prod6 is incomplete in the DB
 def test_read_two_dim_wavelength_angle(telescope_model_sst_prod5):
     tel_model = telescope_model_sst_prod5
@@ -54,7 +45,6 @@ def test_read_incidence_angle_distribution(telescope_model_sst):
 
 
 # depends on prod5 (no 2D camera file file in prod6)
-@pytest.mark.xfail(reason="Test requires Derived-Values Database")
 def test_calc_average_curve(telescope_model_sst_prod5):
     tel_model = telescope_model_sst_prod5
     tel_model.write_sim_telarray_config_file()
@@ -70,7 +60,6 @@ def test_calc_average_curve(telescope_model_sst_prod5):
 
 
 # depends on prod5 (no 2D camera file file in prod6)
-@pytest.mark.xfail(reason="Test requires Derived-Values Database")
 def test_export_table_to_model_directory(telescope_model_sst_prod5):
     tel_model = telescope_model_sst_prod5
     tel_model.write_sim_telarray_config_file()

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -96,8 +96,7 @@ def test_check_run_result(simulator_camera_efficiency):
         simulator_camera_efficiency._check_run_result()
 
 
-@pytest.mark.xfail(reason="Test requires Derived-Values Database")
-def test_get_one_dim_distribution(db_config, simtel_path, model_version_prod5):
+def test_get_one_dim_distribution(db_config, simtel_path, model_version_prod5, site_model_south):
     logger.warning(
         "Running test_get_one_dim_distribution using prod5 model "
         " (prod6 model with 1D transmission function)"
@@ -113,15 +112,16 @@ def test_get_one_dim_distribution(db_config, simtel_path, model_version_prod5):
         },
         db_config=db_config,
         label="validate_camera_efficiency",
-        test=True,
     )
 
     # 2D transmission window not defined in prod6; required prod5 runner
     camera_efficiency_sst_prod5.export_model_files()
     simulator_camera_efficiency_prod5 = SimulatorCameraEfficiency(
         telescope_model=camera_efficiency_sst_prod5.telescope_model,
+        site_model=site_model_south,
         file_simtel=camera_efficiency_sst_prod5._file["sim_telarray"],
         label="test-simtel-runner-camera-efficiency",
+        simtel_path=simtel_path,
     )
     camera_filter_file = simulator_camera_efficiency_prod5._get_one_dim_distribution(
         "camera_filter", "camera_filter_incidence_angle"


### PR DESCRIPTION
Checked all XPASS and XFAIL unit tests:

```
XFAIL tests/unit_tests/model/test_telescope_model.py::test_get_on_axis_eff_optical_area - Missing ray_tracing for prod6 in Derived-DB
XFAIL tests/unit_tests/data_model/test_schema.py::test_validate_schema_astropy_units - No network connection
XFAIL tests/unit_tests/simtel/test_simulator_camera_efficiency.py::test_get_one_dim_distribution - Test requires Derived-Values Database
XPASS tests/unit_tests/model/test_telescope_model.py::test_calc_average_curve - Test requires Derived-Values Database
XPASS tests/unit_tests/model/test_telescope_model.py::test_export_table_to_model_directory - Test requires Derived-Values Database
XPASS tests/unit_tests/utils/test_general.py::test_url_exists - No network connection
```

Going one-by-one through them:

`tests/unit_tests/model/test_telescope_model.py::test_get_on_axis_eff_optical_area - Missing ray_tracing for prod6 in Derived-DB`:

- removed the test, as it it based on an outdated expectation that there is a derived-value DB accessible the same way as model parameters.

`tests/unit_tests/data_model/test_schema.py::test_validate_schema_astropy_units - No network connection`

- intention is to test the if the field `meta_schema_url` is given, the validation of the url is sucessful
- but the tests fail due to in incorrect file path
- insulated the part of the test which needs a network connect; allow to run schema validation with an `offline=True` flag

`tests/unit_tests/simtel/test_simulator_camera_efficiency.py::test_get_one_dim_distribution`

- failed due to missing updates to the CameraEfficiency API. Fixed it and test run passes. Removed XFAIL marker.

`tests/unit_tests/simtel/test_simulator_camera_efficiency.py::test_get_one_dim_distribution`

- tests passes without issues. Used prod5 model (which is fine). Removed XFAIL marker.

`tests/unit_tests/model/test_telescope_model.py::test_export_table_to_model_directory`

- tests passes without issues. Used prod5 model (which is fine). Removed XFAIL marker.

`tests/unit_tests/utils/test_general.py::test_url_exists`

- this is fine - tests passes when there is a network connection, otherwise xfails.

Side note: to run pytest with network connection one can use (in the container)

```
pip install pytest-socket
pytest --disable-socket --allow-hosts=localhost,127.0.0.1 tests/unit_tests/utils/test_general.py::test_url_exists
```

Closes #1841 