### PR TITLE
Fix overwrite model params

### DIFF
--- a/docs/changes/2121.maintenance.md
+++ b/docs/changes/2121.maintenance.md
@@ -1,0 +1,1 @@
+Fix writing of dict-table style model parameter files. Improve and simplify API of ModelDataWriter.

--- a/src/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/src/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -204,7 +204,7 @@ def read_and_export_parameters(args_dict, logger, io_handler):
 
         logger.info(f"sim_telarray parameter: {config_reader.parameter_dict}")
 
-        _json_dict = writer.ModelDataWriter.dump_model_parameter(
+        _json_dict = writer.ModelDataWriter.write_model_parameter(
             parameter_name=_parameter,
             value=config_reader.parameter_dict.get(args_dict["simtel_telescope_name"]),
             instrument=args_dict["telescope"],

--- a/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
+++ b/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
@@ -151,7 +151,7 @@ def main():
             if app_context.args.get("input", "").endswith(".json")
             else layout.export_telescope_list_table(crs_name=app_context.args["export"])
         )
-        writer.ModelDataWriter.dump(
+        writer.ModelDataWriter.write_product_data(
             output_file=app_context.args.get("output_file"),
             output_file_format=app_context.args.get("output_file_format", "ascii.ecsv"),
             metadata=metadata,

--- a/src/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/src/simtools/applications/convert_model_parameter_from_simtel.py
@@ -81,7 +81,7 @@ def main():
 
     simtel_config_reader.compare_simtel_config_with_schema()
 
-    _json_dict = writer.ModelDataWriter.dump_model_parameter(
+    _json_dict = writer.ModelDataWriter.write_model_parameter(
         parameter_name=simtel_config_reader.parameter_name,
         value=simtel_config_reader.parameter_dict.get(app_context.args["simtel_telescope_name"]),
         instrument=app_context.args["telescope"],

--- a/src/simtools/applications/db_get_array_layouts_from_db.py
+++ b/src/simtools/applications/db_get_array_layouts_from_db.py
@@ -125,7 +125,7 @@ def main():
         layout.pprint()
 
         if not app_context.args.get("output_file_from_default", False):
-            writer.ModelDataWriter.dump(
+            writer.ModelDataWriter.write_product_data(
                 output_file=app_context.args["output_file"],
                 output_file_format=app_context.args.get("output_file_format"),
                 metadata=None,

--- a/src/simtools/applications/derive_pulse_shape_parameters.py
+++ b/src/simtools/applications/derive_pulse_shape_parameters.py
@@ -158,7 +158,7 @@ def main():
     instrument = app_context.args.get("telescope")
     parameter_version = app_context.args.get("parameter_version")
 
-    writer.ModelDataWriter.dump_model_parameter(
+    writer.ModelDataWriter.write_model_parameter(
         parameter_name="flasher_pulse_width",
         value=sigma_ns,
         instrument=instrument,
@@ -167,7 +167,7 @@ def main():
         output_path=output_path,
         unit="ns",
     )
-    writer.ModelDataWriter.dump_model_parameter(
+    writer.ModelDataWriter.write_model_parameter(
         parameter_name="flasher_pulse_exp_decay",
         value=tau_ns,
         instrument=instrument,

--- a/src/simtools/applications/generate_regular_arrays.py
+++ b/src/simtools/applications/generate_regular_arrays.py
@@ -116,7 +116,8 @@ def main():
             array_table,
             app_context.args["site"],
             app_context.args["model_version"],
-            Path(output_file).with_suffix(".info.yml"),
+            app_context.io_handler.get_output_directory()
+            / Path(output_file).with_suffix(".info.yml"),
         )
 
 

--- a/src/simtools/applications/generate_regular_arrays.py
+++ b/src/simtools/applications/generate_regular_arrays.py
@@ -106,17 +106,17 @@ def main():
             f"{output_path.stem}-{app_context.args['site']}-{array_name}{output_path.suffix}"
         )
 
-        data_writer = writer.ModelDataWriter(
+        writer.ModelDataWriter.write_product_data(
             output_file=output_file,
             output_file_format=app_context.args.get("output_file_format", "ascii.ecsv"),
+            product_data=array_table,
         )
-        data_writer.write(metadata=None, product_data=array_table)
 
         write_array_elements_info_yaml(
             array_table,
             app_context.args["site"],
             app_context.args["model_version"],
-            Path(data_writer.output_file).with_suffix(".info.yml"),
+            Path(output_file).with_suffix(".info.yml"),
         )
 
 

--- a/src/simtools/applications/submit_data_from_external.py
+++ b/src/simtools/applications/submit_data_from_external.py
@@ -87,7 +87,7 @@ def main():
         data_file=app_context.args["input"],
     )
 
-    writer.ModelDataWriter.dump(
+    writer.ModelDataWriter.write_product_data(
         output_file=app_context.args["output_file"],
         output_file_format=app_context.args.get("output_file_format"),
         metadata=_metadata,

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -115,7 +115,7 @@ def main():
     else:
         output_path = None
 
-    writer.ModelDataWriter.dump_model_parameter(
+    writer.ModelDataWriter.write_model_parameter(
         parameter_name=app_context.args["parameter"],
         value=value,
         instrument=app_context.args["instrument"],

--- a/src/simtools/camera/camera_efficiency.py
+++ b/src/simtools/camera/camera_efficiency.py
@@ -580,7 +580,7 @@ class CameraEfficiency:
         """Write NSB pixel rate parameter file."""
         cfg = settings.config.args
 
-        writer.ModelDataWriter.dump_model_parameter(
+        writer.ModelDataWriter.write_model_parameter(
             parameter_name="nsb_pixel_rate",
             value=self.get_nsb_pixel_rate(
                 reference_conditions=settings.config.args.get(

--- a/src/simtools/camera/single_photon_electron_spectrum.py
+++ b/src/simtools/camera/single_photon_electron_spectrum.py
@@ -96,7 +96,7 @@ class SinglePhotonElectronSpectrum:
             ["amplitude", self.prompt_column, self.prompt_plus_afterpulse_column],
         )
 
-        writer.ModelDataWriter.dump(
+        writer.ModelDataWriter.write_product_data(
             output_file=self.args_dict["output_file"],
             output_file_format=self.args_dict.get("output_file_format"),
             metadata=self.metadata,

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -48,7 +48,7 @@ class ModelDataWriter:
         self.output_file_format = self._derive_data_format(output_file_format, self.output_file)
 
     @staticmethod
-    def dump(
+    def write_product_data(
         output_file=None,
         metadata=None,
         product_data=None,
@@ -81,10 +81,10 @@ class ModelDataWriter:
                 product_data_table=product_data,
                 validate_schema_file=validate_schema_file,
             )
-        writer.write(metadata=metadata, product_data=product_data)
+        writer.write_data(metadata=metadata, product_data=product_data)
 
     @staticmethod
-    def dump_model_parameter(
+    def write_model_parameter(
         parameter_name,
         value,
         instrument,
@@ -158,7 +158,7 @@ class ModelDataWriter:
             unit=unit,
             meta_parameter=meta_parameter,
         )
-        writer.write_dict_to_model_parameter_json(output_file, _json_dict)
+        writer.write_model_parameter_dict_json(output_file, _json_dict)
         if metadata is not None:
             metadata.write(output_path / Path(output_file))
         return _json_dict
@@ -472,7 +472,7 @@ class ModelDataWriter:
 
         return validated
 
-    def write(self, product_data=None, metadata=None):
+    def write_data(self, product_data=None, metadata=None):
         """
         Write model data and metadata.
 
@@ -499,7 +499,7 @@ class ModelDataWriter:
 
         self._logger.info(f"Writing data to {self.output_file}")
         if isinstance(product_data, dict) and Path(self.output_file).suffix == ".json":
-            self.write_dict_to_model_parameter_json(self.output_file, product_data)
+            self.write_model_parameter_dict_json(self.output_file, product_data)
             return
         try:
             product_data.write(self.output_file, format=self.output_file_format, overwrite=True)
@@ -509,7 +509,7 @@ class ModelDataWriter:
         if metadata is not None:
             metadata.write(self.output_file, add_activity_name=True)
 
-    def write_dict_to_model_parameter_json(self, file_name, data_dict):
+    def write_model_parameter_dict_json(self, file_name, data_dict):
         """
         Write dictionary to model-parameter-style json file.
 
@@ -530,6 +530,23 @@ class ModelDataWriter:
             file_name, output_path_label=self.output_label
         )
         self._logger.info(f"Writing data to {output_file}")
+        ModelDataWriter.write_model_parameter_json(data_dict, output_file)
+
+    @staticmethod
+    def write_model_parameter_json(data_dict, output_file):
+        """
+        Write model parameter dictionary to JSON file.
+
+        Centralizes the JSON serialization options (sort_keys, numpy_types,
+        compact_numeric_lists) so all callers use consistent settings.
+
+        Parameters
+        ----------
+        data_dict : dict
+            Data dictionary to write.
+        output_file : str or Path
+            Path of the output JSON file.
+        """
         ascii_handler.write_data_to_file(
             data=data_dict,
             output_file=output_file,

--- a/src/simtools/layout/array_layout_utils.py
+++ b/src/simtools/layout/array_layout_utils.py
@@ -164,7 +164,7 @@ def write_array_layouts(array_layouts, args_dict):
         f"array-layouts-{args_dict['updated_parameter_version']}.json"
     )
 
-    ModelDataWriter.dump_model_parameter(
+    ModelDataWriter.write_model_parameter(
         parameter_name="array_layouts",
         value=array_layouts["value"],
         instrument=f"OBS-{site}",
@@ -646,7 +646,7 @@ def write_array_elements_from_file_to_repository(
         output_path.mkdir(parents=True, exist_ok=True)
         _logger.info(f"Writing array element positions ({coordinate_system}) to {output_path}")
 
-        ModelDataWriter.dump_model_parameter(
+        ModelDataWriter.write_model_parameter(
             parameter_name=parameter_name,
             instrument=instrument,
             value=f"{x[i]} {y[i]} {alt[i]}",

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -320,6 +320,8 @@ class ModelParameter:
         if self.db is None:
             return
 
+        self._load_simulation_software_parameter()
+
         if self.name or self.site:
             # copy parameters dict, is it may be modified later on
             self.parameters = deepcopy(
@@ -334,7 +336,6 @@ class ModelParameter:
                 value_resolver=self._resolve_legacy_table_parameter_value,
             )
 
-        self._load_simulation_software_parameter()
         for software_name, parameters in self._simulation_config_parameters.items():
             self._check_model_parameter_versions(
                 parameters,
@@ -465,9 +466,10 @@ class ModelParameter:
         except FileNotFoundError as exc:
             raise FileNotFoundError(f"Schema file for parameter {par_name} not found.") from exc
 
-    def _resolve_schema_version(self, par_name, metadata):
+    def _resolve_schema_version(self, par_name, metadata, parameter_store=None):
         """Resolve to an available schema version for a model parameter."""
-        par_dict = self.parameters.get(par_name, {})
+        parameter_store = parameter_store or self.parameters
+        par_dict = parameter_store.get(par_name, {})
         schema_version = (
             metadata.get("model_parameter_schema_version")
             if metadata and "model_parameter_schema_version" in metadata
@@ -485,23 +487,32 @@ class ModelParameter:
                 f"Schema version '{requested_version}' not available for parameter '{par_name}'"
             ) from exc
 
-    def _update_parameter_dict(self, par_name, value, parameter_version, metadata):
+    def _update_parameter_dict(
+        self,
+        par_name,
+        value,
+        parameter_version,
+        metadata,
+        parameter_store=None,
+    ):
         """
         Update parameter dictionary with value/metadata and fill schema-derived defaults.
 
         This keeps overwrite behavior robust when metadata dictionaries are incomplete
         (e.g. missing type or unit).
         """
+        parameter_store = parameter_store or self.parameters
         self._logger.debug(
-            f"Changing parameter {par_name} from {self.get_parameter_value(par_name)} to {value}"
+            f"Changing parameter {par_name} from "
+            f"{parameter_store.get(par_name, {}).get('value')} to {value}"
         )
-        par_dict = self.parameters[par_name]
+        par_dict = parameter_store[par_name]
         par_dict["value"] = value
 
         if parameter_version:
             par_dict["parameter_version"] = parameter_version
 
-        schema_version = self._resolve_schema_version(par_name, metadata)
+        schema_version = self._resolve_schema_version(par_name, metadata, parameter_store)
         par_type = schema.get_parameter_attribute_from_schema(par_name, schema_version, "type")
         schema_unit = schema.get_parameter_attribute_from_schema(par_name, schema_version, "unit")
 
@@ -517,6 +528,53 @@ class ModelParameter:
             par_dict.setdefault("type", par_type)
         par_dict.setdefault("unit", schema_unit)
         return par_dict
+
+    def _get_simulation_parameter_store(self, par_name):
+        """Return the simulation software parameter dictionary containing ``par_name``."""
+        for parameter_store in self._simulation_config_parameters.values():
+            if par_name in parameter_store:
+                return parameter_store
+        return None
+
+    def _overwrite_simulation_parameter(self, par_name, par_value):
+        """Overwrite a simulation software configuration parameter."""
+        parameter_store = self._get_simulation_parameter_store(par_name)
+        if parameter_store is None:
+            return False
+
+        if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
+            metadata = {
+                k: v
+                for k, v in par_value.items()
+                if k in ("unit", "model_parameter_schema_version")
+            }
+            value = par_value.get("value")
+            parameter_version = par_value.get("version")
+        else:
+            metadata = None
+            value = par_value
+            parameter_version = None
+
+        if value is None and parameter_version:
+            raise InvalidModelParameterError(
+                f"Parameter {par_name} overwrite requires a value for simulation configuration."
+            )
+
+        try:
+            DataValidator.validate_model_parameter(
+                self._update_parameter_dict(
+                    par_name,
+                    gen.convert_string_to_list(value) if isinstance(value, str) else value,
+                    parameter_version,
+                    metadata,
+                    parameter_store=parameter_store,
+                ),
+                par_name=par_name,
+            )
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Schema file for parameter {par_name} not found.") from exc
+
+        return True
 
     def _overwrite_model_parameter_from_db(self, par_name, parameter_version):
         """Overwrite model parameter from DB for a specific version."""
@@ -606,10 +664,14 @@ class ModelParameter:
             )
 
         for par_name, par_value in changes.items():
-            if par_name not in self.parameters:
+            if par_name not in self.parameters and not self._overwrite_simulation_parameter(
+                par_name, par_value
+            ):
                 raise ValueError(
                     f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
                 )
+            if par_name not in self.parameters:
+                continue
 
             if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
                 # Extract metadata fields that should be applied

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -648,44 +648,62 @@ class ModelParameter:
         changes: dict
             Parameters to be changed.
         """
-        if not changes:
+        key_for_changes, selected_changes = self._select_changes_for_overwrite(changes, flat_dict)
+        if not selected_changes:
             return
-        if not flat_dict:
-            key_for_changes = self._get_key_for_parameter_changes(self.site, self.name, changes)
-            changes = changes.get(key_for_changes, {})
+
+        self._log_overwrite_changes(flat_dict, key_for_changes, selected_changes)
+
+        for par_name, par_value in selected_changes.items():
+            self._overwrite_single_parameter(par_name, par_value)
+
+    def _select_changes_for_overwrite(self, changes, flat_dict):
+        """Select model-relevant changes and return (key, selected_changes)."""
         if not changes:
-            return
+            return None, {}
 
         if flat_dict:
-            self._logger.debug(f"Overwriting parameters with changes: {changes}")
-        else:
-            self._logger.debug(
-                f"Overwriting parameters for {key_for_changes} with changes: {changes}"
+            return None, changes
+
+        key_for_changes = self._get_key_for_parameter_changes(self.site, self.name, changes)
+        return key_for_changes, changes.get(key_for_changes, {})
+
+    def _log_overwrite_changes(self, flat_dict, key_for_changes, selected_changes):
+        """Log selected changes for overwrite_parameters."""
+        if flat_dict:
+            self._logger.debug(f"Overwriting parameters with changes: {selected_changes}")
+            return
+
+        self._logger.debug(
+            f"Overwriting parameters for {key_for_changes} with changes: {selected_changes}"
+        )
+
+    def _overwrite_single_parameter(self, par_name, par_value):
+        """Overwrite a single parameter in base model or simulation configuration."""
+        if par_name not in self.parameters:
+            if self._overwrite_simulation_parameter(par_name, par_value):
+                return
+            raise ValueError(
+                f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
             )
 
-        for par_name, par_value in changes.items():
-            if par_name not in self.parameters and not self._overwrite_simulation_parameter(
-                par_name, par_value
-            ):
-                raise ValueError(
-                    f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
-                )
-            if par_name not in self.parameters:
-                continue
+        if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
+            # Extract metadata fields that should be applied
+            # Note: 'type' is derived from schema, not from overwrite file
+            metadata = {
+                k: v
+                for k, v in par_value.items()
+                if k in ("unit", "model_parameter_schema_version")
+            }
+            self.overwrite_model_parameter(
+                par_name,
+                par_value.get("value"),
+                par_value.get("version"),
+                metadata or None,
+            )
+            return
 
-            if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
-                # Extract metadata fields that should be applied
-                # Note: 'type' is derived from schema, not from overwrite file
-                metadata = {
-                    k: v
-                    for k, v in par_value.items()
-                    if k in ("unit", "model_parameter_schema_version")
-                }
-                self.overwrite_model_parameter(
-                    par_name, par_value.get("value"), par_value.get("version"), metadata or None
-                )
-            else:
-                self.overwrite_model_parameter(par_name, par_value)
+        self.overwrite_model_parameter(par_name, par_value)
 
     def overwrite_model_file(self, par_name, file_path):
         """

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -446,7 +446,7 @@ class ModelParameter:
         InvalidModelParameterError
             If the parameter to be changed does not exist in this model.
         """
-        target_store = parameter_store or self.parameters
+        target_store = self.parameters if parameter_store is None else parameter_store
 
         if par_name not in target_store:
             raise InvalidModelParameterError(f"Parameter {par_name} not in the model")
@@ -463,7 +463,8 @@ class ModelParameter:
             )
 
         # In case parameter is a file, the model files will be outdated
-        if target_store.get("par_name").get("file", False):
+        par_dict = target_store.get(par_name)
+        if isinstance(par_dict, dict) and par_dict.get("file", False):
             self._is_exported_model_files_up_to_date = False
 
     def _overwrite_model_parameter_from_value(

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -413,7 +413,14 @@ class ModelParameter:
 
         legacy_model_parameter.apply_legacy_updates_to_parameters(parameters, _legacy_updates)
 
-    def overwrite_model_parameter(self, par_name, value, parameter_version=None, metadata=None):
+    def overwrite_model_parameter(
+        self,
+        par_name,
+        value,
+        parameter_version=None,
+        metadata=None,
+        parameter_store=None,
+    ):
         """
         Overwrite the parameter dictionary for a specific parameter in the model.
 
@@ -439,16 +446,24 @@ class ModelParameter:
         InvalidModelParameterError
             If the parameter to be changed does not exist in this model.
         """
-        if par_name not in self.parameters:
+        target_store = parameter_store or self.parameters
+
+        if par_name not in target_store:
             raise InvalidModelParameterError(f"Parameter {par_name} not in the model")
 
-        if value is None and parameter_version:
+        if parameter_store is None and value is None and parameter_version:
             self._overwrite_model_parameter_from_db(par_name, parameter_version)
         else:
-            self._overwrite_model_parameter_from_value(par_name, value, parameter_version, metadata)
+            self._overwrite_model_parameter_from_value(
+                par_name,
+                value,
+                parameter_version,
+                metadata,
+                parameter_store=parameter_store,
+            )
 
         # In case parameter is a file, the model files will be outdated
-        if self.get_parameter_file_flag(par_name):
+        if target_store[par_name].get("file", False):
             self._is_exported_model_files_up_to_date = False
 
     def _overwrite_model_parameter_from_value(
@@ -538,36 +553,6 @@ class ModelParameter:
             if par_name in parameter_store:
                 return parameter_store
         return None
-
-    def _overwrite_simulation_parameter(self, par_name, par_value):
-        """Overwrite a simulation software configuration parameter."""
-        parameter_store = self._get_simulation_parameter_store(par_name)
-        if parameter_store is None:
-            return False
-
-        if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
-            metadata = {
-                k: v
-                for k, v in par_value.items()
-                if k in ("unit", "model_parameter_schema_version")
-            }
-            value = par_value.get("value")
-            parameter_version = par_value.get("version")
-        else:
-            metadata = None
-            value = par_value
-            parameter_version = None
-
-        if value is None and parameter_version:
-            raise InvalidModelParameterError(
-                f"Parameter {par_name} overwrite requires a value for simulation configuration."
-            )
-
-        self._overwrite_model_parameter_from_value(
-            par_name, value, parameter_version, metadata, parameter_store
-        )
-
-        return True
 
     def _overwrite_model_parameter_from_db(self, par_name, parameter_version):
         """Overwrite model parameter from DB for a specific version."""
@@ -673,30 +658,41 @@ class ModelParameter:
 
     def _overwrite_single_parameter(self, par_name, par_value):
         """Overwrite a single parameter in base model or simulation configuration."""
-        if par_name not in self.parameters:
-            if self._overwrite_simulation_parameter(par_name, par_value):
-                return
-            raise ValueError(
-                f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
-            )
+        is_base_model_parameter = par_name in self.parameters
+        parameter_store = None
+        if not is_base_model_parameter:
+            parameter_store = self._get_simulation_parameter_store(par_name)
+            if parameter_store is None:
+                raise ValueError(
+                    f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
+                )
 
+        self._apply_parameter_overwrite(par_name, par_value, parameter_store=parameter_store)
+
+    def _parse_parameter_overwrite_input(self, par_value):
+        """Parse overwrite input into value, version, and metadata."""
         if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
-            # Extract metadata fields that should be applied
-            # Note: 'type' is derived from schema, not from overwrite file
             metadata = {
-                k: v
-                for k, v in par_value.items()
-                if k in ("unit", "model_parameter_schema_version")
+                key: value
+                for key, value in par_value.items()
+                if key in ("unit", "model_parameter_schema_version")
             }
-            self.overwrite_model_parameter(
-                par_name,
-                par_value.get("value"),
-                par_value.get("version"),
-                metadata or None,
-            )
-            return
+            return par_value.get("value"), par_value.get("version"), metadata or None
 
-        self.overwrite_model_parameter(par_name, par_value)
+        return par_value, None, None
+
+    def _apply_parameter_overwrite(
+        self,
+        par_name,
+        par_value,
+        parameter_store=None,
+    ):
+        """Apply overwrite to base model parameters or a provided parameter store."""
+        value, parameter_version, metadata = self._parse_parameter_overwrite_input(par_value)
+
+        self.overwrite_model_parameter(
+            par_name, value, parameter_version, metadata, parameter_store
+        )
 
     def overwrite_model_file(self, par_name, file_path):
         """

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -451,7 +451,9 @@ class ModelParameter:
         if self.get_parameter_file_flag(par_name):
             self._is_exported_model_files_up_to_date = False
 
-    def _overwrite_model_parameter_from_value(self, par_name, value, parameter_version, metadata):
+    def _overwrite_model_parameter_from_value(
+        self, par_name, value, parameter_version, metadata, parameter_store=None
+    ):
         """Overwrite model parameter from provided value only."""
         try:
             DataValidator.validate_model_parameter(
@@ -460,6 +462,7 @@ class ModelParameter:
                     gen.convert_string_to_list(value) if isinstance(value, str) else value,
                     parameter_version,
                     metadata,
+                    parameter_store=parameter_store,
                 ),
                 par_name=par_name,
             )
@@ -560,19 +563,9 @@ class ModelParameter:
                 f"Parameter {par_name} overwrite requires a value for simulation configuration."
             )
 
-        try:
-            DataValidator.validate_model_parameter(
-                self._update_parameter_dict(
-                    par_name,
-                    gen.convert_string_to_list(value) if isinstance(value, str) else value,
-                    parameter_version,
-                    metadata,
-                    parameter_store=parameter_store,
-                ),
-                par_name=par_name,
-            )
-        except FileNotFoundError as exc:
-            raise FileNotFoundError(f"Schema file for parameter {par_name} not found.") from exc
+        self._overwrite_model_parameter_from_value(
+            par_name, value, parameter_version, metadata, parameter_store
+        )
 
         return True
 

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -463,7 +463,7 @@ class ModelParameter:
             )
 
         # In case parameter is a file, the model files will be outdated
-        if target_store[par_name].get("file", False):
+        if target_store.get("par_name").get("file", False):
             self._is_exported_model_files_up_to_date = False
 
     def _overwrite_model_parameter_from_value(

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -564,7 +564,7 @@ def _download_model_parameter_from_workflow(
     target_dir = get_model_parameter_directory(simulation_models_path) / telescope / param
     target_dir.mkdir(parents=True, exist_ok=True)
     target_file = target_dir / f"{param}-{param_data['version']}.json"
-    ascii_handler.write_data_to_file(downloaded_data, target_file, sort_keys=True)
+    writer.ModelDataWriter.write_model_parameter_json(downloaded_data, target_file)
 
 
 def _create_new_model_parameter_entry(telescope, param, param_data, simulation_models_path):
@@ -606,7 +606,7 @@ def _create_new_model_parameter_entry(telescope, param, param_data, simulation_m
             param_data["value"] = [param_data["value"]] * len(json_data["value"])
         param_data["meta_parameter"] = json_data.get("meta_parameter", False)
 
-    writer.ModelDataWriter.dump_model_parameter(
+    writer.ModelDataWriter.write_model_parameter(
         parameter_name=param,
         value=param_data["value"],
         instrument=telescope,

--- a/src/simtools/ray_tracing/incident_angles.py
+++ b/src/simtools/ray_tracing/incident_angles.py
@@ -752,13 +752,13 @@ class IncidentAnglesCalculator:
             table["Incidence angle"] = bin_centers * u.deg
             table["Fraction"] = hist
 
-            writer = ModelDataWriter(output_file=self.output_dir / f"{param_name}.ecsv")
-            writer.write(
+            ModelDataWriter.write_product_data(
+                output_file=self.output_dir / f"{param_name}.ecsv",
                 product_data=table,
                 metadata=MetadataCollector(args_dict=self.config_data),
             )
 
-            ModelDataWriter.dump_model_parameter(
+            ModelDataWriter.write_model_parameter(
                 parameter_name=param_name,
                 value=f"{param_name}.ecsv",
                 instrument=self.config_data["telescope"],

--- a/src/simtools/ray_tracing/mirror_panel_psf.py
+++ b/src/simtools/ray_tracing/mirror_panel_psf.py
@@ -389,7 +389,7 @@ class MirrorPanelPSF:
         # Export averaged RNDA
         if telescope and parameter_version and self.rnda_opt is not None:
             try:
-                model_data_writer.ModelDataWriter.dump_model_parameter(
+                model_data_writer.ModelDataWriter.write_model_parameter(
                     parameter_name=parameter_name,
                     value=[float(f"{v:.4f}") for v in self.rnda_opt],
                     instrument=str(telescope),

--- a/src/simtools/ray_tracing/psf_parameter_optimisation.py
+++ b/src/simtools/ray_tracing/psf_parameter_optimisation.py
@@ -1095,7 +1095,7 @@ def export_psf_parameters(best_pars, telescope, parameter_version, output_dir):
         psf_pars_with_units = _add_units_to_psf_parameters(best_pars)
         parameter_output_path = output_dir.joinpath(telescope)
         for parameter_name, parameter_value in psf_pars_with_units.items():
-            writer.ModelDataWriter.dump_model_parameter(
+            writer.ModelDataWriter.write_model_parameter(
                 parameter_name=parameter_name,
                 value=parameter_value,
                 instrument=telescope,

--- a/tests/unit_tests/camera/test_camera_efficiency.py
+++ b/tests/unit_tests/camera/test_camera_efficiency.py
@@ -265,7 +265,7 @@ def test_dump_nsb_pixel_rate(camera_efficiency_lst, mocker, caplog):
         return_value=u.Quantity(np.full(10, 5.0), u.GHz),
     )
     mock_dump = mocker.patch(
-        "simtools.data_model.model_data_writer.ModelDataWriter.dump_model_parameter"
+        "simtools.data_model.model_data_writer.ModelDataWriter.write_model_parameter"
     )
     mock_config = mocker.MagicMock()
     mock_config.args = {"telescope": "LSTN-01", "parameter_version": "1.0.0"}
@@ -288,7 +288,7 @@ def test_dump_nsb_pixel_rate_reference_conditions(camera_efficiency_lst, mocker)
         return_value=u.Quantity(np.full(20, 7.0), u.GHz),
     )
     mock_dump = mocker.patch(
-        "simtools.data_model.model_data_writer.ModelDataWriter.dump_model_parameter"
+        "simtools.data_model.model_data_writer.ModelDataWriter.write_model_parameter"
     )
     mock_config = mocker.MagicMock()
     mock_config.args = {

--- a/tests/unit_tests/camera/test_single_photon_electron_spectrum.py
+++ b/tests/unit_tests/camera/test_single_photon_electron_spectrum.py
@@ -76,7 +76,7 @@ def test_derive_single_pe_spectrum(mock_derive_spectrum_norm_spe, spe_spectrum):
 
 
 @patch("simtools.camera.single_photon_electron_spectrum.io_handler.IOHandler.get_output_directory")
-@patch("simtools.camera.single_photon_electron_spectrum.writer.ModelDataWriter.dump")
+@patch("simtools.camera.single_photon_electron_spectrum.writer.ModelDataWriter.write_product_data")
 @patch("builtins.open", new_callable=MagicMock)
 def test_write_single_pe_spectrum(
     mock_open, mock_dump, mock_get_output_directory, spe_spectrum, tmp_test_directory

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -38,20 +38,20 @@ def num_gains_schema(num_gains_schema_file):
 def test_write(tmp_test_directory, args_dict_site):
     # both none (no exception expected)
     w_1 = writer.ModelDataWriter(output_path=tmp_test_directory)
-    result = w_1.write(metadata=None, product_data=None)
+    result = w_1.write_data(metadata=None, product_data=None)
     assert result is None
 
     # metadata not none; no data and metadata file
     _metadata = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     w_1.output_file = tmp_test_directory.join("test_file.ecsv")
     metadata_file = tmp_test_directory.join("test_file.meta.yml")
-    w_1.write(metadata=_metadata, product_data=None)
+    w_1.write_data(metadata=_metadata, product_data=None)
     assert not metadata_file.exists()
     assert not Path(w_1.output_file).exists()
 
     # product_data not none - expect data file to be written; no metadata file
     empty_table = Table()
-    w_1.write(metadata=None, product_data=empty_table)
+    w_1.write_data(metadata=None, product_data=empty_table)
     assert Path(w_1.output_file).exists()
     assert not metadata_file.exists()
 
@@ -59,7 +59,7 @@ def test_write(tmp_test_directory, args_dict_site):
     data = {"pixel": [25, 30, 28]}
     small_table = Table(data)
     w_1.output_file = tmp_test_directory.join(test_file_2)
-    w_1.write(metadata=_metadata, product_data=small_table)
+    w_1.write_data(metadata=_metadata, product_data=small_table)
     assert Path(w_1.output_file).exists()
     assert (
         (Path(tmp_test_directory) / test_file_2).with_suffix(".integration_test.meta.yml").exists()
@@ -72,31 +72,31 @@ def test_write(tmp_test_directory, args_dict_site):
 
     w_1.output_file_format = "not_an_astropy_format"
     with pytest.raises(IORegistryError):
-        w_1.write(metadata=None, product_data=empty_table)
+        w_1.write_data(metadata=None, product_data=empty_table)
 
     # test json format
     dict_data = {"value": 5.5}
     w_1.output_file = tmp_test_directory.join("test_file.json")
-    w_1.write(metadata=None, product_data=dict_data)
+    w_1.write_data(metadata=None, product_data=dict_data)
     assert Path(w_1.output_file).is_file()
 
 
-def test_write_dict_to_model_parameter_json(tmp_test_directory):
+def test__write_model_parameter_dict_json(tmp_test_directory):
     w1 = writer.ModelDataWriter(output_path=tmp_test_directory)
     data_dict = {"value": 5.5}
     data_file = tmp_test_directory.join("test_file.json")
-    w1.write_dict_to_model_parameter_json(file_name=data_file, data_dict=data_dict)
+    w1.write_model_parameter_dict_json(file_name=data_file, data_dict=data_dict)
     assert Path(data_file).is_file()
 
 
-def test_write_dict_to_model_parameter_json_compact_numeric_lists_switch(tmp_test_directory):
+def test__write_model_parameter_dict_json_compact_numeric_lists_switch(tmp_test_directory):
     w1 = writer.ModelDataWriter(output_path=tmp_test_directory)
     data_file = tmp_test_directory.join("test_file.json")
 
     with patch(
         "simtools.data_model.model_data_writer.ascii_handler.write_data_to_file"
     ) as mock_write:
-        w1.write_dict_to_model_parameter_json(
+        w1.write_model_parameter_dict_json(
             file_name=data_file,
             data_dict={"value": {"a": [1, 2, 3]}},
         )
@@ -105,7 +105,7 @@ def test_write_dict_to_model_parameter_json_compact_numeric_lists_switch(tmp_tes
     with patch(
         "simtools.data_model.model_data_writer.ascii_handler.write_data_to_file"
     ) as mock_write:
-        w1.write_dict_to_model_parameter_json(
+        w1.write_model_parameter_dict_json(
             file_name=data_file,
             data_dict={"value": [1, 2, 3]},
         )
@@ -117,7 +117,7 @@ def test_dump(args_dict):
     empty_table = Table()
 
     output_file = "test_file.ecsv"
-    writer.ModelDataWriter().dump(
+    writer.ModelDataWriter().write_product_data(
         output_file=output_file,
         metadata=None,
         product_data=empty_table,
@@ -131,7 +131,7 @@ def test_dump(args_dict):
     args_dict["skip_output_validation"] = False
     settings.config.load(args=args_dict)
     with pytest.raises(KeyError):
-        writer.ModelDataWriter().dump(
+        writer.ModelDataWriter().write_product_data(
             output_file=output_file,
             metadata=None,
             product_data=empty_table,
@@ -186,12 +186,12 @@ def test_derive_data_format():
     assert writer.ModelDataWriter._derive_data_format(None, output_file="file.hdf5") == "hdf5"
 
 
-def test_dump_model_parameter(tmp_test_directory):
+def test_write_model_parameter(tmp_test_directory):
     parameter_version = "1.1.0"
     instrument = "LSTN-01"
     num_gains_name = "num_gains"
     # single value, no unit
-    num_gains_dict = writer.ModelDataWriter.dump_model_parameter(
+    num_gains_dict = writer.ModelDataWriter.write_model_parameter(
         parameter_name=num_gains_name,
         value=2,
         instrument=instrument,
@@ -205,7 +205,7 @@ def test_dump_model_parameter(tmp_test_directory):
     assert num_gains_dict["unit"] is None
 
     # list of value, with unit
-    position_dict = writer.ModelDataWriter.dump_model_parameter(
+    position_dict = writer.ModelDataWriter.write_model_parameter(
         parameter_name="array_element_position_utm",
         value=[217.6596 * u.km, 3184.9951 * u.km, 218500.0 * u.cm],
         instrument=instrument,
@@ -221,7 +221,7 @@ def test_dump_model_parameter(tmp_test_directory):
     assert position_dict["value"][2] == pytest.approx(2185.0)
     assert Path(tmp_test_directory / "array_element_position_utm.meta.yml").is_file()
 
-    position_dict = writer.ModelDataWriter.dump_model_parameter(
+    position_dict = writer.ModelDataWriter.write_model_parameter(
         parameter_name="focus_offset",
         value=[6.55 * u.cm, 0.0 * u.deg, 0.0, 0.0],
         instrument="LSTN-01",
@@ -237,7 +237,7 @@ def test_dump_model_parameter(tmp_test_directory):
     with patch(
         "simtools.data_model.model_data_writer.ModelDataWriter.check_db_for_existing_parameter"
     ) as mock_db_check:
-        writer.ModelDataWriter.dump_model_parameter(
+        writer.ModelDataWriter.write_model_parameter(
             parameter_name=num_gains_name,
             value=2,
             instrument=instrument,
@@ -248,11 +248,11 @@ def test_dump_model_parameter(tmp_test_directory):
         mock_db_check.assert_called_once_with(num_gains_name, instrument, parameter_version)
 
 
-def test_dump_model_parameter_does_not_write_metadata_on_validation_failure(tmp_test_directory):
+def test_write_model_parameter_does_not_write_metadata_on_validation_failure(tmp_test_directory):
     output_file = "num_gains.json"
 
     with pytest.raises(ValueError, match=r"^Value for column '0' out of range."):
-        writer.ModelDataWriter.dump_model_parameter(
+        writer.ModelDataWriter.write_model_parameter(
             parameter_name="num_gains",
             value=25,
             instrument="LSTN-01",

--- a/tests/unit_tests/layout/test_array_layout_utils.py
+++ b/tests/unit_tests/layout/test_array_layout_utils.py
@@ -71,7 +71,7 @@ def test_write_array_layouts(
     mock_io_handler.return_value.set_paths.assert_called_once_with(output_path=test_path)
     mock_io_handler.return_value.get_output_file.assert_called_once_with("array-layouts-v1.json")
 
-    mock_model_data_writer.dump_model_parameter.assert_called_once_with(
+    mock_model_data_writer.write_model_parameter.assert_called_once_with(
         parameter_name="array_layouts",
         value=array_layouts["value"],
         instrument="OBS-North",

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -609,6 +609,81 @@ def test_overwrite_parameters_with_simple_value(telescope_model_lst):
     assert tel_model.parameters["num_gains"]["value"] == changes["num_gains"]
 
 
+def test_overwrite_parameters_allows_sim_telarray_parameter_without_collection_name(
+    telescope_model_lst,
+):
+    """Test overwriting a sim_telarray parameter from telescope-scoped changes."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+
+    simtel_parameters = tel_model.get_simulation_software_parameters("sim_telarray")
+    simtel_only_parameters = [
+        par_name for par_name in simtel_parameters if par_name not in tel_model.parameters
+    ]
+    if not simtel_only_parameters:
+        pytest.skip("No sim_telarray-only parameter available for this telescope model")
+
+    par_name = simtel_only_parameters[0]
+    current_value = simtel_parameters[par_name]["value"]
+
+    tel_model.overwrite_parameters(
+        {
+            par_name: {
+                "value": current_value,
+            }
+        },
+        flat_dict=True,
+    )
+
+    assert simtel_parameters[par_name]["value"] == current_value
+
+
+def test_get_simulation_parameter_store_returns_matching_store(telescope_model_lst):
+    """Test simulation parameter store lookup returns the matching software dictionary."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+    tel_model._simulation_config_parameters = {
+        "sim_telarray": {"simtel_only_parameter": {"value": 1}},
+        "corsika": {"corsika_only_parameter": {"value": 2}},
+    }
+
+    assert (
+        tel_model._get_simulation_parameter_store("simtel_only_parameter")
+        == (tel_model._simulation_config_parameters["sim_telarray"])
+    )
+    assert (
+        tel_model._get_simulation_parameter_store("corsika_only_parameter")
+        == (tel_model._simulation_config_parameters["corsika"])
+    )
+    assert tel_model._get_simulation_parameter_store("not_a_parameter") is None
+
+
+def test_overwrite_simulation_parameter_raises_without_value(telescope_model_lst):
+    """Test simulation parameter overwrite fails when only version is provided."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+    tel_model._simulation_config_parameters = {
+        "sim_telarray": {
+            "simtel_only_parameter": {
+                "value": 1,
+                "parameter_version": "1.0.0",
+                "model_parameter_schema_version": "1.0.0",
+            }
+        },
+        "corsika": {},
+    }
+
+    with pytest.raises(
+        InvalidModelParameterError,
+        match=r"overwrite requires a value for simulation configuration",
+    ):
+        tel_model._overwrite_simulation_parameter("simtel_only_parameter", {"version": "2.0.0"})
+
+
+def test_overwrite_simulation_parameter_returns_false_for_missing_parameter(telescope_model_lst):
+    """Test simulation parameter overwrite returns False when parameter does not exist."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+
+    assert tel_model._overwrite_simulation_parameter("not_a_parameter", 1) is False
+
+
 def test_overwrite_parameters_raises_for_unknown_parameter(telescope_model_lst):
     """Test overwrite_parameters raises when attempting to overwrite unknown parameter."""
     tel_model = copy.deepcopy(telescope_model_lst)

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -230,8 +230,8 @@ def test_overwrite_parameters(telescope_model_lst, mocker):
     telescope_copy.overwrite_parameters(
         {"camera_pixels": {"value": 9999}, "mirror_focal_length": {"value": 55}}, flat_dict=True
     )
-    mock_change.assert_any_call("camera_pixels", 9999, None, None)
-    mock_change.assert_any_call("mirror_focal_length", 55, None, None)
+    mock_change.assert_any_call("camera_pixels", 9999, None, None, None)
+    mock_change.assert_any_call("mirror_focal_length", 55, None, None, None)
 
 
 def test_overwrite_parameter_with_schema_metadata(telescope_model_lst, tmp_test_directory, mocker):
@@ -656,32 +656,17 @@ def test_get_simulation_parameter_store_returns_matching_store(telescope_model_l
     assert tel_model._get_simulation_parameter_store("not_a_parameter") is None
 
 
-def test_overwrite_simulation_parameter_raises_without_value(telescope_model_lst):
-    """Test simulation parameter overwrite fails when only version is provided."""
+def test_overwrite_single_parameter_raises_for_missing_simulation_parameter(
+    telescope_model_lst,
+):
+    """Test unknown simulation parameter raises ValueError."""
     tel_model = copy.deepcopy(telescope_model_lst)
-    tel_model._simulation_config_parameters = {
-        "sim_telarray": {
-            "simtel_only_parameter": {
-                "value": 1,
-                "parameter_version": "1.0.0",
-                "model_parameter_schema_version": "1.0.0",
-            }
-        },
-        "corsika": {},
-    }
 
     with pytest.raises(
-        InvalidModelParameterError,
-        match=r"overwrite requires a value for simulation configuration",
+        ValueError,
+        match=r"Parameter not_a_parameter not found in model .* cannot overwrite it.",
     ):
-        tel_model._overwrite_simulation_parameter("simtel_only_parameter", {"version": "2.0.0"})
-
-
-def test_overwrite_simulation_parameter_returns_false_for_missing_parameter(telescope_model_lst):
-    """Test simulation parameter overwrite returns False when parameter does not exist."""
-    tel_model = copy.deepcopy(telescope_model_lst)
-
-    assert tel_model._overwrite_simulation_parameter("not_a_parameter", 1) is False
+        tel_model._overwrite_single_parameter("not_a_parameter", 1)
 
 
 def test_overwrite_parameters_raises_for_unknown_parameter(telescope_model_lst):

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -885,10 +885,10 @@ def test_apply_changes_to_model_parameters_with_both_value_and_activity_id_raise
     mock_create_entry.assert_not_called()
 
 
-@patch("simtools.model.model_repository.ascii_handler.write_data_to_file")
 @patch("simtools.model.model_repository.ascii_handler.collect_data_from_git")
+@patch("simtools.model.model_repository.writer.ModelDataWriter.write_model_parameter_json")
 def test_download_model_parameter_from_workflow(
-    mock_collect_data, mock_write_data, tmp_test_directory
+    mock_write_json, mock_collect_data, tmp_test_directory
 ):
     """Test downloading and writing model parameter from workflow repository."""
     telescope = "LSTN-design"
@@ -917,7 +917,7 @@ def test_download_model_parameter_from_workflow(
         git_repository="https://example.org/workflows.git",
         git_branch="v2.1.0",
     )
-    mock_write_data.assert_called_once_with(
+    mock_write_json.assert_called_once_with(
         {"parameter_version": "3.0.0", "value": [1, 2, 3]},
         tmp_test_directory
         / "simulation-models"
@@ -925,14 +925,13 @@ def test_download_model_parameter_from_workflow(
         / "LSTN-design"
         / "pm_photoelectron_spectrum"
         / "pm_photoelectron_spectrum-3.0.0.json",
-        sort_keys=True,
     )
 
 
-@patch("simtools.model.model_repository.ascii_handler.write_data_to_file")
 @patch("simtools.model.model_repository.ascii_handler.collect_data_from_git")
+@patch("simtools.model.model_repository.writer.ModelDataWriter.write_model_parameter_json")
 def test_download_model_parameter_from_workflow_raises_on_version_mismatch(
-    mock_collect_data, mock_write_data, tmp_test_directory
+    mock_write_json, mock_collect_data, tmp_test_directory
 ):
     """Test that mismatched requested/downloaded versions raise a ValueError."""
     telescope = "LSTN-design"
@@ -952,11 +951,11 @@ def test_download_model_parameter_from_workflow_raises_on_version_mismatch(
             setting_workflows_git_tag="v2.1.0",
         )
 
-    mock_write_data.assert_not_called()
+    mock_write_json.assert_not_called()
 
 
 @patch("simtools.model.model_repository._get_latest_model_parameter_file")
-@patch("simtools.model.model_repository.writer.ModelDataWriter.dump_model_parameter")
+@patch("simtools.model.model_repository.writer.ModelDataWriter.write_model_parameter")
 def test_create_new_model_parameter_entry_simple(mock_dump, mock_get_latest, tmp_test_directory):
     """Test creating a new model parameter entry."""
     telescope = "MSTx-FlashCam"
@@ -973,7 +972,7 @@ def test_create_new_model_parameter_entry_simple(mock_dump, mock_get_latest, tmp
         telescope, param, param_data, Path(tmp_test_directory)
     )
 
-    # Verify dump_model_parameter was called with correct arguments
+    # Verify write_model_parameter was called with correct arguments
     mock_dump.assert_called_once_with(
         parameter_name=param,
         value=param_data["value"],
@@ -1003,7 +1002,7 @@ def test_create_new_model_parameter_entry_telescope_dir_not_exists(tmp_test_dire
 @patch("simtools.model.model_repository._check_for_major_version_jump")
 @patch("simtools.model.model_repository.ascii_handler.collect_data_from_file")
 @patch("simtools.model.model_repository._get_latest_model_parameter_file")
-@patch("simtools.model.model_repository.writer.ModelDataWriter.dump_model_parameter")
+@patch("simtools.model.model_repository.writer.ModelDataWriter.write_model_parameter")
 def test_create_new_model_parameter_entry_with_existing_file(
     mock_dump, mock_get_latest, mock_collect_data, mock_check_version, tmp_test_directory
 ):

--- a/tests/unit_tests/ray_tracing/test_incident_angles.py
+++ b/tests/unit_tests/ray_tracing/test_incident_angles.py
@@ -805,14 +805,9 @@ def test_save_model_parameters(calculator, tmp_test_directory, monkeypatch):
 
     calculator.save_model_parameters(results_by_offset)
 
-    # ModelDataWriter should be instantiated for each written parameter
-    assert mock_writer.call_count > 0
-
-    writer_instance = mock_writer.return_value
-    assert writer_instance.write.call_count > 0
-
-    # dump_model_parameter is a class/static method and should be called as well
-    assert mock_writer.dump_model_parameter.call_count > 0
+    # write_product_data and write_model_parameter are static methods called directly
+    assert mock_writer.write_product_data.call_count > 0
+    assert mock_writer.write_model_parameter.call_count > 0
 
 
 def test_save_model_parameters_no_results_logs_warning(

--- a/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
+++ b/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
@@ -391,7 +391,7 @@ def test_write_optimization_data_warns_when_parameter_export_fails(tmp_path, moc
     inst.per_mirror_results = []
 
     dump = mocker.patch(
-        "simtools.data_model.model_data_writer.ModelDataWriter.dump_model_parameter",
+        "simtools.data_model.model_data_writer.ModelDataWriter.write_model_parameter",
         side_effect=OSError("boom"),
     )
 
@@ -425,7 +425,7 @@ def test_write_optimization_data_also_exports_model_parameter_json(tmp_path, moc
     ]
 
     dump = mocker.patch(
-        "simtools.data_model.model_data_writer.ModelDataWriter.dump_model_parameter"
+        "simtools.data_model.model_data_writer.ModelDataWriter.write_model_parameter"
     )
     inst.write_optimization_data()
 

--- a/tests/unit_tests/ray_tracing/test_psf_parameter_optimisation.py
+++ b/tests/unit_tests/ray_tracing/test_psf_parameter_optimisation.py
@@ -408,9 +408,11 @@ def test_export_psf_parameters(mock_telescope_model, temp_dir, sample_parameters
         )
 
         mock_units.assert_called_once_with(sample_parameters)
-        assert mock_writer.ModelDataWriter.dump_model_parameter.call_count == len(sample_parameters)
+        assert mock_writer.ModelDataWriter.write_model_parameter.call_count == len(
+            sample_parameters
+        )
 
-        for call_args in mock_writer.ModelDataWriter.dump_model_parameter.call_args_list:
+        for call_args in mock_writer.ModelDataWriter.write_model_parameter.call_args_list:
             _, kwargs = call_args
             assert kwargs["instrument"] == mock_telescope_model.name
             assert kwargs["parameter_version"] == "1.0.0"
@@ -423,7 +425,7 @@ def test_export_psf_parameters(mock_telescope_model, temp_dir, sample_parameters
         patch("simtools.ray_tracing.psf_parameter_optimisation.logger") as mock_logger,
     ):
         mock_units.return_value = sample_parameters
-        mock_writer.ModelDataWriter.dump_model_parameter.side_effect = ValueError("Test error")
+        mock_writer.ModelDataWriter.write_model_parameter.side_effect = ValueError("Test error")
 
         psf_opt.export_psf_parameters(
             sample_parameters, mock_telescope_model.name, "1.0.0", temp_dir


### PR DESCRIPTION
Overwrite model parameters was not working for parameters belonging to the collection ```configuration_sim_telarray``` because the overwrite was being applied before the simulation parameters were loaded so they  were not overwritten. Also the parameters being checked for the overwrite were the base model parameters only, not the simulation software parameters.
