### PR TITLE
Compact numeric lists

### DIFF
--- a/docs/changes/2114.maintenance.md
+++ b/docs/changes/2114.maintenance.md
@@ -1,0 +1,1 @@
+Keep compact numerical list in json for non-dict-type numerical values.

--- a/docs/changes/2114.maintenance.md
+++ b/docs/changes/2114.maintenance.md
@@ -1,1 +1,1 @@
-Keep compact numerical list in json for non-dict-type numerical values.
+Do not use compact numeric list in json for non-dict-type numerical values.

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -535,6 +535,7 @@ class ModelDataWriter:
             output_file=output_file,
             sort_keys=True,
             numpy_types=True,
+            compact_numeric_lists=isinstance(data_dict.get("value"), dict),
         )
 
     @staticmethod

--- a/src/simtools/io/ascii_handler.py
+++ b/src/simtools/io/ascii_handler.py
@@ -190,7 +190,14 @@ def is_utf8_file(file_name):
         return False
 
 
-def write_data_to_file(data, output_file, sort_keys=False, numpy_types=False, unique_lines=False):
+def write_data_to_file(
+    data,
+    output_file,
+    sort_keys=False,
+    numpy_types=False,
+    unique_lines=False,
+    compact_numeric_lists=False,
+):
     """
     Write structured data to JSON, YAML, or text file.
 
@@ -206,10 +213,18 @@ def write_data_to_file(data, output_file, sort_keys=False, numpy_types=False, un
         If True, sort the keys.
     numpy_types: bool, optional
         If True, convert numpy types to native Python types.
+    compact_numeric_lists: bool, optional
+        If True, serialize numeric lists on a single line for JSON output.
     """
     output_file = Path(output_file)
     if output_file.suffix.lower() == ".json":
-        _write_to_json(data, output_file, sort_keys, numpy_types)
+        _write_to_json(
+            data,
+            output_file,
+            sort_keys,
+            numpy_types,
+            compact_numeric_lists=compact_numeric_lists,
+        )
         return
     if output_file.suffix.lower() in [".yml", ".yaml"]:
         _write_to_yaml(data, output_file, sort_keys)
@@ -251,7 +266,7 @@ def _write_to_text_file(data, output_file, unique_lines):
             file.write(f"{line}\n")
 
 
-def _write_to_json(data, output_file, sort_keys, numpy_types):
+def _write_to_json(data, output_file, sort_keys, numpy_types, compact_numeric_lists=False):
     """
     Write data to a JSON file.
 
@@ -265,16 +280,28 @@ def _write_to_json(data, output_file, sort_keys, numpy_types):
         If True, sort the keys.
     numpy_types: bool
         If True, convert numpy types to native Python types.
+    compact_numeric_lists: bool
+        If True, serialize numeric lists on a single line.
     """
     with open(output_file, "w", encoding="utf-8") as file:
-        file.write(
-            json.dumps(
-                data,
-                indent=4,
-                sort_keys=sort_keys,
-                cls=JsonNumpyEncoder if numpy_types else None,
+        if numpy_types:
+            file.write(
+                json.dumps(
+                    data,
+                    indent=4,
+                    sort_keys=sort_keys,
+                    cls=JsonNumpyEncoder,
+                    compact_numeric_lists=compact_numeric_lists,
+                )
             )
-        )
+        else:
+            file.write(
+                json.dumps(
+                    data,
+                    indent=4,
+                    sort_keys=sort_keys,
+                )
+            )
         file.write("\n")
 
 
@@ -316,11 +343,20 @@ def _to_builtin(data):
 class JsonNumpyEncoder(json.JSONEncoder):
     """Convert numpy to python types as accepted by json.dump.
 
-    Lists whose elements are all numbers (int or float) are serialized on a
-    single line regardless of the surrounding indentation level. This keeps
-    row-oriented table data human-readable without expanding every number onto
-    its own line.
+    Lists whose elements are all numbers (int or float) can be serialized on a
+    single line when ``compact_numeric_lists`` is enabled.
     """
+
+    def __init__(self, *args, compact_numeric_lists=False, **kwargs):
+        """Initialize JSON encoder.
+
+        Parameters
+        ----------
+        compact_numeric_lists : bool
+            If True, serialize numeric lists on a single line.
+        """
+        super().__init__(*args, **kwargs)
+        self.compact_numeric_lists = compact_numeric_lists
 
     def default(self, o):
         """Return default encoder."""
@@ -338,10 +374,14 @@ class JsonNumpyEncoder(json.JSONEncoder):
 
     def encode(self, o):
         """Encode with compact inner numeric lists."""
+        if not self.compact_numeric_lists:
+            return super().encode(o)
+
         # Convert numpy (and other custom) types to pure-Python types first so
         # that _encode_compact_rows only needs to handle builtins.
         native = json.loads(super().encode(o))
-        return _encode_compact_rows(native, indent=4, level=0)
+        indent = self.indent if isinstance(self.indent, int) else 4
+        return _encode_compact_rows(native, indent=indent, level=0)
 
 
 def _is_numeric_list(obj):

--- a/src/simtools/io/ascii_handler.py
+++ b/src/simtools/io/ascii_handler.py
@@ -213,6 +213,8 @@ def write_data_to_file(
         If True, sort the keys.
     numpy_types: bool, optional
         If True, convert numpy types to native Python types.
+    unique_lines: bool, optional
+        If True, write only unique lines (applicable for text files).
     compact_numeric_lists: bool, optional
         If True, serialize numeric lists on a single line for JSON output.
     """

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -89,6 +89,29 @@ def test_write_dict_to_model_parameter_json(tmp_test_directory):
     assert Path(data_file).is_file()
 
 
+def test_write_dict_to_model_parameter_json_compact_numeric_lists_switch(tmp_test_directory):
+    w1 = writer.ModelDataWriter(output_path=tmp_test_directory)
+    data_file = tmp_test_directory.join("test_file.json")
+
+    with patch(
+        "simtools.data_model.model_data_writer.ascii_handler.write_data_to_file"
+    ) as mock_write:
+        w1.write_dict_to_model_parameter_json(
+            file_name=data_file,
+            data_dict={"value": {"a": [1, 2, 3]}},
+        )
+        assert mock_write.call_args.kwargs["compact_numeric_lists"] is True
+
+    with patch(
+        "simtools.data_model.model_data_writer.ascii_handler.write_data_to_file"
+    ) as mock_write:
+        w1.write_dict_to_model_parameter_json(
+            file_name=data_file,
+            data_dict={"value": [1, 2, 3]},
+        )
+        assert mock_write.call_args.kwargs["compact_numeric_lists"] is False
+
+
 def test_dump(args_dict):
     settings.config.load(args=args_dict)
     empty_table = Table()

--- a/tests/unit_tests/io/test_ascii_handler.py
+++ b/tests/unit_tests/io/test_ascii_handler.py
@@ -210,6 +210,13 @@ def test_json_numpy_encoder():
         encoder.default("abc")
 
 
+def test_json_numpy_encoder_compact_numeric_lists_enabled():
+    encoder = ascii_handler.JsonNumpyEncoder(compact_numeric_lists=True)
+    encoded = encoder.encode({"rows": [[1, 2, 3], [4.0, 5.0, 6.0]]})
+    assert "[1, 2, 3]" in encoded
+    assert "[4.0, 5.0, 6.0]" in encoded
+
+
 def test_write_to_yaml(tmp_test_directory):
     """Test the _write_to_yaml function."""
     test_data = {"key1": "value1", "key2": [1, 2, 3], "key3": {"nested_key": "nested_value"}}
@@ -273,6 +280,36 @@ def test_write_to_json(tmp_test_directory):
         "float": 3.14,
         "int": 42,
     }
+
+
+def test_write_to_json_compact_numeric_lists_toggle(tmp_test_directory):
+    data = {"value": {"rows": [[1, 2, 3], [4, 5, 6]]}}
+
+    non_compact_file = tmp_test_directory / "test_non_compact.json"
+    ascii_handler._write_to_json(
+        data,
+        non_compact_file,
+        sort_keys=False,
+        numpy_types=True,
+        compact_numeric_lists=False,
+    )
+    non_compact_text = non_compact_file.read_text(encoding="utf-8")
+    assert "[1, 2, 3]" not in non_compact_text
+    expected_multiline_list = (
+        "[\n                1,\n                2,\n                3\n            ]"
+    )
+    assert expected_multiline_list in non_compact_text
+
+    compact_file = tmp_test_directory / "test_compact.json"
+    ascii_handler._write_to_json(
+        data,
+        compact_file,
+        sort_keys=False,
+        numpy_types=True,
+        compact_numeric_lists=True,
+    )
+    compact_text = compact_file.read_text(encoding="utf-8")
+    assert "[1, 2, 3]" in compact_text
 
 
 def test_write_data_to_file_json(tmp_test_directory):


### PR DESCRIPTION
In #2088 we introduce a format change to the JSON output for numerical lists to increase readability for table-style dicts.

Noticed now only (obviously) that this affects all lists numerical lists, which interferes with the way we check that all model parameters are changed using the info-change files only. CI failure e.g., [here](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/667213).

This PR applies the compact writing for dict-style values only (and leave normal lists as before).

If you are really interested - we want the first and not the second format (otherwise we have to rewrite our CI or update many model parameter json files in the simulation models repository):

```
@@ -16,11 +16,5 @@
         null,
         null
     ],
-    "value": [
-        1,
-        0.00231,
-        4.38113,
-        3.38831,
-        1.43381
-    ]
+    "value": [1, 0.00231, 4.38113, 3.38831, 1.43381]
 }
``` 