### PR TITLE
Update simulation model directly from settings workflows

### DIFF
--- a/docs/changes/2115.feature.md
+++ b/docs/changes/2115.feature.md
@@ -1,0 +1,1 @@
+Add functionality to update simulation model directly from settings workflows using the model parameter version and derivation activity ID.

--- a/docs/changes/2115.maintenance.md
+++ b/docs/changes/2115.maintenance.md
@@ -1,0 +1,1 @@
+Generalize reading from git repositories. Add CTAO git repos as default values.

--- a/src/simtools/applications/db_upload_model_repository.py
+++ b/src/simtools/applications/db_upload_model_repository.py
@@ -41,13 +41,9 @@ used to name the database, but no tag checkout is done):
 """
 
 from simtools.application_control import build_application
+from simtools.constants import DEFAULT_SIMULATION_MODELS
 from simtools.db import db_handler, db_model_upload
 from simtools.settings import config
-
-DEFAULT_REPOSITORY_URL = (
-    "https://gitlab.cta-observatory.org/cta-science/simulations/"
-    "simulation-model/simulation-models.git"
-)
 
 
 def _add_arguments(parser):
@@ -96,7 +92,7 @@ def main():
         db=db,
         db_simulation_model=app_context.args.get("db_simulation_model"),
         db_simulation_model_version=app_context.args.get("db_simulation_model_version"),
-        repository_url=DEFAULT_REPOSITORY_URL,
+        repository_url=DEFAULT_SIMULATION_MODELS,
         repository_branch=app_context.args.get("branch"),
     )
 

--- a/src/simtools/applications/derive_ctao_array_layouts.py
+++ b/src/simtools/applications/derive_ctao_array_layouts.py
@@ -43,6 +43,7 @@ r"""
 """
 
 from simtools.application_control import build_application
+from simtools.constants import DEFAULT_COMPUTING_REPO
 from simtools.db import db_handler
 from simtools.layout.array_layout_utils import (
     merge_array_layouts,
@@ -57,7 +58,7 @@ def _add_arguments(parser):
         "--repository_url",
         help="URL or path of the CTAO common identifiers repository.",
         type=str,
-        default="https://gitlab.cta-observatory.org/cta-computing/common/identifiers/-/raw/",
+        default=f"{DEFAULT_COMPUTING_REPO}/common/identifiers/-/raw/",
     )
     parser.add_argument(
         "--repository_branch",

--- a/src/simtools/constants.py
+++ b/src/simtools/constants.py
@@ -28,3 +28,11 @@ RESOURCE_PATH = files("simtools") / "resources"
 SIMTEL_MAX_SEED = 2147483647
 # Maximum value allowed for random seeds in CORSIKA
 CORSIKA_MAX_SEED = 900000000
+
+# Default repository URLs for simulations and computing resources
+DEFAULT_SIMULATIONS_REPO = "https://gitlab.cta-observatory.org/cta-science/simulations"
+DEFAULT_COMPUTING_REPO = "https://gitlab.cta-observatory.org/cta-computing"
+DEFAULT_SIMULATION_MODELS = f"{DEFAULT_SIMULATIONS_REPO}/simulation-model/simulation-models.git"
+DEFAULT_SIMULATION_WORKFLOWS = (
+    f"{DEFAULT_SIMULATIONS_REPO}/simulation-model/simulation-model-parameter-setting.git"
+)

--- a/src/simtools/io/ascii_handler.py
+++ b/src/simtools/io/ascii_handler.py
@@ -134,6 +134,38 @@ def collect_data_from_http(url):
     return data
 
 
+def collect_data_from_git(file_name, git_repository, git_branch="main"):
+    """
+    Download yaml/json/list data from a git repository via its raw URL interface.
+
+    Supports both repository URLs (with or without ``.git`` suffix) and raw URL bases
+    containing ``/-/raw/``.
+
+    Parameters
+    ----------
+    file_name: str or Path
+        File path inside repository (e.g. ``path/to/file.json``).
+    git_repository: str
+        Git repository URL or raw URL base.
+    git_branch: str
+        Branch or tag to use when reading from raw endpoint.
+
+    Returns
+    -------
+    dict or list
+        Parsed file content.
+    """
+    file_path = Path(file_name).as_posix().lstrip("/")
+    repository_url = str(git_repository).rstrip("/")
+
+    if "/-/raw" in repository_url:
+        url = f"{repository_url}/{git_branch}/{file_path}"
+    else:
+        url = f"{repository_url.removesuffix('.git')}/-/raw/{git_branch}/{file_path}"
+
+    return collect_data_from_http(url)
+
+
 def read_file_encoded_in_utf_or_latin(file_name):
     """
     Read a file encoded in UTF-8 or Latin-1.

--- a/src/simtools/layout/array_layout_utils.py
+++ b/src/simtools/layout/array_layout_utils.py
@@ -39,11 +39,15 @@ def retrieve_ctao_array_layouts(site, repository_url, branch_name="main"):
     _logger.info(f"Retrieving array layouts from {repository_url} on branch {branch_name}.")
 
     if gen.is_url(repository_url):
-        array_element_ids = ascii_handler.collect_data_from_http(
-            url=f"{repository_url}/{branch_name}/array-element-ids.json"
+        array_element_ids = ascii_handler.collect_data_from_git(
+            file_name="array-element-ids.json",
+            git_repository=repository_url,
+            git_branch=branch_name,
         )
-        sub_arrays = ascii_handler.collect_data_from_http(
-            url=f"{repository_url}/{branch_name}/subarray-ids.json"
+        sub_arrays = ascii_handler.collect_data_from_git(
+            file_name="subarray-ids.json",
+            git_repository=repository_url,
+            git_branch=branch_name,
         )
     else:
         array_element_ids = ascii_handler.collect_data_from_file(

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -19,6 +19,7 @@ from packaging.version import Version
 from packaging.version import parse as parse_version
 
 import simtools.data_model.model_data_writer as writer
+from simtools.constants import DEFAULT_SIMULATION_WORKFLOWS
 from simtools.io import ascii_handler
 from simtools.utils import names
 
@@ -202,6 +203,7 @@ def generate_new_production(model_version, simulation_models_path):
     """
     modification_dict = _get_changes_dict(model_version, simulation_models_path)
     update_type = modification_dict.get("model_update", "full_update")
+    setting_workflows_git_tag = modification_dict.get("setting_workflows_git_tag", "main")
     changes, base_model_version = _get_changes_to_production(
         modification_dict, simulation_models_path, update_type
     )
@@ -214,7 +216,7 @@ def generate_new_production(model_version, simulation_models_path):
         simulation_models_path,
     )
 
-    _apply_changes_to_model_parameters(changes, simulation_models_path)
+    _apply_changes_to_model_parameters(changes, simulation_models_path, setting_workflows_git_tag)
 
 
 def _get_production_table_key(table_name):
@@ -441,7 +443,9 @@ def _update_parameters_dict(table_parameters, changes, table_name):
     return new_params, deprecated_params
 
 
-def _apply_changes_to_model_parameters(changes, simulation_models_path):
+def _apply_changes_to_model_parameters(
+    changes, simulation_models_path, setting_workflows_git_tag="main"
+):
     """
     Apply changes to model parameters by creating new parameter entries.
 
@@ -451,13 +455,74 @@ def _apply_changes_to_model_parameters(changes, simulation_models_path):
         The changes to be applied.
     simulation_models_path: Path
         Path to the simulation models directory.
+    setting_workflows_git_tag: str
+        Branch or tag used to download parameters from simulation workflow repository.
     """
     for telescope, parameters in changes.items():
         for param, param_data in parameters.items():
-            if param_data.get("value") is not None:
+            if param_data.get("activity_id") is not None:
+                _download_model_parameter_from_workflow(
+                    telescope,
+                    param,
+                    param_data,
+                    simulation_models_path,
+                    setting_workflows_git_tag,
+                )
+            elif param_data.get("value") is not None:
                 _create_new_model_parameter_entry(
                     telescope, param, param_data, simulation_models_path
                 )
+
+
+def _download_model_parameter_from_workflow(
+    telescope,
+    param,
+    param_data,
+    simulation_models_path,
+    setting_workflows_git_tag="main",
+):
+    """
+    Download model parameter entry from simulation workflow repository.
+
+    Parameters
+    ----------
+    telescope: str
+        Name of the telescope.
+    param: str
+        Name of the parameter.
+    param_data: dict
+        Dictionary containing the parameter data including version and activity_id.
+    simulation_models_path: Path
+        Path to the simulation models directory.
+    setting_workflows_git_tag: str
+        Branch or tag used to download parameters from simulation workflow repository.
+
+    Raises
+    ------
+    TypeError
+        If downloaded content is not a dictionary.
+    """
+    source_file = (
+        f"output/{telescope}/{param}/{param_data['activity_id']}/"
+        f"{param}/{param}-{param_data['version']}.json"
+    )
+    _logger.info(f"Downloading model parameter '{telescope} - {param}' from '{source_file}'.")
+
+    downloaded_data = ascii_handler.collect_data_from_git(
+        file_name=source_file,
+        git_repository=DEFAULT_SIMULATION_WORKFLOWS,
+        git_branch=setting_workflows_git_tag,
+    )
+    if not isinstance(downloaded_data, dict):
+        raise TypeError(
+            f"Downloaded model parameter is of type {type(downloaded_data)} "
+            f"for '{telescope} - {param}'."
+        )
+
+    target_dir = get_model_parameter_directory(simulation_models_path) / telescope / param
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_file = target_dir / f"{param}-{param_data['version']}.json"
+    ascii_handler.write_data_to_file(downloaded_data, target_file, sort_keys=True)
 
 
 def _create_new_model_parameter_entry(telescope, param, param_data, simulation_models_path):

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -204,6 +204,9 @@ def generate_new_production(model_version, simulation_models_path):
     modification_dict = _get_changes_dict(model_version, simulation_models_path)
     update_type = modification_dict.get("model_update", "full_update")
     setting_workflows_git_tag = modification_dict.get("setting_workflows_git_tag", "main")
+    setting_workflows_git_repository = modification_dict.get(
+        "setting_workflows_git_repository", DEFAULT_SIMULATION_WORKFLOWS
+    )
     changes, base_model_version = _get_changes_to_production(
         modification_dict, simulation_models_path, update_type
     )
@@ -216,7 +219,12 @@ def generate_new_production(model_version, simulation_models_path):
         simulation_models_path,
     )
 
-    _apply_changes_to_model_parameters(changes, simulation_models_path, setting_workflows_git_tag)
+    _apply_changes_to_model_parameters(
+        changes,
+        simulation_models_path,
+        setting_workflows_git_tag,
+        setting_workflows_git_repository,
+    )
 
 
 def _get_production_table_key(table_name):
@@ -444,7 +452,10 @@ def _update_parameters_dict(table_parameters, changes, table_name):
 
 
 def _apply_changes_to_model_parameters(
-    changes, simulation_models_path, setting_workflows_git_tag="main"
+    changes,
+    simulation_models_path,
+    setting_workflows_git_tag="main",
+    setting_workflows_git_repository=DEFAULT_SIMULATION_WORKFLOWS,
 ):
     """
     Apply changes to model parameters by creating new parameter entries.
@@ -457,6 +468,8 @@ def _apply_changes_to_model_parameters(
         Path to the simulation models directory.
     setting_workflows_git_tag: str
         Branch or tag used to download parameters from simulation workflow repository.
+    setting_workflows_git_repository: str
+        Repository URL used to download parameters from simulation workflow repository.
 
     Raises
     ------
@@ -478,6 +491,7 @@ def _apply_changes_to_model_parameters(
                     param_data,
                     simulation_models_path,
                     setting_workflows_git_tag,
+                    setting_workflows_git_repository,
                 )
             elif param_data.get("value") is not None:
                 _create_new_model_parameter_entry(
@@ -491,6 +505,7 @@ def _download_model_parameter_from_workflow(
     param_data,
     simulation_models_path,
     setting_workflows_git_tag="main",
+    setting_workflows_git_repository=DEFAULT_SIMULATION_WORKFLOWS,
 ):
     """
     Download model parameter entry from simulation workflow repository.
@@ -507,6 +522,8 @@ def _download_model_parameter_from_workflow(
         Path to the simulation models directory.
     setting_workflows_git_tag: str
         Branch or tag used to download parameters from simulation workflow repository.
+    setting_workflows_git_repository: str
+        Repository URL used to download parameters from simulation workflow repository.
 
     Raises
     ------
@@ -523,7 +540,7 @@ def _download_model_parameter_from_workflow(
 
     downloaded_data = ascii_handler.collect_data_from_git(
         file_name=source_file,
-        git_repository=DEFAULT_SIMULATION_WORKFLOWS,
+        git_repository=setting_workflows_git_repository,
         git_branch=setting_workflows_git_tag,
     )
     if not isinstance(downloaded_data, dict):

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -457,9 +457,20 @@ def _apply_changes_to_model_parameters(
         Path to the simulation models directory.
     setting_workflows_git_tag: str
         Branch or tag used to download parameters from simulation workflow repository.
+
+    Raises
+    ------
+    ValueError
+        If both ``activity_id`` and ``value`` are provided for the same parameter.
     """
     for telescope, parameters in changes.items():
         for param, param_data in parameters.items():
+            if param_data.get("activity_id") is not None and param_data.get("value") is not None:
+                raise ValueError(
+                    f"Both activity_id and value are set for '{telescope} - {param}'. "
+                    "Provide only one source for model parameter content."
+                )
+
             if param_data.get("activity_id") is not None:
                 _download_model_parameter_from_workflow(
                     telescope,
@@ -501,6 +512,8 @@ def _download_model_parameter_from_workflow(
     ------
     TypeError
         If downloaded content is not a dictionary.
+    ValueError
+        If downloaded parameter_version does not match requested version.
     """
     source_file = (
         f"output/{telescope}/{param}/{param_data['activity_id']}/"
@@ -517,6 +530,13 @@ def _download_model_parameter_from_workflow(
         raise TypeError(
             f"Downloaded model parameter is of type {type(downloaded_data)} "
             f"for '{telescope} - {param}'."
+        )
+
+    downloaded_version = downloaded_data.get("parameter_version")
+    if downloaded_version != param_data["version"]:
+        raise ValueError(
+            f"Version mismatch for '{telescope} - {param}': requested "
+            f"'{param_data['version']}', downloaded '{downloaded_version}'."
         )
 
     target_dir = get_model_parameter_directory(simulation_models_path) / telescope / param

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
+from simtools.constants import DEFAULT_SIMULATIONS_REPO
 from simtools.db import db_handler
 from simtools.io import ascii_handler, io_handler
 from simtools.model.telescope_model import TelescopeModel
@@ -467,10 +468,9 @@ class ReadParameters:
                     outfile.write(f"![Parameter plot.]({outpath}/{plot_name}.png)\n\n")
 
                 outfile.write(
-                    "\n\nThe full file can be found in the Simulation Model repository [here]"
-                    "(https://gitlab.cta-observatory.org/cta-science/simulations/"
-                    "simulation-model/simulation-models/-/blob/main/simulation-models/"
-                    f"model_parameters/Files/{input_file.name}).\n\n"
+                    f"\n\nThe full file can be found in the Simulation Model repository [here]"
+                    f"({DEFAULT_SIMULATIONS_REPO}/simulation-model/simulation-models/-/blob/main/"
+                    f"simulation-models/model_parameters/Files/{input_file.name}).\n\n"
                 )
                 outfile.write("\n\n")
                 outfile.write("The first 30 lines of the file are:\n")
@@ -489,8 +489,8 @@ class ReadParameters:
             input_file_name = f"{self.output_path}/model/{value_data}"
             if parameter_version is None:
                 return (
-                    f"[{Path(value_data).name}](https://gitlab.cta-observatory.org/"
-                    "cta-science/simulations/simulation-model/simulation-models/-/blob/main/"
+                    f"[{Path(value_data).name}]({DEFAULT_SIMULATIONS_REPO}"
+                    f"/simulation-model/simulation-models/-/blob/main/"
                     f"simulation-models/model_parameters/Files/{value_data})"
                 ).strip()
             output_file_name = self._convert_to_md(parameter, parameter_version, input_file_name)

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -28,6 +28,9 @@ definitions:
       setting_workflows_git_tag:
         type: string
         description: Branch or release tag used when downloading workflow outputs.
+      setting_workflows_git_repository:
+        type: string
+        description: Repository URL used when downloading workflow outputs.
       description:
         type: string
         description: A detailed description of the model changes.
@@ -84,6 +87,17 @@ $defs:
           - type: "null"
       model_parameter_schema_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+    oneOf:
+      - required:
+          - value
+        not:
+          required:
+            - activity_id
+      - required:
+          - activity_id
+        not:
+          required:
+            - value
     required:
       - version
     additionalProperties: false

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -25,6 +25,9 @@ definitions:
         description: A list of previous model versions.
         items:
           $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      setting_workflows_git_tag:
+        type: string
+        description: Branch or release tag used when downloading workflow outputs.
       description:
         type: string
         description: A detailed description of the model changes.
@@ -65,6 +68,8 @@ $defs:
     properties:
       version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      activity_id:
+        type: string
       value:
         oneOf:
           - type: string

--- a/tests/unit_tests/io/test_ascii_handler.py
+++ b/tests/unit_tests/io/test_ascii_handler.py
@@ -145,6 +145,40 @@ def test_collect_data_from_http():
         ascii_handler.collect_data_from_http(url + _file)
 
 
+@patch("simtools.io.ascii_handler.collect_data_from_http")
+def test_collect_data_from_git_builds_url_from_repository(mock_collect_http):
+    """Test git raw URL construction from repository URL."""
+    mock_collect_http.return_value = {"key": "value"}
+
+    result = ascii_handler.collect_data_from_git(
+        file_name="folder/file.json",
+        git_repository="https://gitlab.cta-observatory.org/group/project.git",
+        git_branch="v1.2.3",
+    )
+
+    assert result == {"key": "value"}
+    mock_collect_http.assert_called_once_with(
+        "https://gitlab.cta-observatory.org/group/project/-/raw/v1.2.3/folder/file.json"
+    )
+
+
+@patch("simtools.io.ascii_handler.collect_data_from_http")
+def test_collect_data_from_git_builds_url_from_raw_base(mock_collect_http):
+    """Test git raw URL construction from a raw-base URL."""
+    mock_collect_http.return_value = {"subarrays": []}
+
+    result = ascii_handler.collect_data_from_git(
+        file_name="subarray-ids.json",
+        git_repository="https://gitlab.cta-observatory.org/group/project/-/raw",
+        git_branch="main",
+    )
+
+    assert result == {"subarrays": []}
+    mock_collect_http.assert_called_once_with(
+        "https://gitlab.cta-observatory.org/group/project/-/raw/main/subarray-ids.json"
+    )
+
+
 def test_read_file_encoded_in_utf_or_latin(tmp_test_directory, caplog) -> None:
     """
     Test the read_file_encoded_in_utf_or_latin function.

--- a/tests/unit_tests/layout/test_array_layout_utils.py
+++ b/tests/unit_tests/layout/test_array_layout_utils.py
@@ -204,7 +204,7 @@ def test_retrieve_ctao_array_layouts_from_url():
     with (
         patch("simtools.layout.array_layout_utils.gen") as mock_gen,
         patch(
-            "simtools.layout.array_layout_utils.ascii_handler.collect_data_from_http"
+            "simtools.layout.array_layout_utils.ascii_handler.collect_data_from_git"
         ) as mock_ascii_handler,
     ):
         mock_gen.is_url.return_value = True
@@ -215,7 +215,17 @@ def test_retrieve_ctao_array_layouts_from_url():
         )
 
         mock_gen.is_url.assert_called_once_with("https://test.com")
-        mock_ascii_handler.assert_called_with(url="https://test.com/test-branch/subarray-ids.json")
+        assert mock_ascii_handler.call_count == 2
+        mock_ascii_handler.assert_any_call(
+            file_name="array-element-ids.json",
+            git_repository="https://test.com",
+            git_branch="test-branch",
+        )
+        mock_ascii_handler.assert_any_call(
+            file_name="subarray-ids.json",
+            git_repository="https://test.com",
+            git_branch="test-branch",
+        )
 
 
 def test_retrieve_ctao_array_layouts_from_file(test_path):

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -782,20 +782,15 @@ def test_apply_changes_to_model_parameters_simple(mock_create_entry, tmp_path):
 @patch("simtools.model.model_repository._download_model_parameter_from_workflow")
 @patch("simtools.model.model_repository._create_new_model_parameter_entry")
 def test_apply_changes_to_model_parameters_with_activity_id(
-    mock_create_entry, mock_download_workflow, tmp_path
+    mock_create_entry, mock_download_workflow, tmp_test_directory
 ):
     """Test applying changes to model parameters using activity_id workflow source."""
-    model_parameters_dir = tmp_path / "model_parameters"
+    model_parameters_dir = tmp_test_directory / "model_parameters"
     changes = {
         "LSTN-design": {
             "pm_photoelectron_spectrum": {
                 "version": "3.0.0",
                 "activity_id": "019d85b6-1f98-715b-b92b-bfbcd06d7cd8",
-            },
-            "param_with_both": {
-                "version": "1.0.0",
-                "activity_id": "workflow-123",
-                "value": 10,
             },
             "value_only_param": {"version": "2.0.0", "value": 42},
         }
@@ -805,7 +800,7 @@ def test_apply_changes_to_model_parameters_with_activity_id(
         changes, model_parameters_dir, setting_workflows_git_tag="release-v1"
     )
 
-    assert mock_download_workflow.call_count == 2
+    assert mock_download_workflow.call_count == 1
     mock_download_workflow.assert_any_call(
         "LSTN-design",
         "pm_photoelectron_spectrum",
@@ -816,25 +811,39 @@ def test_apply_changes_to_model_parameters_with_activity_id(
         model_parameters_dir,
         "release-v1",
     )
-    mock_download_workflow.assert_any_call(
-        "LSTN-design",
-        "param_with_both",
-        {
-            "version": "1.0.0",
-            "activity_id": "workflow-123",
-            "value": 10,
-        },
-        model_parameters_dir,
-        "release-v1",
-    )
     mock_create_entry.assert_called_once_with(
         "LSTN-design", "value_only_param", {"version": "2.0.0", "value": 42}, model_parameters_dir
     )
 
 
+@patch("simtools.model.model_repository._download_model_parameter_from_workflow")
+@patch("simtools.model.model_repository._create_new_model_parameter_entry")
+def test_apply_changes_to_model_parameters_with_both_value_and_activity_id_raises(
+    mock_create_entry, mock_download_workflow, tmp_test_directory
+):
+    """Test that setting both value and activity_id raises an error."""
+    changes = {
+        "LSTN-design": {
+            "param_with_both": {
+                "version": "1.0.0",
+                "activity_id": "workflow-123",
+                "value": 10,
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="Both activity_id and value are set"):
+        model_repository._apply_changes_to_model_parameters(changes, tmp_test_directory)
+
+    mock_download_workflow.assert_not_called()
+    mock_create_entry.assert_not_called()
+
+
 @patch("simtools.model.model_repository.ascii_handler.write_data_to_file")
 @patch("simtools.model.model_repository.ascii_handler.collect_data_from_git")
-def test_download_model_parameter_from_workflow(mock_collect_data, mock_write_data, tmp_path):
+def test_download_model_parameter_from_workflow(
+    mock_collect_data, mock_write_data, tmp_test_directory
+):
     """Test downloading and writing model parameter from workflow repository."""
     telescope = "LSTN-design"
     param = "pm_photoelectron_spectrum"
@@ -848,7 +857,7 @@ def test_download_model_parameter_from_workflow(mock_collect_data, mock_write_da
         telescope=telescope,
         param=param,
         param_data=param_data,
-        simulation_models_path=tmp_path,
+        simulation_models_path=tmp_test_directory,
         setting_workflows_git_tag="v2.1.0",
     )
 
@@ -866,7 +875,7 @@ def test_download_model_parameter_from_workflow(mock_collect_data, mock_write_da
     )
     mock_write_data.assert_called_once_with(
         {"parameter_version": "3.0.0", "value": [1, 2, 3]},
-        tmp_path
+        tmp_test_directory
         / "simulation-models"
         / "model_parameters"
         / "LSTN-design"
@@ -874,6 +883,32 @@ def test_download_model_parameter_from_workflow(mock_collect_data, mock_write_da
         / "pm_photoelectron_spectrum-3.0.0.json",
         sort_keys=True,
     )
+
+
+@patch("simtools.model.model_repository.ascii_handler.write_data_to_file")
+@patch("simtools.model.model_repository.ascii_handler.collect_data_from_git")
+def test_download_model_parameter_from_workflow_raises_on_version_mismatch(
+    mock_collect_data, mock_write_data, tmp_test_directory
+):
+    """Test that mismatched requested/downloaded versions raise a ValueError."""
+    telescope = "LSTN-design"
+    param = "pm_photoelectron_spectrum"
+    param_data = {
+        "version": "3.0.0",
+        "activity_id": "019d85b6-1f98-715b-b92b-bfbcd06d7cd8",
+    }
+    mock_collect_data.return_value = {"parameter_version": "2.9.9", "value": [1, 2, 3]}
+
+    with pytest.raises(ValueError, match="Version mismatch"):
+        model_repository._download_model_parameter_from_workflow(
+            telescope=telescope,
+            param=param,
+            param_data=param_data,
+            simulation_models_path=tmp_test_directory,
+            setting_workflows_git_tag="v2.1.0",
+        )
+
+    mock_write_data.assert_not_called()
 
 
 @patch("simtools.model.model_repository._get_latest_model_parameter_file")

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -685,6 +685,7 @@ def test_generate_new_production_empty_version_history(
         "model_version": "6.5.0",
         "model_version_history": [],
         "setting_workflows_git_tag": "v0.3.0",
+        "setting_workflows_git_repository": "https://example.org/workflows.git",
         "changes": {},
     }
 
@@ -693,7 +694,9 @@ def test_generate_new_production_empty_version_history(
     mock_apply_table_changes.assert_called_once_with(
         {}, "6.5.0", "6.5.0", "full_update", str(tmp_path)
     )
-    mock_apply_model_changes.assert_called_once_with({}, str(tmp_path), "v0.3.0")
+    mock_apply_model_changes.assert_called_once_with(
+        {}, str(tmp_path), "v0.3.0", "https://example.org/workflows.git"
+    )
 
 
 def test_apply_changes_to_production_table_patch_update():
@@ -810,6 +813,8 @@ def test_apply_changes_to_model_parameters_with_activity_id(
         },
         model_parameters_dir,
         "release-v1",
+        "https://gitlab.cta-observatory.org/cta-science/simulations/"
+        "simulation-model/simulation-model-parameter-setting.git",
     )
     mock_create_entry.assert_called_once_with(
         "LSTN-design", "value_only_param", {"version": "2.0.0", "value": 42}, model_parameters_dir
@@ -859,6 +864,7 @@ def test_download_model_parameter_from_workflow(
         param_data=param_data,
         simulation_models_path=tmp_test_directory,
         setting_workflows_git_tag="v2.1.0",
+        setting_workflows_git_repository="https://example.org/workflows.git",
     )
 
     mock_collect_data.assert_called_once_with(
@@ -867,10 +873,7 @@ def test_download_model_parameter_from_workflow(
             "019d85b6-1f98-715b-b92b-bfbcd06d7cd8/pm_photoelectron_spectrum/"
             "pm_photoelectron_spectrum-3.0.0.json"
         ),
-        git_repository=(
-            "https://gitlab.cta-observatory.org/cta-science/simulations/"
-            "simulation-model/simulation-model-parameter-setting.git"
-        ),
+        git_repository="https://example.org/workflows.git",
         git_branch="v2.1.0",
     )
     mock_write_data.assert_called_once_with(

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -684,6 +684,7 @@ def test_generate_new_production_empty_version_history(
     mock_collect_data.return_value = {
         "model_version": "6.5.0",
         "model_version_history": [],
+        "setting_workflows_git_tag": "v0.3.0",
         "changes": {},
     }
 
@@ -692,7 +693,7 @@ def test_generate_new_production_empty_version_history(
     mock_apply_table_changes.assert_called_once_with(
         {}, "6.5.0", "6.5.0", "full_update", str(tmp_path)
     )
-    mock_apply_model_changes.assert_called_once()
+    mock_apply_model_changes.assert_called_once_with({}, str(tmp_path), "v0.3.0")
 
 
 def test_apply_changes_to_production_table_patch_update():
@@ -775,6 +776,103 @@ def test_apply_changes_to_model_parameters_simple(mock_create_entry, tmp_path):
         "discriminator_threshold",
         {"version": "4.0.0", "value": 31.9},
         model_parameters_dir,
+    )
+
+
+@patch("simtools.model.model_repository._download_model_parameter_from_workflow")
+@patch("simtools.model.model_repository._create_new_model_parameter_entry")
+def test_apply_changes_to_model_parameters_with_activity_id(
+    mock_create_entry, mock_download_workflow, tmp_path
+):
+    """Test applying changes to model parameters using activity_id workflow source."""
+    model_parameters_dir = tmp_path / "model_parameters"
+    changes = {
+        "LSTN-design": {
+            "pm_photoelectron_spectrum": {
+                "version": "3.0.0",
+                "activity_id": "019d85b6-1f98-715b-b92b-bfbcd06d7cd8",
+            },
+            "param_with_both": {
+                "version": "1.0.0",
+                "activity_id": "workflow-123",
+                "value": 10,
+            },
+            "value_only_param": {"version": "2.0.0", "value": 42},
+        }
+    }
+
+    model_repository._apply_changes_to_model_parameters(
+        changes, model_parameters_dir, setting_workflows_git_tag="release-v1"
+    )
+
+    assert mock_download_workflow.call_count == 2
+    mock_download_workflow.assert_any_call(
+        "LSTN-design",
+        "pm_photoelectron_spectrum",
+        {
+            "version": "3.0.0",
+            "activity_id": "019d85b6-1f98-715b-b92b-bfbcd06d7cd8",
+        },
+        model_parameters_dir,
+        "release-v1",
+    )
+    mock_download_workflow.assert_any_call(
+        "LSTN-design",
+        "param_with_both",
+        {
+            "version": "1.0.0",
+            "activity_id": "workflow-123",
+            "value": 10,
+        },
+        model_parameters_dir,
+        "release-v1",
+    )
+    mock_create_entry.assert_called_once_with(
+        "LSTN-design", "value_only_param", {"version": "2.0.0", "value": 42}, model_parameters_dir
+    )
+
+
+@patch("simtools.model.model_repository.ascii_handler.write_data_to_file")
+@patch("simtools.model.model_repository.ascii_handler.collect_data_from_git")
+def test_download_model_parameter_from_workflow(mock_collect_data, mock_write_data, tmp_path):
+    """Test downloading and writing model parameter from workflow repository."""
+    telescope = "LSTN-design"
+    param = "pm_photoelectron_spectrum"
+    param_data = {
+        "version": "3.0.0",
+        "activity_id": "019d85b6-1f98-715b-b92b-bfbcd06d7cd8",
+    }
+    mock_collect_data.return_value = {"parameter_version": "3.0.0", "value": [1, 2, 3]}
+
+    model_repository._download_model_parameter_from_workflow(
+        telescope=telescope,
+        param=param,
+        param_data=param_data,
+        simulation_models_path=tmp_path,
+        setting_workflows_git_tag="v2.1.0",
+    )
+
+    mock_collect_data.assert_called_once_with(
+        file_name=(
+            "output/LSTN-design/pm_photoelectron_spectrum/"
+            "019d85b6-1f98-715b-b92b-bfbcd06d7cd8/pm_photoelectron_spectrum/"
+            "pm_photoelectron_spectrum-3.0.0.json"
+        ),
+        git_repository=(
+            "https://gitlab.cta-observatory.org/cta-science/simulations/"
+            "simulation-model/simulation-model-parameter-setting.git"
+        ),
+        git_branch="v2.1.0",
+    )
+    mock_write_data.assert_called_once_with(
+        {"parameter_version": "3.0.0", "value": [1, 2, 3]},
+        tmp_path
+        / "simulation-models"
+        / "model_parameters"
+        / "LSTN-design"
+        / "pm_photoelectron_spectrum"
+        / "pm_photoelectron_spectrum-3.0.0.json",
+        sort_keys=True,
     )
 
 


### PR DESCRIPTION
Add functionality to update simulation model directly from settings workflows using the model parameter version and derivation activity ID.

Add to the info.yml for production updates the following:

```
    pm_photoelectron_spectrum:
      version: "3.0.0"
      activity_id: 019d85b6-1f98-715b-b92b-bfbcd06d7cd8
```

This will pull the corresponding json files from the [setting workflow repo](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-model-parameter-setting).

(allow also to pull from a branch with the `setting_workflows_git_tag` key/value pair.

In this context, applied the following generalization:

- add function to have a single function on how to download a file from git in ascii_handler: `def collect_data_from_git(file_name, git_repository, git_branch="main")`
- move the gitlab URLs into `constant.py` as default values (can partly be overwritten by the command line; might add this for all of them in future).
