### PR TITLE
Fix simtools-dev image date (temporary)

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -45,7 +45,8 @@ jobs:
   integration_tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/gammasim/simtools-dev:latest
+      # Temporary fix: use fixed image date until PR 1917 is merged
+      image: ghcr.io/gammasim/simtools-dev:20251123-020721
       options: --user 0
 
     services:


### PR DESCRIPTION
PR 1917 is doing a relatively large change on how CORSIKA / sim_telarray images are build. The latest build in the package registry is not yet compatible with the current simtools version. This PR therefore fixes the image version to allow tests to pass.