### PR TITLE
Minor fix on summary text for camera efficiency

### DIFF
--- a/src/simtools/camera/camera_efficiency.py
+++ b/src/simtools/camera/camera_efficiency.py
@@ -260,17 +260,17 @@ class CameraEfficiency:
         nsb_spectrum_text = (
             f"NSB spectrum file: {self.config['nsb_spectrum']}"
             if self.config["nsb_spectrum"]
-            else "default sim_telarray spectrum."
+            else "default sim_telarray NSB spectrum."
         )
         results = (
             f"Results summary for {self.telescope_model.name} at "
             f"zenith={self.config['zenith_angle']:.1f} deg, "
             f"azimuth={self.config['azimuth_angle']:.1f} deg\n"
             f"Using the {nsb_spectrum_text}\n"
-            f"\nSpectrum weighted reflectivity: {self.calc_reflectivity():.4f}\n"
         )
         if self.efficiency_type == "shower":
             results += (
+                f"Spectrum (shower) weighted reflectivity: {self.calc_reflectivity():.4f}\n"
                 "Camera nominal efficiency with gaps (B-TEL-1170): "
                 f"{self.calc_camera_efficiency():.4f}\n"
                 "Telescope total efficiency"

--- a/tests/unit_tests/camera/test_camera_efficiency.py
+++ b/tests/unit_tests/camera/test_camera_efficiency.py
@@ -328,7 +328,7 @@ def test_results_summary_shower_type(camera_efficiency_lst, prepare_results_file
     assert "Results summary for LSTN-01" in summary
     assert "zenith=20.0 deg" in summary
     assert "azimuth=0.0 deg" in summary
-    assert "Spectrum weighted reflectivity:" in summary
+    assert "Spectrum (shower) weighted reflectivity:" in summary
     assert "Camera nominal efficiency with gaps (B-TEL-1170):" in summary
     assert "Telescope total efficiency" in summary
     assert "Telescope total Cherenkov light efficiency" in summary
@@ -370,4 +370,4 @@ def test_results_summary_without_nsb_spectrum(camera_efficiency_lst, prepare_res
     camera_efficiency_lst.export_model_files()
     camera_efficiency_lst.config["nsb_spectrum"] = None
     summary = camera_efficiency_lst.results_summary()
-    assert "default sim_telarray spectrum" in summary
+    assert "default sim_telarray NSB spectrum" in summary


### PR DESCRIPTION
New output is now:

```
Results summary for SSTS-design at zenith=0.0 deg, azimuth=0.0 deg
Using the default sim_telarray NSB spectrum.
Spectrum (shower) weighted reflectivity: 0.9128
Camera nominal efficiency with gaps (B-TEL-1170): 0.3622
Telescope total efficiency with gaps (was A-PERF-2020): 0.3512
Telescope total Cherenkov light efficiency / sqrt(total NSB efficiency) (A-PERF-2025/B-TEL-0090): 0.5123
Expected NSB pixel rate for the provided NSB spectrum: 0.0351 GHz [p.e./ns]
Expected NSB pixel rate for the reference NSB: 0.0317 GHz [p.e./ns]
Fraction of light (from muons) in the wavelength range 200-290 nm (B-TEL-0095): 0.0328
```

The output before that the spectrum weighted reflectivity printed for a shower and muon Cherenkov spectrum.

Closes #2004 