### PR TITLE
Update DOI in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -34,5 +34,5 @@ authors:
     affiliation: DESY
     orcid: 'https://orcid.org/0000-0001-9868-4700'
 repository-code: 'https://github.com/gammasim/simtools'
-doi: 10.5281/zenodo.6346697
+doi: 10.5281/zenodo.6346696
 license: BSD-3-Clause


### PR DESCRIPTION
When I copy pasted the current DOI link, I got to an old version on Zenodo. Trying this link since Zenodo says it cites all versions.