### PR TITLE
improve legend font size in plots

### DIFF
--- a/docs/changes/2119.maintenance.md
+++ b/docs/changes/2119.maintenance.md
@@ -1,0 +1,1 @@
+Change legend font size in tabular plotting.

--- a/src/simtools/visualization/visualize.py
+++ b/src/simtools/visualization/visualize.py
@@ -300,6 +300,8 @@ def plot_1d(data, **kwargs):
           Set a plot title.
         * no_legend: bool
           Do not print a legend for the plot.
+        * legend_fontsize: str or float
+            Legend font size (e.g. "small", "medium", or a numeric point size).
         * big_plot: bool
           Increase marker and font sizes (like in a wide light curve).
         * no_markers: bool
@@ -352,6 +354,7 @@ def handle_kwargs(kwargs):
         "empty_markers": False,
         "plot_ratio": False,
         "plot_difference": False,
+        "legend_fontsize": "xx-small",
         "xscale": "linear",
         "yscale": "linear",
         "xlim": (None, None),
@@ -470,7 +473,7 @@ def plot_main_data(data_dict, kwargs, plot_args):
         plt.title(kwargs["title"], y=1.02)
 
     if "_default" not in data_dict and not kwargs["no_legend"]:
-        plt.legend()
+        plt.legend(fontsize=kwargs["legend_fontsize"])
 
 
 def plot_ratio_difference(ax1, data_dict, plot_ratio, gs, plot_args):

--- a/src/simtools/visualization/visualize.py
+++ b/src/simtools/visualization/visualize.py
@@ -114,7 +114,7 @@ def _add_unit(title, array):
 
     The unit is extracted from the unit field of the array, in case array is an astropy quantity.
     If a unit is found, it is added to title in the form [unit]. If a unit already is present in
-    title (in the same form), a warning is printed and no unit is added. The function assumes
+    title (in the same form), no unit is added. The function assumes
     array not to be empty and returns the modified title.
 
     Parameters
@@ -128,7 +128,7 @@ def _add_unit(title, array):
         Title with units.
     """
     if title and "[" in title and "]" in title:
-        _logger.warning(
+        _logger.debug(
             "Tried to add a unit from astropy.unit, "
             "but axis already has an explicit unit. Left axis title as is."
         )

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -84,6 +84,23 @@ def test_plot_table(io_handler):
     plt.close(fig)
 
 
+def test_plot_1d_legend_fontsize_setting():
+    """Test that plot_1d applies the requested legend font size."""
+    dtype = [("x", float), ("y", float)]
+    data_ref = np.array([(1.0, 1.0), (2.0, 2.0)], dtype=dtype)
+    data_cmp = np.array([(1.0, 1.2), (2.0, 2.3)], dtype=dtype)
+
+    fig = visualize.plot_1d(
+        {"ref": data_ref, "cmp": data_cmp},
+        legend_fontsize=8,
+    )
+
+    legend = fig.axes[0].get_legend()
+    assert legend is not None
+    assert all(text.get_fontsize() == 8 for text in legend.get_texts())
+    plt.close(fig)
+
+
 def test_add_unit(caplog, wavelength):
     value_with_unit = [30, 40] << u.nm
     assert visualize._add_unit("Wavelength", value_with_unit) == wavelength

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -107,7 +107,7 @@ def test_add_unit(caplog, wavelength):
     value_without_unit = [30, 40]
     assert visualize._add_unit("Wavelength", value_without_unit) == "Wavelength"
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.DEBUG):
         assert visualize._add_unit(wavelength, value_with_unit)
     assert "Tried to add a unit from astropy.unit" in caplog.text
 


### PR DESCRIPTION
Matplotlib-generated plots seem to be by design ugly. 

This is a simple fix to avoid legends which cover completely the actual plot - we lower the font size to get:

<img width="769" height="568" alt="fadc_pulse_shape_comparison" src="https://github.com/user-attachments/assets/740901fb-4960-4663-a9ee-2bdcb1f4fe25" />

In comparison, before we had:

<img width="769" height="568" alt="fadc_pulse_shape_comparison" src="https://github.com/user-attachments/assets/3dbe7f7d-87f9-40ff-a8c1-953d8b4387c2" />

Also changed a warning about units in axis title to a debug statement (not something important for the user)