### PR TITLE
Reduce debug statements

### DIFF
--- a/docs/changes/2002.maintenance.md
+++ b/docs/changes/2002.maintenance.md
@@ -1,0 +1,1 @@
+Reduce the number of unnecessary debug statements.

--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -39,7 +39,6 @@ class CorsikaConfig:
     def __init__(self, array_model, run_number, label=None):
         """Initialize CorsikaConfig."""
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init CorsikaConfig")
 
         self.label = label
         self.shower_events = self.mc_events = None

--- a/src/simtools/corsika/corsika_histograms.py
+++ b/src/simtools/corsika/corsika_histograms.py
@@ -31,7 +31,6 @@ class CorsikaHistograms:
 
     def __init__(self, input_file, normalization_method="per-telescope", axis_distance=1000 * u.m):
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init CorsikaHistograms")
         self.input_file = Path(input_file)
         if not self.input_file.exists():
             raise FileNotFoundError(f"File {self.input_file} does not exist.")

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -260,9 +260,7 @@ class DatabaseHandler:
             collection,
         )
         if cache_dict:
-            self._logger.debug(f"Found {array_element} in cache (key: {cache_key})")
             return cache_dict
-        self._logger.debug(f"Did not find {array_element} in cache (key: {cache_key})")
 
         try:
             parameter_version_table = production_table["parameters"][array_element]

--- a/src/simtools/io/io_handler.py
+++ b/src/simtools/io/io_handler.py
@@ -22,8 +22,6 @@ class IOHandler(metaclass=IOHandlerSingleton):
     def __init__(self):
         """Initialize IOHandler."""
         self.logger = logging.getLogger(__name__)
-        self.logger.debug("Init IOHandler")
-
         self.output_path = None
         self.model_path = None
 

--- a/src/simtools/layout/array_layout.py
+++ b/src/simtools/layout/array_layout.py
@@ -331,7 +331,6 @@ class ArrayLayout:
         astropy.table.QTable
             Table with the telescope layout information.
         """
-        self._logger.debug("Initializing array (site and telescope parameters)")
         self._initialize_site_parameters_from_db()
         self._initialize_coordinate_systems()
 

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -51,7 +51,6 @@ class ArrayModel:
     ):
         """Initialize ArrayModel."""
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init ArrayModel")
         self.model_version = model_version
         self.label = label
         self.layout_name = (
@@ -257,7 +256,6 @@ class ArrayModel:
         for tel_model in self.telescope_models.values():
             name = tel_model.name
             if name not in exported_models:
-                self._logger.debug(f"Exporting configuration file for telescope {name}")
                 tel_model.write_sim_telarray_config_file(
                     additional_models=self.calibration_models.get(tel_model.name)
                 )

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -276,8 +276,6 @@ class ModelParameter:
         )
         self._config_file_path = self.config_file_directory.joinpath(config_file_name)
 
-        self._logger.debug(f"Config file path: {self._config_file_path}")
-
     def get_simulation_software_parameters(self, simulation_software):
         """
         Get simulation software parameters.

--- a/src/simtools/model/telescope_model.py
+++ b/src/simtools/model/telescope_model.py
@@ -56,7 +56,6 @@ class TelescopeModel(ModelParameter):
         )
 
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init TelescopeModel %s %s", site, telescope_name)
 
         self._single_mirror_list_file_paths = None
         self._mirrors = None

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -50,7 +50,6 @@ class SimtelConfigWriter:
     ):
         """Initialize SimtelConfigWriter."""
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Init SimtelConfigWriter")
 
         self._site = site
         self._model_version = model_version


### PR DESCRIPTION
Partially addresses #1980 

Removed unnecessary debug statements when running

```
 python src/simtools/applications/simulate_prod.py --config tests/integration_tests/config/simulate_prod_gamma_62_deg_South_check_output.yml
```

There are still a lot - especially from the overwrite model parameter feature. But some of them point towards an issue, which will be resolved soon.