### PR TITLE
Remove mamba step from linter

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -63,12 +63,6 @@ jobs:
         with:
           args: "--validate"
 
-      - name: Install mamba dependencies
-        uses: mamba-org/setup-micromamba@v2
-        with:
-          environment-file: environment.yml
-          init-shell: bash
-
       - name: Python dependencies
         run: |
           pip install -e '.[tests,dev,doc]'


### PR DESCRIPTION
There are a couple of failing linter workflows (e.g. [here](https://github.com/gammasim/simtools/actions/runs/19843344183)) at the micromamba stage. Not sure what the reason is - remove the actually uncessary mamba step and use pip to install the packages.