### PR TITLE
Add missing epos table

### DIFF
--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -445,6 +445,7 @@ class CorsikaConfig:
         epos_par["EPOPAR fname pathnx"] = [f"{epos_path}/"]
         for epos_file in ["inics", "iniev", "inirj", "initl", "check"]:
             epos_par[f"EPOPAR fname {epos_file}"] = [str(epos_path / f"epos.{epos_file}")]
+        epos_par["EPOPAR fname hpf"] = [str(epos_path / "urqmd34/tables.dat")]
 
         return epos_par
 


### PR DESCRIPTION
Checked again the example in the CORSIKA manual (in the footnote) and the example input file provided with CORSIKA. Had one EPOS parameter missing:

```
EPOPAR fname hpf   ../epos/urqmd34/tables.dat
```

<img width="785" height="222" alt="Screenshot 2026-01-19 at 13 25 27" src="https://github.com/user-attachments/assets/d95c3a75-f821-449c-9a0a-d8724a8c2f0d" />
