### PR TITLE
Add `model_status` keywords to `SimulationModelsInfo` schema.

### DIFF
--- a/docs/changes/2116.feature.md
+++ b/docs/changes/2116.feature.md
@@ -1,0 +1,1 @@
+Add `model_status` keywords to `SimulationModelsInfo` schema.

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -264,7 +264,7 @@ def _get_local_schema_candidates(schema_file):
     if gen.is_url(str(schema_file)):
         schema_name = Path(str(schema_file)).name
         if schema_name:
-            candidates.extend([Path(schema_name), SCHEMA_PATH / schema_name])
+            candidates.extend([SCHEMA_PATH / schema_name, Path(schema_name)])
 
     # Keep order stable while removing duplicates.
     return list(dict.fromkeys(candidates))

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -231,13 +231,22 @@ def load_schema(schema_file=None, schema_version="latest"):
     """
     schema_file = schema_file or METADATA_JSON_SCHEMA
 
-    for path in (schema_file, SCHEMA_PATH / schema_file):
+    schema = None
+    for path in _get_local_schema_candidates(schema_file):
         try:
             schema = ascii_handler.collect_data_from_file(file_name=path)
             break
         except FileNotFoundError:
             continue
-    else:
+
+    # Fall back to remote retrieval only if local resolution fails.
+    if schema is None and gen.is_url(str(schema_file)):
+        try:
+            schema = ascii_handler.collect_data_from_file(file_name=schema_file)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Schema file not found: {schema_file}") from exc
+
+    if schema is None:
         raise FileNotFoundError(f"Schema file not found: {schema_file}")
 
     _logger.debug(f"Loading schema from {schema_file} for schema version {schema_version}")
@@ -245,6 +254,20 @@ def load_schema(schema_file=None, schema_version="latest"):
     _add_array_elements("InstrumentTypeElement", schema)
 
     return schema
+
+
+def _get_local_schema_candidates(schema_file):
+    """Build local candidate paths for a schema file reference."""
+    schema_path = Path(str(schema_file))
+    candidates = [schema_path, SCHEMA_PATH / schema_path]
+
+    if gen.is_url(str(schema_file)):
+        schema_name = Path(str(schema_file)).name
+        if schema_name:
+            candidates.extend([Path(schema_name), SCHEMA_PATH / schema_name])
+
+    # Keep order stable while removing duplicates.
+    return list(dict.fromkeys(candidates))
 
 
 def _get_schema_for_version(schema, schema_file, schema_version):
@@ -439,8 +462,12 @@ def _get_schema_file_name(schema_file=None, file_name=None, data_dict=None):
     if schema_file is not None:
         return schema_file
 
-    if data_dict and (url := data_dict.get("meta_schema_url")):
-        return url
+    if data_dict:
+        # Check for meta_schema_url (metadata) or schema_url (data with embedded schema info)
+        if url := data_dict.get("meta_schema_url"):
+            return url
+        if url := data_dict.get("schema_url"):
+            return url
 
     if file_name:
         return _extract_schema_from_file(file_name)

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -16,15 +16,11 @@ definitions:
       applications:
         "$ref": "#/definitions/applications"
       schema_version:
-        type: string
-        description: "Version of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
       schema_url:
-        type: string
-        format: uri
-        description: "URL of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_url_field'
       schema_name:
-        type: string
-        description: "Name of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_name_field'
       activity_id:
         type: string
         description: "Workflow activity UUID. If omitted, generated automatically."

--- a/src/simtools/schemas/common_definitions.schema.yml
+++ b/src/simtools/schemas/common_definitions.schema.yml
@@ -9,6 +9,19 @@ schema_name: common_definitions
 type: object
 
 $defs:
+  schema_url_field:
+    type: string
+    format: uri
+    description: URL of the schema.
+
+  schema_version_field:
+    type: string
+    description: Version of the schema.
+
+  schema_name_field:
+    type: string
+    description: Name of the schema.
+
   telescope_name_pattern:
     type: string
     description: |

--- a/src/simtools/schemas/plot_configuration.metaschema.yml
+++ b/src/simtools/schemas/plot_configuration.metaschema.yml
@@ -15,15 +15,11 @@ definitions:
       plot:
         "$ref": "#/definitions/plot"
       schema_version:
-        type: string
-        description: "Version of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
       schema_url:
-        type: string
-        format: uri
-        description: "URL of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_url_field'
       schema_name:
-        type: string
-        description: "Name of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_name_field'
     required:
       - plot
     title: "SimtoolsPlotConfiguration"

--- a/src/simtools/schemas/production_configuration_metrics.schema.yml
+++ b/src/simtools/schemas/production_configuration_metrics.schema.yml
@@ -21,15 +21,11 @@ definitions:
       energy_estimate:
         $ref: '#/definitions/ErrorMetric'
       schema_version:
-        type: string
-        description: "Version of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
       schema_url:
-        type: string
-        format: uri
-        description: "URL of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_url_field'
       schema_name:
-        type: string
-        description: "Name of the schema."
+        $ref: 'common_definitions.schema.yml#/$defs/schema_name_field'
 
   ErrorMetric:
     type: object

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -101,18 +101,18 @@ $defs:
       model_parameter_schema_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
     oneOf:
-      - required:
-          - value
+      - required: [value]
         not:
-          required:
-            - activity_id
-      - required:
-          - activity_id
+          required: [activity_id]
+      - required: [activity_id]
         not:
-          required:
-            - value
-    required:
-      - version
+          required: [value]
+      - not:
+          anyOf:
+            - required: [value]
+            - required: [activity_id]
+        required:
+          - version
     additionalProperties: false
 ...
 ---

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -3,6 +3,118 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimulationModelsInfo'
 title: Production and simulation model information schema
 description: Schema for validating 'info.yml' files used to update CTAO simulation models.
+schema_version: 0.2.0
+schema_name: simulation_models_info.metaschema
+type: object
+additionalProperties: false
+
+definitions:
+  SimulationModelsInfo:
+    properties:
+      model_version:
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      model_update:
+        type: [string, 'null']
+        description: The type of update for the model version.
+        enum:
+          - patch_update
+          - full_update
+          - null
+      model_version_history:
+        type: array
+        description: A list of previous model versions.
+        items:
+          $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      model_status:
+        type: string
+        description: Status of the production model version.
+        enum:
+          - development
+          - production
+          - superseded
+      setting_workflows_git_tag:
+        type: string
+        description: Branch or release tag used when downloading workflow outputs.
+      setting_workflows_git_repository:
+        type: string
+        description: Repository URL used when downloading workflow outputs.
+      description:
+        type: string
+        description: A detailed description of the model changes.
+      changes:
+        type: object
+        description: A map of design names to their parameter changes.
+        propertyNames:
+          anyOf:
+            - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+            - enum:
+                - "configuration_corsika"
+        additionalProperties:
+          type: object
+          additionalProperties:
+            anyOf:
+              - $ref: '#/$defs/ParameterValue'
+              - $ref: '#/$defs/DeprecatedParameter'
+    required:
+      - model_version
+      - model_update
+      - model_version_history
+      - model_status
+      - description
+      - changes
+
+$defs:
+  DeprecatedParameter:
+    type: object
+    properties:
+      deprecated:
+        type: boolean
+        const: true
+    required:
+      - deprecated
+    additionalProperties: false
+
+  ParameterValue:
+    type: object
+    properties:
+      version:
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      activity_id:
+        type: string
+      value:
+        oneOf:
+          - type: string
+          - type: number
+          - type: boolean
+          - type: array
+          - type: object
+      unit:
+        oneOf:
+          - type: string
+          - type: array
+          - type: "null"
+      model_parameter_schema_version:
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+    oneOf:
+      - required:
+          - value
+        not:
+          required:
+            - activity_id
+      - required:
+          - activity_id
+        not:
+          required:
+            - value
+    required:
+      - version
+    additionalProperties: false
+...
+---
+$schema: http://json-schema.org/draft-06/schema#
+$ref: '#/definitions/SimulationModelsInfo'
+title: Production and simulation model information schema
+description: Schema for validating 'info.yml' files used to update CTAO simulation models.
 schema_version: 0.1.0
 schema_name: simulation_models_info.metaschema
 type: object

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -6,10 +6,10 @@ description: Schema for validating 'info.yml' files used to update CTAO simulati
 schema_version: 0.2.0
 schema_name: simulation_models_info.metaschema
 type: object
-additionalProperties: false
 
 definitions:
   SimulationModelsInfo:
+    additionalProperties: false
     properties:
       model_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
@@ -59,7 +59,6 @@ definitions:
       - model_version
       - model_update
       - model_version_history
-      - model_status
       - description
       - changes
 
@@ -118,10 +117,10 @@ description: Schema for validating 'info.yml' files used to update CTAO simulati
 schema_version: 0.1.0
 schema_name: simulation_models_info.metaschema
 type: object
-additionalProperties: false
 
 definitions:
   SimulationModelsInfo:
+    additionalProperties: false
     properties:
       model_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -9,6 +9,7 @@ type: object
 
 definitions:
   SimulationModelsInfo:
+    type: object
     additionalProperties: false
     properties:
       model_version:
@@ -126,6 +127,7 @@ type: object
 
 definitions:
   SimulationModelsInfo:
+    type: object
     additionalProperties: false
     properties:
       model_version:

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -13,6 +13,12 @@ definitions:
     properties:
       model_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      schema_version:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
+      schema_url:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_url_field'
+      schema_name:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_name_field'
       model_update:
         type: [string, 'null']
         description: The type of update for the model version.
@@ -124,6 +130,12 @@ definitions:
     properties:
       model_version:
         $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
+      schema_version:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
+      schema_url:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_url_field'
+      schema_name:
+        $ref: 'common_definitions.schema.yml#/$defs/schema_name_field'
       model_update:
         type: [string, 'null']
         description: The type of update for the model version.

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -256,24 +256,6 @@ def test_validate_simulation_models_info_schema_rejects_invalid_model_status():
         )
 
 
-def test_validate_simulation_models_info_schema_requires_model_status_for_020():
-    """Test simulation models info schema 0.2.0 requires model_status."""
-    data = {
-        "model_version": "6.1.0",
-        "model_update": "patch_update",
-        "model_version_history": ["6.0.2"],
-        "description": "test",
-        "changes": {},
-    }
-
-    with pytest.raises(jsonschema.exceptions.ValidationError):
-        schema.validate_dict_using_schema(
-            data=data,
-            schema_file="simulation_models_info.schema.yml",
-            offline=True,
-        )
-
-
 def test_validate_simulation_models_info_schema_allows_missing_model_status_for_010():
     """Test simulation models info schema 0.1.0 keeps backward compatibility."""
     data = {

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -315,6 +315,56 @@ def test_load_schema(caplog, tmp_test_directory):
     assert "Schema version 0.3.0 does not match 0.2.0" in caplog.text
 
 
+def test_load_schema_prefers_local_before_remote(monkeypatch, tmp_path):
+    """Test URL-based schema loading checks local schema files before remote access."""
+    monkeypatch.setattr(schema, "SCHEMA_PATH", tmp_path)
+    schema._retrieve_yaml_schema_from_uri.cache_clear()
+
+    remote_url = "https://example.com/schemas/simulation_models_info.schema.yml"
+    local_schema_path = tmp_path / "simulation_models_info.schema.yml"
+    expected_schema = {"schema_version": "0.2.0", "definitions": {}}
+
+    calls = []
+
+    def _mock_collect_data_from_file(file_name, yaml_document=None):
+        calls.append(str(file_name))
+        if Path(str(file_name)) == local_schema_path:
+            return expected_schema
+        raise FileNotFoundError(f"Missing schema: {file_name}")
+
+    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _mock_collect_data_from_file)
+
+    result = schema.load_schema(schema_file=remote_url, schema_version="0.2.0")
+
+    assert result == expected_schema
+    assert str(local_schema_path) in calls
+    assert remote_url not in calls
+
+
+def test_load_schema_falls_back_to_remote_when_local_missing(monkeypatch, tmp_path):
+    """Test URL-based schema loading falls back to remote retrieval if local lookup fails."""
+    monkeypatch.setattr(schema, "SCHEMA_PATH", tmp_path)
+    schema._retrieve_yaml_schema_from_uri.cache_clear()
+
+    remote_url = "https://example.com/schemas/simulation_models_info.schema.yml"
+    expected_schema = {"schema_version": "0.2.0", "definitions": {}}
+
+    calls = []
+
+    def _mock_collect_data_from_file(file_name, yaml_document=None):
+        calls.append(str(file_name))
+        if str(file_name) == remote_url:
+            return expected_schema
+        raise FileNotFoundError(f"Missing schema: {file_name}")
+
+    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _mock_collect_data_from_file)
+
+    result = schema.load_schema(schema_file=remote_url, schema_version="0.2.0")
+
+    assert result == expected_schema
+    assert str(remote_url) in calls
+
+
 def test_add_array_elements():
     test_dict_1 = {"data": {"InstrumentTypeElement": {"enum": ["LSTN", "MSTN"]}}}
     test_dict_added = schema._add_array_elements("InstrumentTypeElement", test_dict_1)
@@ -618,6 +668,19 @@ def test_get_schema_file_name(tmp_test_directory):
     data_dict = {"meta_schema_url": "https://schema.example.com"}
     result = schema._get_schema_file_name(data_dict=data_dict)
     assert result == "https://schema.example.com"
+
+    # Test with schema_url in data_dict (e.g. info.yml files)
+    data_dict = {"schema_url": "https://info-schema.example.com"}
+    result = schema._get_schema_file_name(data_dict=data_dict)
+    assert result == "https://info-schema.example.com"
+
+    # Test that meta_schema_url takes precedence over schema_url
+    data_dict = {
+        "meta_schema_url": "https://meta-schema.example.com",
+        "schema_url": "https://schema.example.com",
+    }
+    result = schema._get_schema_file_name(data_dict=data_dict)
+    assert result == "https://meta-schema.example.com"
 
     # Test with file_name (lowercase cta)
     test_file = Path(tmp_test_directory) / "test_file.yml"

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -222,6 +222,7 @@ def test_validate_schema_astropy_units(caplog):
 def test_validate_simulation_models_info_schema_accepts_model_status(model_status):
     """Test simulation models info schema accepts all supported model_status values."""
     data = {
+        "schema_version": "0.2.0",
         "model_version": "6.1.0",
         "model_update": "patch_update",
         "model_version_history": ["6.0.2"],
@@ -240,6 +241,7 @@ def test_validate_simulation_models_info_schema_accepts_model_status(model_statu
 def test_validate_simulation_models_info_schema_rejects_invalid_model_status():
     """Test simulation models info schema rejects unsupported model_status values."""
     data = {
+        "schema_version": "0.2.0",
         "model_version": "6.1.0",
         "model_update": "patch_update",
         "model_version_history": ["6.0.2"],

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -218,6 +218,80 @@ def test_validate_schema_astropy_units(caplog):
         )
 
 
+@pytest.mark.parametrize("model_status", ["development", "production", "superseded"])
+def test_validate_simulation_models_info_schema_accepts_model_status(model_status):
+    """Test simulation models info schema accepts all supported model_status values."""
+    data = {
+        "model_version": "6.1.0",
+        "model_update": "patch_update",
+        "model_version_history": ["6.0.2"],
+        "model_status": model_status,
+        "description": "test",
+        "changes": {},
+    }
+
+    schema.validate_dict_using_schema(
+        data=data,
+        schema_file="simulation_models_info.schema.yml",
+        offline=True,
+    )
+
+
+def test_validate_simulation_models_info_schema_rejects_invalid_model_status():
+    """Test simulation models info schema rejects unsupported model_status values."""
+    data = {
+        "model_version": "6.1.0",
+        "model_update": "patch_update",
+        "model_version_history": ["6.0.2"],
+        "model_status": "ready-for-production",
+        "description": "test",
+        "changes": {},
+    }
+
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        schema.validate_dict_using_schema(
+            data=data,
+            schema_file="simulation_models_info.schema.yml",
+            offline=True,
+        )
+
+
+def test_validate_simulation_models_info_schema_requires_model_status_for_020():
+    """Test simulation models info schema 0.2.0 requires model_status."""
+    data = {
+        "model_version": "6.1.0",
+        "model_update": "patch_update",
+        "model_version_history": ["6.0.2"],
+        "description": "test",
+        "changes": {},
+    }
+
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        schema.validate_dict_using_schema(
+            data=data,
+            schema_file="simulation_models_info.schema.yml",
+            offline=True,
+        )
+
+
+def test_validate_simulation_models_info_schema_allows_missing_model_status_for_010():
+    """Test simulation models info schema 0.1.0 keeps backward compatibility."""
+    data = {
+        "schema_version": "0.1.0",
+        "model_version": "6.1.0",
+        "model_update": "patch_update",
+        "model_version_history": ["6.0.2"],
+        "description": "test",
+        "changes": {},
+    }
+
+    schema.validate_dict_using_schema(
+        data=data,
+        schema_file="simulation_models_info.schema.yml",
+        offline=True,
+    )
+
+
 def test_load_schema(caplog, tmp_test_directory):
     _metadata_schema = schema.load_schema()
     assert isinstance(_metadata_schema, dict)


### PR DESCRIPTION
see discussion in [simulation models repo](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/work_items/56)

Additional fix and improvements for reading schema files. Generalize the schema_version fields.

For all other changes - see the Copilot summary, which is better than I would have written...