### PR TITLE
Unit tests for simtools.simulator are slow due to frequent DB interaction. Use more mocking.

### DIFF
--- a/tests/unit_tests/runners/test_corsika_runner.py
+++ b/tests/unit_tests/runners/test_corsika_runner.py
@@ -119,6 +119,15 @@ def test_get_autoinputs_command(corsika_runner_mock_array_model, caplog):
     assert "--keep-seeds" in autoinputs_command_with_seeds
 
 
+def test_get_autoinputs_command_with_multipipe(corsika_runner_mock_array_model):
+    # Enable multipipe and ensure log file name is prefixed accordingly
+    corsika_runner_mock_array_model._use_multipipe = True
+    cmd = corsika_runner_mock_array_model._get_autoinputs_command(
+        run_number=7, input_tmp_file="tmp"
+    )
+    assert "multipipe_" in cmd
+
+
 def test_get_resources(corsika_runner_mock_array_model):
     with pytest.raises(FileNotFoundError):
         corsika_runner_mock_array_model.get_resources()

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -235,6 +235,8 @@ def test_get_resources(runner_service_mock_array_model, caplog):
     assert isinstance(resources, dict)
     assert "runtime" in resources
     assert resources["runtime"] == 500
+    # NSHOW from corsika_config_data fixture
+    assert resources["n_events"] == 100
 
     with open(sub_log_file, "w", encoding="utf-8") as file:
         lines_to_write = ["SOMETHING ELSE 500\n"]


### PR DESCRIPTION
Noticed while working on #1883 that the unit tests for simtools.simulator are very slow. Frequent ArrayModel inits with full DB queries are the reason. Introduced more mocking to fix this. Also fixed some missing coverage in runners.