### PR TITLE
Add possibility to plot single layout from a array layout parameter json file.

### DIFF
--- a/docs/changes/2126.feature.md
+++ b/docs/changes/2126.feature.md
@@ -1,0 +1,1 @@
+Add possibility to plot single layout from a array layout parameter json file.

--- a/docs/changes/2126.feature.md
+++ b/docs/changes/2126.feature.md
@@ -1,1 +1,1 @@
-Add possibility to plot single layout from a array layout parameter json file.
+Add the possibility to plot a single layout from an array layout parameter JSON file.

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -446,7 +446,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 default=None,
             )
         if "layout_parameter_file" in model_options:
-            _layout_group.add_argument(
+            job_group.add_argument(
                 "--array_layout_parameter_file",
                 help="Array layout model parameter file (typically in JSON format).",
                 type=str,

--- a/src/simtools/layout/array_layout_utils.py
+++ b/src/simtools/layout/array_layout_utils.py
@@ -212,7 +212,9 @@ def validate_array_layouts_with_db(production_table, array_layouts):
     return array_layouts
 
 
-def get_array_layouts_from_parameter_file(file_path, model_version, coordinate_system="ground"):
+def get_array_layouts_from_parameter_file(
+    file_path, model_version, coordinate_system="ground", array_layout_name=None
+):
     """
     Retrieve array layouts from parameter file.
 
@@ -224,6 +226,8 @@ def get_array_layouts_from_parameter_file(file_path, model_version, coordinate_s
         Model version to retrieve.
     coordinate_system : str
         Coordinate system to use for the array elements (default is "ground").
+    array_layout_name : list
+        List of array layouts to plot (if None: plot all)
 
     Returns
     -------
@@ -246,6 +250,7 @@ def get_array_layouts_from_parameter_file(file_path, model_version, coordinate_s
             coordinate_system,
         )
         for layout in value
+        if array_layout_name is None or layout.get("name") in array_layout_name
     ]
 
 
@@ -428,6 +433,15 @@ def read_layouts(args_dict):
             args_dict["coordinate_system"],
         )["array_elements"]
 
+    if args_dict["array_layout_parameter_file"] is not None:
+        _logger.info("Plotting array from parameter file(s).")
+        return get_array_layouts_from_parameter_file(
+            args_dict["array_layout_parameter_file"],
+            args_dict["model_version"],
+            args_dict["coordinate_system"],
+            args_dict["array_layout_name"],
+        ), background_layout
+
     if args_dict["array_layout_name"] is not None or args_dict["plot_all_layouts"]:
         _logger.info("Plotting array from DB using layout array name(s).")
         layouts = get_array_layouts_from_db(
@@ -439,14 +453,6 @@ def read_layouts(args_dict):
         if isinstance(layouts, list):
             return layouts, background_layout
         return [layouts], background_layout
-
-    if args_dict["array_layout_parameter_file"] is not None:
-        _logger.info("Plotting array from parameter file(s).")
-        return get_array_layouts_from_parameter_file(
-            args_dict["array_layout_parameter_file"],
-            args_dict["model_version"],
-            args_dict["coordinate_system"],
-        ), background_layout
 
     if args_dict["array_layout_file"] is not None:
         _logger.info("Plotting array from telescope table file(s).")

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -382,15 +382,25 @@ def test_layout_parsers():
         simulation_model=["layout", "layout_file", "plot_all_layouts", "layout_parameter_file"]
     )
     job_groups = _parser_9._action_groups
+    parser_actions = _parser_9._actions
     for group in job_groups:
         if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "array_layout_name" for action in group._group_actions)
             assert any(action.dest == "array_element_list" for action in group._group_actions)
             assert any(action.dest == "array_layout_file" for action in group._group_actions)
             assert any(action.dest == "plot_all_layouts" for action in group._group_actions)
-            assert any(
-                action.dest == "array_layout_parameter_file" for action in group._group_actions
-            )
+    assert any(action.dest == "array_layout_parameter_file" for action in parser_actions)
+
+    args = _parser_9.parse_args(
+        [
+            "--array_layout_name",
+            "alpha",
+            "--array_layout_parameter_file",
+            "array_layouts.json",
+        ]
+    )
+    assert args.array_layout_name == ["alpha"]
+    assert args.array_layout_parameter_file == "array_layouts.json"
 
 
 def test_simulation_configuration():

--- a/tests/unit_tests/layout/test_array_layout_utils.py
+++ b/tests/unit_tests/layout/test_array_layout_utils.py
@@ -404,6 +404,51 @@ def test_get_array_layouts_from_parameter_file_missing_value_key(mocker):
         array_layout_utils.get_array_layouts_from_parameter_file("test_file.json", "6.0.0")
 
 
+def test_get_array_layouts_from_parameter_file_filtered_by_name(mocker, mock_array_model):
+    """Test that only layouts matching array_layout_name are returned."""
+    model_version = "6.0.0"
+    fake_data = {
+        "value": [
+            {"name": "array1"},
+            {"name": "array2"},
+            {"name": "array3"},
+        ],
+        "site": "north",
+    }
+    mocker.patch(PATCH_ASCII_COLLECT_FILE, return_value=fake_data)
+    fake_table = ["tel1", "tel2"]
+    instance = mock_array_model.return_value
+    instance.export_array_elements_as_table.return_value = fake_table
+
+    results = array_layout_utils.get_array_layouts_from_parameter_file(
+        "test_file.json", model_version, array_layout_name=["array1", "array3"]
+    )
+
+    assert len(results) == 2
+    returned_names = {layout["name"] for layout in results}
+    assert returned_names == {"array1", "array3"}
+    assert "array2" not in returned_names
+
+
+def test_get_array_layouts_from_parameter_file_no_matches(mocker, mock_array_model):
+    """Test that an empty list is returned when no layouts match array_layout_name."""
+    model_version = "6.0.0"
+    fake_data = {
+        "value": [
+            {"name": "array1"},
+            {"name": "array2"},
+        ],
+        "site": "north",
+    }
+    mocker.patch(PATCH_ASCII_COLLECT_FILE, return_value=fake_data)
+
+    results = array_layout_utils.get_array_layouts_from_parameter_file(
+        "test_file.json", model_version, array_layout_name=["nonexistent"]
+    )
+
+    assert results == []
+
+
 def test_get_array_layouts_from_db_with_layout_name(mock_array_model):
     # Test when a specific layout_name is provided.
     layout_name = "layout_test"


### PR DESCRIPTION
The `array-layouts` model parameters lists all defined layout for each site.

Add a small change such that we can plot one or several array layouts listed by name from the model parameter json file. Until now, the tool `plot_array_layout.py` plotted always all layouts. 