### PR TITLE
Legacy workflow on manual trigger only.

### DIFF
--- a/.github/workflows/build-corsika-simtel-legacy.yml
+++ b/.github/workflows/build-corsika-simtel-legacy.yml
@@ -8,11 +8,6 @@ name: build-corsika-simtel-legacy
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - docker/Dockerfile-corsika-simtel
-  schedule:
-    - cron: '0 0 1 * *'  # Every 1st day of the month at 00:00 UTC (build only)
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-simtools-legacy.yml
+++ b/.github/workflows/build-simtools-legacy.yml
@@ -6,16 +6,6 @@ name: build-simtools-legacy
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["build-corsika-simtel"]
-    types: [completed]
-  pull_request:
-    paths:
-      - docker/Dockerfile-simtools-legacy
-  release:
-    types: [published]
-  schedule:
-    - cron: '0 1 * * 0'  # Every Sunday at 01:00 UTC (1 hour after base images)
 
 env:
   REGISTRY: ghcr.io

--- a/docs/changes/1993.maintenace.md
+++ b/docs/changes/1993.maintenace.md
@@ -1,0 +1,1 @@
+Switch to 'trigger manually only' for legacy build workflows for CORSIKA, sim_telarray and simtools.


### PR DESCRIPTION
Switch to 'trigger manually only' for legacy build workflows for CORSIKA, sim_telarray and simtools.