### PR TITLE
Fix integration tests with overwrite parameters

### DIFF
--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
@@ -20,7 +20,6 @@ applications:
     simulation_software: corsika_sim_telarray
     site: South
     zenith_angle: 40
-    overwrite_model_parameters: tests/resources/info_test_model_parameter_changes.yml
   integration_tests:
   - test_output_files:
     - file: gamma_run000001_za40deg_azm180deg_South_beta_6.0_check_output.log_hist.tar.gz
@@ -35,20 +34,6 @@ applications:
         trigger_time:
         - 0
         - 50
-      file: gamma_run000001_za40deg_azm180deg_South_beta_6.0_check_output.simtel.zst
-      path_descriptor: pack_for_grid_register
-    - expected_simtel_metadata:
-        site_config_name: South
-        1:
-          effective_focal_length: '2923.7 0 0 2 0'
-        2:
-          effective_focal_length: '2923.7 0 0 0 0'
-        4:
-          effective_focal_length: '1644.51 0 0 0 0'
-        5:
-          effective_focal_length: '315.191 0 0 0 0'
-        38:
-          effective_focal_length: '215.191 0 0 0 0'
       file: gamma_run000001_za40deg_azm180deg_South_beta_6.0_check_output.simtel.zst
       path_descriptor: pack_for_grid_register
   - test_simtel_cfg_files:

--- a/tests/integration_tests/config/simulate_prod_gamma_62_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_62_deg_South_check_output.yml
@@ -1,0 +1,44 @@
+---
+applications:
+- application: simtools-simulate-prod
+  configuration:
+    array_layout_name: beta
+    azimuth_angle: South
+    core_scatter: 1 840 m
+    corsika_test_seeds: true
+    data_directory: simtools-data
+    energy_range: 400 GeV 1000 GeV
+    label: check_output
+    log_level: DEBUG
+    model_version: 6.0
+    nshow: 5
+    output_path: simtools-output
+    pack_for_grid_register: simtools-grid-output
+    primary: gamma
+    run_number: 20
+    sim_telarray_instrument_seeds: 1745,290
+    simulation_software: corsika_sim_telarray
+    site: South
+    zenith_angle: 62.
+    overwrite_model_parameters: tests/resources/info_test_model_parameter_changes.yml
+  integration_tests:
+  - test_output_files:
+    - file: gamma_run000020_za62deg_azm180deg_South_beta_6.0_check_output.log_hist.tar.gz
+      path_descriptor: pack_for_grid_register
+    - expected_simtel_metadata:
+        site_config_name: South
+        1:
+          effective_focal_length: '2923.7 0 0 2 0'
+        2:
+          effective_focal_length: '2923.7 0 0 0 0'
+        4:
+          effective_focal_length: '1644.51 0 0 0 0'
+        5:
+          effective_focal_length: '315.191 0 0 0 0'
+        38:
+          effective_focal_length: '215.191 0 0 0 0'
+      file: gamma_run000020_za62deg_azm180deg_South_beta_6.0_check_output.simtel.zst
+      path_descriptor: pack_for_grid_register
+  test_name: gamma_62_deg_south_check_output
+schema_name: application_workflow.metaschema
+schema_version: 0.4.0


### PR DESCRIPTION
PR #1856 fixed a severe bug in the integration tests for simulate_prod - generated configuration files for sim_telarray were not compared with the reference files.

Annoyingly, these tests are working now very well and this leads to a new failure: `simulate_prod_gamma_40_deg_South_check_output.yml` is testing both the new `overwrite_model_parameters` options (which allows to change parameter values) and compares to reference files. Obviously, changing model parameters and expect that they are the same as the reference is not working.

Separate these two items and have:

- simulate_prod_gamma_40_deg_South_check_output.yml tests for the south against the reference configuration
- simulate_prod_gamma_62_deg_South_check_output tests the overwrite_model_parameters parameter functionality

Note that `simulate_prod_gamma_62_deg_South_check_output` will be expanded in #1859 to test the usage of the curved CORSIKA executable.