### PR TITLE
CI-docs should not trigger on any push

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -4,8 +4,8 @@ name: CI-docs
 
 on:
   workflow_dispatch:
-  push:
   pull_request:
+    types: [opened, synchronize]
   release:
     types: [published]
 


### PR DESCRIPTION
PR #1907 changed the way the CI-docs is trigger. There is a small mistake - we do not want to trigger it on any `push` - only on pushes to open PR (as it is now, CI-docs is the only CI which runs when pushing a new branch to remote).