### PR TITLE
Remove unused command line parameter from simtools-simulate-prod.

### DIFF
--- a/docs/changes/1891.maintenance.md
+++ b/docs/changes/1891.maintenance.md
@@ -1,0 +1,1 @@
+Remove unused command line parameter `data_directory` from simtools-simulate-prod.

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -39,10 +39,6 @@ r"""
         It allows the transformation system to keep using sequential run numbers without repetition.
     run (int, required)
         Run number (actual run number will be 'start_run' + 'run').
-    data_directory (str, optional)
-        The location of the output directories corsika-data and simtel-data.
-        the label is added to the data_directory, such that the output
-        will be written to data_directory/label/simtel-data.
     pack_for_grid_register (str, optional)
         Set whether to prepare a tarball for registering the output files on the grid.
         The files are written to the specified directory.
@@ -58,13 +54,6 @@ r"""
         simtools-simulate-prod \\
         --model_version 5.0.0 --site north --primary gamma --azimuth_angle north \\
         --zenith_angle 20 --start_run 0 --run 1
-
-    By default the configuration is saved in simtools-output/test-production
-    together with the actual simulation output in corsika-data and simtel-data within.
-    The location of the latter directories can be set
-    to a different location via the option --data_directory,
-    but the label is always added to the data_directory, such that the output
-    will be written to data_directory/label/simtel-data.
 """
 
 from simtools.application_control import startup_application
@@ -75,17 +64,6 @@ from simtools.simulator import Simulator
 def _parse():
     """Parse command line configuration."""
     config = configurator.Configurator(description="Run simulations for productions")
-    config.parser.add_argument(
-        "--data_directory",
-        help=(
-            "The directory where to save the corsika-data and simtel-data output directories."
-            "the label is added to the data_directory, such that the output"
-            "will be written to data_directory/label/simtel-data."
-        ),
-        type=str.lower,
-        required=False,
-        default="./simtools-output/",
-    )
     config.parser.add_argument(
         "--pack_for_grid_register",
         help="Directory for a tarball for registering the output files on the grid.",

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -137,7 +137,6 @@ simtools-simulate-prod \\
     --run_number $((process_id)) \\
     --run_number_offset {run_number_offset} \\
     --number_of_runs 1 \\
-    --data_directory /tmp/simtools-data \\
     --output_path /tmp/simtools-output \\
     --log_level {args_dict["log_level"]} \\
     --pack_for_grid_register simtools-output

--- a/src/simtools/testing/configuration.py
+++ b/src/simtools/testing/configuration.py
@@ -204,7 +204,7 @@ def _prepare_test_options(config, output_path, model_version=None):
     if model_version and "model_version" in config:
         config.update({"model_version": model_version})
 
-    for key in ["output_path", "data_directory", "pack_for_grid_register"]:
+    for key in ["output_path", "pack_for_grid_register"]:
         if key in config:
             config[key] = str(Path(output_path).joinpath(config[key]))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -338,7 +338,6 @@ def corsika_config_data(model_version):
         "primary": "proton",
         "primary_id_type": "common_name",
         "correct_for_b_field_alignment": True,
-        "data_directory": "simtools-output",
         "model_version": model_version,
     }
 

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_multiple_model_versions.yml
@@ -6,7 +6,6 @@ applications:
     azimuth_angle: South
     core_scatter: 5 700 m
     corsika_test_seeds: true
-    data_directory: simtools-data
     energy_range: 100 GeV 300 GeV
     label: multiple_model_versions
     log_level: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
@@ -6,7 +6,6 @@ applications:
     azimuth_angle: South
     core_scatter: 2 600 m
     corsika_test_seeds: true
-    data_directory: simtools-data
     energy_range: 150 GeV 400 GeV
     label: test
     log_level: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
@@ -6,7 +6,6 @@ applications:
     azimuth_angle: South
     core_scatter: 1 840 m
     corsika_test_seeds: true
-    data_directory: simtools-data
     energy_range: 150 GeV 400 GeV
     label: test
     log_level: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_62_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_62_deg_South_check_output.yml
@@ -6,7 +6,6 @@ applications:
     azimuth_angle: South
     core_scatter: 1 840 m
     corsika_test_seeds: true
-    data_directory: simtools-data
     energy_range: 400 GeV 1000 GeV
     label: check_output
     log_level: DEBUG

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
@@ -6,7 +6,6 @@ applications:
     azimuth_angle: South
     core_scatter: 5 500 m
     corsika_test_seeds: true
-    data_directory: simtools-data
     energy_range: 200 GeV 500 GeV
     label: check_output
     log_level: DEBUG

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -86,7 +86,6 @@ simtools-simulate-prod \\
     --run_number $((process_id)) \\
     --run_number_offset {args_dict["run_number_offset"]} \\
     --number_of_runs 1 \\
-    --data_directory /tmp/simtools-data \\
     --output_path /tmp/simtools-output \\
     --log_level {args_dict["log_level"]} \\
     --pack_for_grid_register simtools-output

--- a/tests/unit_tests/testing/test_configuration.py
+++ b/tests/unit_tests/testing/test_configuration.py
@@ -183,25 +183,8 @@ def test_prepare_test_options_with_output_path(tmp_test_directory, tmp_config_st
     assert written_config["output_path"] == str(tmp_test_directory / "results")
 
 
-def test_prepare_test_options_with_data_directory(tmp_test_directory, tmp_config_string):
-    config = {"data_directory": "data"}
-    model_version = None
-
-    config_file, config_string, config_file_model_version = configuration._prepare_test_options(
-        config, tmp_test_directory, model_version
-    )
-
-    assert config_file == tmp_test_directory / tmp_config_string
-    assert config_string is None
-    assert config_file_model_version is None
-
-    with open(config_file, encoding="utf-8") as file:
-        written_config = yaml.safe_load(file)
-    assert written_config["data_directory"] == str(tmp_test_directory / "data")
-
-
 def test_prepare_test_options_with_full_config(tmp_test_directory, tmp_config_string):
-    config = {"model_version": "v1.0", "output_path": "results", "data_directory": "data"}
+    config = {"model_version": "v1.0", "output_path": "results"}
     model_version = "v2.0"
 
     config_file, config_string, config_file_model_version = configuration._prepare_test_options(
@@ -216,7 +199,6 @@ def test_prepare_test_options_with_full_config(tmp_test_directory, tmp_config_st
         written_config = yaml.safe_load(file)
     assert written_config["model_version"] == "v2.0"
     assert written_config["output_path"] == str(tmp_test_directory / "results")
-    assert written_config["data_directory"] == str(tmp_test_directory / "data")
 
 
 def test_configure_with_model_version_use_current(tmp_test_directory, mocker, tmp_config_string):
@@ -253,7 +235,7 @@ def test_configure_with_configuration(tmp_test_directory, mocker, tmp_config_str
     config = {
         "application": "test_app",
         "test_name": "test_name",
-        "configuration": {"output_path": "results", "data_directory": "data"},
+        "configuration": {"output_path": "results"},
     }
     request = mocker.Mock()
     request.config.getoption.return_value = None
@@ -272,9 +254,6 @@ def test_configure_with_configuration(tmp_test_directory, mocker, tmp_config_str
         written_config = yaml.safe_load(file)
     assert written_config["output_path"] == str(
         tmp_test_directory / "test_app-test_name" / "results"
-    )
-    assert written_config["data_directory"] == str(
-        tmp_test_directory / "test_app-test_name" / "data"
     )
 
 

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -337,12 +337,12 @@ def test_validate_reference_output_file(mocker, output_path, test_path):
 
 def test_validate_output_path_and_file(output_path, mock_path_exists, mock_check_output):
     config = {
-        "configuration": {"output_path": output_path, "data_directory": "/path/to/data"},
+        "configuration": {"output_path": output_path},
         "integration_tests": [{"expected_output": "expected_output"}],
     }
     integration_test = [
         {
-            "path_descriptor": "data_directory",
+            "path_descriptor": "output_path",
             "file": "output_file.simtel.zst",
             "expected_output": {},
         }
@@ -352,9 +352,9 @@ def test_validate_output_path_and_file(output_path, mock_path_exists, mock_check
 
     mock_path_exists.assert_called()
     mock_check_output.assert_called_once_with(
-        Path(config["configuration"]["data_directory"]).joinpath(integration_test[0]["file"]),
+        Path(config["configuration"]["output_path"]).joinpath(integration_test[0]["file"]),
         {
-            "path_descriptor": "data_directory",
+            "path_descriptor": "output_path",
             "file": "output_file.simtel.zst",
             "expected_output": {},
         },
@@ -371,11 +371,11 @@ def test_validate_output_path_and_file(output_path, mock_path_exists, mock_check
 
 def test_validate_output_path_and_file_log_archive(output_path, mock_path_exists):
     config = {
-        "configuration": {"output_path": output_path, "data_directory": "/path/to/data"},
+        "configuration": {"output_path": output_path},
     }
     integration_test = [
         {
-            "path_descriptor": "data_directory",
+            "path_descriptor": "output_path",
             "file": "test.log_hist.tar.gz",
             "expected_log_output": {"pattern": ["test"]},
         }


### PR DESCRIPTION
The functionality of `data_directory` has been replaced a while ago by `output_path` (to be consistent with other simtools). We forgot to remove it. 