### PR TITLE
Update configuration simulation software using overwrite model parameters

### DIFF
--- a/docs/changes/2124.feature.md
+++ b/docs/changes/2124.feature.md
@@ -1,0 +1,1 @@
+Add possibility to overwrite model parameters for CORSIKA and sim_telarray configuration from command line.

--- a/docs/changes/2127.feature.md
+++ b/docs/changes/2127.feature.md
@@ -1,0 +1,1 @@
+Add possibility to overwrite model parameters for CORSIKA and sim_telarray configuration from command line.

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -313,44 +313,66 @@ class ModelParameter:
                     "corsika": "configuration_corsika",
                 }.get(simulation_software)
 
-                if software_collection and self.overwrite_model_parameter_dict:
-                    configuration_changes = {}
-                    for key, parameter_changes in self.overwrite_model_parameter_dict.items():
-                        if not isinstance(parameter_changes, dict):
-                            continue
+                if not software_collection or not self.overwrite_model_parameter_dict:
+                    continue
 
-                        filtered_parameter_changes = {}
-                        for par_name, par_value in parameter_changes.items():
-                            try:
-                                parameter_collection = names.get_collection_name_from_parameter_name(
-                                    par_name
-                                )
-                            except KeyError:
-                                logging.warning(
-                                    f"Skipping unknown overwrite parameter '{par_name}' while "
-                                    f"loading {simulation_software} configuration parameters."
-                                )
-                                continue
-
-                            if parameter_collection == software_collection:
-                                filtered_parameter_changes[par_name] = par_value
-
-                        if filtered_parameter_changes:
-                            configuration_changes[key] = filtered_parameter_changes
-                    if configuration_changes:
-                        flat_configuration_changes = {
-                            par_name: par_value
-                            for parameter_changes in configuration_changes.values()
-                            for par_name, par_value in parameter_changes.items()
-                        }
-                        self.overwrite_parameters(
-                            flat_configuration_changes,
-                            flat_dict=True,
-                            ignore_collection=None,
-                            parameter_store=self._simulation_config_parameters[simulation_software],
-                        )
+                flat_configuration_changes = self._collect_flat_simulation_overwrites(
+                    simulation_software,
+                    software_collection,
+                )
+                if flat_configuration_changes:
+                    self.overwrite_parameters(
+                        flat_configuration_changes,
+                        flat_dict=True,
+                        ignore_collection=None,
+                        parameter_store=self._simulation_config_parameters[simulation_software],
+                    )
             except ValueError:
                 pass
+
+    def _collect_flat_simulation_overwrites(self, simulation_software, software_collection):
+        """Collect and flatten overwrite changes for a simulation software collection."""
+        configuration_changes = {}
+        for key, parameter_changes in self.overwrite_model_parameter_dict.items():
+            if not isinstance(parameter_changes, dict):
+                continue
+
+            filtered_parameter_changes = self._filter_changes_for_collection(
+                parameter_changes,
+                software_collection,
+                simulation_software,
+            )
+            if filtered_parameter_changes:
+                configuration_changes[key] = filtered_parameter_changes
+
+        return {
+            par_name: par_value
+            for parameter_changes in configuration_changes.values()
+            for par_name, par_value in parameter_changes.items()
+        }
+
+    def _filter_changes_for_collection(
+        self,
+        parameter_changes,
+        software_collection,
+        simulation_software,
+    ):
+        """Filter overwrite entries to one software collection."""
+        filtered_parameter_changes = {}
+        for par_name, par_value in parameter_changes.items():
+            try:
+                parameter_collection = names.get_collection_name_from_parameter_name(par_name)
+            except KeyError:
+                self._logger.warning(
+                    f"Skipping unknown overwrite parameter '{par_name}' while "
+                    f"loading {simulation_software} configuration parameters."
+                )
+                continue
+
+            if parameter_collection == software_collection:
+                filtered_parameter_changes[par_name] = par_value
+
+        return filtered_parameter_changes
 
     def _load_parameters_from_db(self):
         """
@@ -480,6 +502,8 @@ class ModelParameter:
             New version for the parameter.
         metadata: dict, optional
             Additional metadata (type, unit, model_parameter_schema_version).
+        parameter_store: dict, optional
+            Target parameter dictionary to update instead of ``self.parameters``.
 
         Raises
         ------
@@ -663,24 +687,18 @@ class ModelParameter:
         parameter_store=None,
     ):
         """
-        Change the value of multiple existing parameters in the model.
-
-        This function does not modify the DB, it affects only the current instance.
-
-        Allows for two types of 'changes' dictionary:
-
-        - simple (flat_dict=True): '{parameter_name: new_value, ...}'
-        - model repository style (flat_dict=False):
-          '{array_element: {parameter_name: {"value": new_value, "version": new_version}, ...}}'
+        Overwrite multiple parameters in memory (no DB update).
 
         Parameters
         ----------
-        parameters: dict
-            Current model parameters.
         changes: dict
-            Parameters to be changed.
-        configuration_sim_telarray: bool
-            If True, the changes are for sim_telarray configuration.
+            Parameter updates as either a flat mapping or model-repository mapping.
+        flat_dict: bool
+            If True, interpret ``changes`` as ``{parameter_name: value_or_dict}``.
+        ignore_collection: tuple[str] or None
+            Collection names to skip during overwrite.
+        parameter_store: dict, optional
+            Alternative parameter store to update instead of ``self.parameters``.
         """
         if not changes:
             return

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -700,67 +700,83 @@ class ModelParameter:
         parameter_store: dict, optional
             Alternative parameter store to update instead of ``self.parameters``.
         """
-        if not changes:
-            return
-        if not flat_dict:
-            key_for_changes = self._get_key_for_parameter_changes(self.site, self.name, changes)
-            changes = changes.get(key_for_changes, {})
-        if not changes:
+        key_for_changes, selected_changes = self._select_changes_for_overwrite(changes, flat_dict)
+        if not selected_changes:
             return
 
-        if flat_dict:
-            self._logger.debug(f"Overwriting parameters with changes: {changes}")
-        else:
-            self._logger.debug(
-                f"Overwriting parameters for {key_for_changes} with changes: {changes}"
-            )
+        self._log_overwrite_changes(flat_dict, key_for_changes, selected_changes)
 
         target_parameters = self.parameters if parameter_store is None else parameter_store
-        for par_name, par_value in changes.items():
-            if ignore_collection:
-                try:
-                    collection_name = names.get_collection_name_from_parameter_name(par_name)
-                except KeyError:
-                    collection_name = None
-                if collection_name in ignore_collection:
-                    continue
-            if par_name not in target_parameters:
-                raise ValueError(
-                    f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
-                )
+        for par_name, par_value in selected_changes.items():
+            if self._skip_parameter_by_collection(par_name, ignore_collection):
+                continue
 
-            if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
-                # Extract metadata fields that should be applied
-                # Note: 'type' is derived from schema, not from overwrite file
-                metadata = {
-                    k: v
-                    for k, v in par_value.items()
-                    if k in ("unit", "model_parameter_schema_version")
-                }
-                if parameter_store is None:
-                    self.overwrite_model_parameter(
-                        par_name,
-                        par_value.get("value"),
-                        par_value.get("version"),
-                        metadata or None,
-                    )
-                else:
-                    self.overwrite_model_parameter(
-                        par_name,
-                        par_value.get("value"),
-                        par_value.get("version"),
-                        metadata or None,
-                        parameter_store=target_parameters,
-                    )
-            else:
-                if parameter_store is None:
-                    self.overwrite_model_parameter(par_name, par_value)
-                else:
-                    self.overwrite_model_parameter(
-                        par_name,
-                        par_value,
-                        parameter_store=target_parameters,
-                    )
+            self._validate_parameter_exists(par_name, target_parameters)
+            self._apply_parameter_overwrite(par_name, par_value, target_parameters)
+
+    def _select_changes_for_overwrite(self, changes, flat_dict):
+        """Select changes to apply and return key with selected changes."""
+        if not changes:
+            return None, {}
+
+        if flat_dict:
+            return None, changes
+
+        key_for_changes = self._get_key_for_parameter_changes(self.site, self.name, changes)
+        return key_for_changes, changes.get(key_for_changes, {})
+
+    def _log_overwrite_changes(self, flat_dict, key_for_changes, selected_changes):
+        """Log selected parameter changes."""
+        if flat_dict:
+            self._logger.debug(f"Overwriting parameters with changes: {selected_changes}")
+            return
+
+        self._logger.debug(
+            f"Overwriting parameters for {key_for_changes} with changes: {selected_changes}"
+        )
+
+    @staticmethod
+    def _skip_parameter_by_collection(par_name, ignore_collection):
+        """Return True if parameter should be skipped due to collection filter."""
+        if not ignore_collection:
+            return False
+
+        try:
+            collection_name = names.get_collection_name_from_parameter_name(par_name)
+        except KeyError:
+            return False
+        return collection_name in ignore_collection
+
+    def _validate_parameter_exists(self, par_name, target_parameters):
+        """Raise ValueError if parameter is missing in target store."""
+        if par_name in target_parameters:
+            return
+        raise ValueError(
+            f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
+        )
+
+    def _apply_parameter_overwrite(self, par_name, par_value, target_parameters):
+        """Apply one overwrite entry to the target parameter store."""
+        if isinstance(par_value, dict) and ("value" in par_value or "version" in par_value):
+            metadata = {
+                key: value
+                for key, value in par_value.items()
+                if key in ("unit", "model_parameter_schema_version")
+            }
+            self.overwrite_model_parameter(
+                par_name,
+                par_value.get("value"),
+                par_value.get("version"),
+                metadata or None,
+                parameter_store=target_parameters,
+            )
+            return
+
+        self.overwrite_model_parameter(
+            par_name,
+            par_value,
+            parameter_store=target_parameters,
+        )
 
     def overwrite_model_file(self, par_name, file_path):
         """

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -691,11 +691,13 @@ class ModelParameter:
 
         target_parameters = self.parameters if parameter_store is None else parameter_store
         for par_name, par_value in changes.items():
-            if (
-                ignore_collection
-                and names.get_collection_name_from_parameter_name(par_name) in ignore_collection
-            ):
-                continue
+            if ignore_collection:
+                try:
+                    collection_name = names.get_collection_name_from_parameter_name(par_name)
+                except KeyError:
+                    collection_name = None
+                if collection_name in ignore_collection:
+                    continue
             if par_name not in target_parameters:
                 raise ValueError(
                     f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -329,34 +329,17 @@ class ModelParameter:
                         for key, parameter_changes in configuration_changes.items()
                         if parameter_changes
                     }
-                    if simulation_software == "corsika":
-                        print(
-                            "AAAAA",
-                            self._simulation_config_parameters[simulation_software][
-                                "corsika_cherenkov_photon_bunch_size"
-                            ],
-                        )
-
                     if configuration_changes:
                         flat_configuration_changes = {
                             par_name: par_value
                             for parameter_changes in configuration_changes.values()
                             for par_name, par_value in parameter_changes.items()
                         }
-
-                        print("BBB OVERWRITE", configuration_changes)
                         self.overwrite_parameters(
                             flat_configuration_changes,
                             flat_dict=True,
                             ignore_collection=None,
                             parameter_store=self._simulation_config_parameters[simulation_software],
-                        )
-                    if simulation_software == "corsika":
-                        print(
-                            "DDDDD",
-                            self._simulation_config_parameters[simulation_software][
-                                "corsika_cherenkov_photon_bunch_size"
-                            ],
                         )
             except ValueError:
                 pass

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -308,6 +308,56 @@ class ModelParameter:
                         simulation_software=simulation_software,
                     )
                 )
+                software_collection = {
+                    "sim_telarray": "configuration_sim_telarray",
+                    "corsika": "configuration_corsika",
+                }.get(simulation_software)
+
+                if software_collection and self.overwrite_model_parameter_dict:
+                    configuration_changes = {
+                        key: {
+                            par_name: par_value
+                            for par_name, par_value in parameter_changes.items()
+                            if names.get_collection_name_from_parameter_name(par_name)
+                            == software_collection
+                        }
+                        for key, parameter_changes in self.overwrite_model_parameter_dict.items()
+                        if isinstance(parameter_changes, dict)
+                    }
+                    configuration_changes = {
+                        key: parameter_changes
+                        for key, parameter_changes in configuration_changes.items()
+                        if parameter_changes
+                    }
+                    if simulation_software == "corsika":
+                        print(
+                            "AAAAA",
+                            self._simulation_config_parameters[simulation_software][
+                                "corsika_cherenkov_photon_bunch_size"
+                            ],
+                        )
+
+                    if configuration_changes:
+                        flat_configuration_changes = {
+                            par_name: par_value
+                            for parameter_changes in configuration_changes.values()
+                            for par_name, par_value in parameter_changes.items()
+                        }
+
+                        print("BBB OVERWRITE", configuration_changes)
+                        self.overwrite_parameters(
+                            flat_configuration_changes,
+                            flat_dict=True,
+                            ignore_collection=None,
+                            parameter_store=self._simulation_config_parameters[simulation_software],
+                        )
+                    if simulation_software == "corsika":
+                        print(
+                            "DDDDD",
+                            self._simulation_config_parameters[simulation_software][
+                                "corsika_cherenkov_photon_bunch_size"
+                            ],
+                        )
             except ValueError:
                 pass
 
@@ -412,7 +462,14 @@ class ModelParameter:
 
         legacy_model_parameter.apply_legacy_updates_to_parameters(parameters, _legacy_updates)
 
-    def overwrite_model_parameter(self, par_name, value, parameter_version=None, metadata=None):
+    def overwrite_model_parameter(
+        self,
+        par_name,
+        value,
+        parameter_version=None,
+        metadata=None,
+        parameter_store=None,
+    ):
         """
         Overwrite the parameter dictionary for a specific parameter in the model.
 
@@ -438,19 +495,38 @@ class ModelParameter:
         InvalidModelParameterError
             If the parameter to be changed does not exist in this model.
         """
-        if par_name not in self.parameters:
+        target_parameters = self.parameters if parameter_store is None else parameter_store
+
+        if par_name not in target_parameters:
             raise InvalidModelParameterError(f"Parameter {par_name} not in the model")
 
         if value is None and parameter_version:
-            self._overwrite_model_parameter_from_db(par_name, parameter_version)
+            self._overwrite_model_parameter_from_db(
+                par_name,
+                parameter_version,
+                parameter_store=target_parameters,
+            )
         else:
-            self._overwrite_model_parameter_from_value(par_name, value, parameter_version, metadata)
+            self._overwrite_model_parameter_from_value(
+                par_name,
+                value,
+                parameter_version,
+                metadata,
+                parameter_store=target_parameters,
+            )
 
         # In case parameter is a file, the model files will be outdated
-        if self.get_parameter_file_flag(par_name):
+        if target_parameters.get(par_name, {}).get("file", False):
             self._is_exported_model_files_up_to_date = False
 
-    def _overwrite_model_parameter_from_value(self, par_name, value, parameter_version, metadata):
+    def _overwrite_model_parameter_from_value(
+        self,
+        par_name,
+        value,
+        parameter_version,
+        metadata,
+        parameter_store=None,
+    ):
         """Overwrite model parameter from provided value only."""
         try:
             DataValidator.validate_model_parameter(
@@ -459,15 +535,17 @@ class ModelParameter:
                     gen.convert_string_to_list(value) if isinstance(value, str) else value,
                     parameter_version,
                     metadata,
+                    parameter_store=parameter_store,
                 ),
                 par_name=par_name,
             )
         except FileNotFoundError as exc:
             raise FileNotFoundError(f"Schema file for parameter {par_name} not found.") from exc
 
-    def _resolve_schema_version(self, par_name, metadata):
+    def _resolve_schema_version(self, par_name, metadata, parameter_store=None):
         """Resolve to an available schema version for a model parameter."""
-        par_dict = self.parameters.get(par_name, {})
+        target_parameters = self.parameters if parameter_store is None else parameter_store
+        par_dict = target_parameters.get(par_name, {})
         schema_version = (
             metadata.get("model_parameter_schema_version")
             if metadata and "model_parameter_schema_version" in metadata
@@ -485,23 +563,35 @@ class ModelParameter:
                 f"Schema version '{requested_version}' not available for parameter '{par_name}'"
             ) from exc
 
-    def _update_parameter_dict(self, par_name, value, parameter_version, metadata):
+    def _update_parameter_dict(
+        self,
+        par_name,
+        value,
+        parameter_version,
+        metadata,
+        parameter_store=None,
+    ):
         """
         Update parameter dictionary with value/metadata and fill schema-derived defaults.
 
         This keeps overwrite behavior robust when metadata dictionaries are incomplete
         (e.g. missing type or unit).
         """
+        target_parameters = self.parameters if parameter_store is None else parameter_store
         self._logger.debug(
-            f"Changing parameter {par_name} from {self.get_parameter_value(par_name)} to {value}"
+            f"Changing parameter {par_name} from {target_parameters[par_name]['value']} to {value}"
         )
-        par_dict = self.parameters[par_name]
+        par_dict = target_parameters[par_name]
         par_dict["value"] = value
 
         if parameter_version:
             par_dict["parameter_version"] = parameter_version
 
-        schema_version = self._resolve_schema_version(par_name, metadata)
+        schema_version = self._resolve_schema_version(
+            par_name,
+            metadata,
+            parameter_store=target_parameters,
+        )
         par_type = schema.get_parameter_attribute_from_schema(par_name, schema_version, "type")
         schema_unit = schema.get_parameter_attribute_from_schema(par_name, schema_version, "unit")
 
@@ -518,8 +608,9 @@ class ModelParameter:
         par_dict.setdefault("unit", schema_unit)
         return par_dict
 
-    def _overwrite_model_parameter_from_db(self, par_name, parameter_version):
+    def _overwrite_model_parameter_from_db(self, par_name, parameter_version, parameter_store=None):
         """Overwrite model parameter from DB for a specific version."""
+        target_parameters = self.parameters if parameter_store is None else parameter_store
         _para_dict = self.db.get_model_parameter(
             parameter=par_name,
             site=self.site,
@@ -527,10 +618,10 @@ class ModelParameter:
             parameter_version=parameter_version,
         )
         if _para_dict:
-            self.parameters[par_name] = _para_dict.get(par_name)
+            target_parameters[par_name] = _para_dict.get(par_name)
         self._logger.debug(
             f"Changing parameter {par_name} to version {parameter_version} with value "
-            f"{self.parameters[par_name]['value']}"
+            f"{target_parameters[par_name]['value']}"
         )
 
     def _get_key_for_parameter_changes(self, site, array_element_name, changes_data):
@@ -573,7 +664,13 @@ class ModelParameter:
 
         return None
 
-    def overwrite_parameters(self, changes, flat_dict=False):
+    def overwrite_parameters(
+        self,
+        changes,
+        flat_dict=False,
+        ignore_collection=("configuration_sim_telarray", "configuration_corsika"),
+        parameter_store=None,
+    ):
         """
         Change the value of multiple existing parameters in the model.
 
@@ -587,8 +684,12 @@ class ModelParameter:
 
         Parameters
         ----------
+        parameters: dict
+            Current model parameters.
         changes: dict
             Parameters to be changed.
+        configuration_sim_telarray: bool
+            If True, the changes are for sim_telarray configuration.
         """
         if not changes:
             return
@@ -605,8 +706,14 @@ class ModelParameter:
                 f"Overwriting parameters for {key_for_changes} with changes: {changes}"
             )
 
+        target_parameters = self.parameters if parameter_store is None else parameter_store
         for par_name, par_value in changes.items():
-            if par_name not in self.parameters:
+            if (
+                ignore_collection
+                and names.get_collection_name_from_parameter_name(par_name) in ignore_collection
+            ):
+                continue
+            if par_name not in target_parameters:
                 raise ValueError(
                     f"Parameter {par_name} not found in model {self.name}, cannot overwrite it."
                 )
@@ -619,11 +726,30 @@ class ModelParameter:
                     for k, v in par_value.items()
                     if k in ("unit", "model_parameter_schema_version")
                 }
-                self.overwrite_model_parameter(
-                    par_name, par_value.get("value"), par_value.get("version"), metadata or None
-                )
+                if parameter_store is None:
+                    self.overwrite_model_parameter(
+                        par_name,
+                        par_value.get("value"),
+                        par_value.get("version"),
+                        metadata or None,
+                    )
+                else:
+                    self.overwrite_model_parameter(
+                        par_name,
+                        par_value.get("value"),
+                        par_value.get("version"),
+                        metadata or None,
+                        parameter_store=target_parameters,
+                    )
             else:
-                self.overwrite_model_parameter(par_name, par_value)
+                if parameter_store is None:
+                    self.overwrite_model_parameter(par_name, par_value)
+                else:
+                    self.overwrite_model_parameter(
+                        par_name,
+                        par_value,
+                        parameter_store=target_parameters,
+                    )
 
     def overwrite_model_file(self, par_name, file_path):
         """

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -314,21 +314,29 @@ class ModelParameter:
                 }.get(simulation_software)
 
                 if software_collection and self.overwrite_model_parameter_dict:
-                    configuration_changes = {
-                        key: {
-                            par_name: par_value
-                            for par_name, par_value in parameter_changes.items()
-                            if names.get_collection_name_from_parameter_name(par_name)
-                            == software_collection
-                        }
-                        for key, parameter_changes in self.overwrite_model_parameter_dict.items()
-                        if isinstance(parameter_changes, dict)
-                    }
-                    configuration_changes = {
-                        key: parameter_changes
-                        for key, parameter_changes in configuration_changes.items()
-                        if parameter_changes
-                    }
+                    configuration_changes = {}
+                    for key, parameter_changes in self.overwrite_model_parameter_dict.items():
+                        if not isinstance(parameter_changes, dict):
+                            continue
+
+                        filtered_parameter_changes = {}
+                        for par_name, par_value in parameter_changes.items():
+                            try:
+                                parameter_collection = names.get_collection_name_from_parameter_name(
+                                    par_name
+                                )
+                            except KeyError:
+                                logging.warning(
+                                    f"Skipping unknown overwrite parameter '{par_name}' while "
+                                    f"loading {simulation_software} configuration parameters."
+                                )
+                                continue
+
+                            if parameter_collection == software_collection:
+                                filtered_parameter_changes[par_name] = par_value
+
+                        if filtered_parameter_changes:
+                            configuration_changes[key] = filtered_parameter_changes
                     if configuration_changes:
                         flat_configuration_changes = {
                             par_name: par_value

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -679,6 +679,133 @@ def test_check_model_parameter_with_overwrite(model_version):
     )
 
 
+def test_check_simulation_software_parameter_with_overwrite(model_version):
+    """Test sim_telarray configuration parameter overwrite during initialization."""
+
+    site = "North"
+    telescope_name = "LSTN-01"
+    changes = {
+        telescope_name: {
+            "correct_nsb_spectrum_to_telescope_altitude": {"value": "nsb_spectrum_overwritten.dat"}
+        }
+    }
+
+    tel_model = TelescopeModel(
+        site=site,
+        telescope_name=telescope_name,
+        model_version=model_version,
+        label="test-telescope-model",
+        overwrite_model_parameter_dict=changes,
+    )
+
+    assert (
+        tel_model.get_simulation_software_parameters("sim_telarray")[
+            "correct_nsb_spectrum_to_telescope_altitude"
+        ]["value"]
+        == "nsb_spectrum_overwritten.dat"
+    )
+
+
+def test_check_corsika_simulation_software_parameter_with_overwrite(model_version, mock_db_handler):
+    """Test corsika configuration parameter overwrite during initialization."""
+
+    site = "North"
+    telescope_name = "LSTN-01"
+    corsika_parameter = "corsika_particle_kinetic_energy_cutoff"
+    mock_db_handler.get_simulation_configuration_parameters.side_effect = lambda **kwargs: (
+        {corsika_parameter: {"value": 1.0, "type": "float64", "file": False}}
+        if kwargs.get("simulation_software") == "corsika"
+        else {
+            "correct_nsb_spectrum_to_telescope_altitude": {
+                "value": "nsb.dat",
+                "type": "str",
+                "file": True,
+            }
+        }
+    )
+
+    changes = {
+        telescope_name: {
+            corsika_parameter: {
+                "value": 2.5,
+            }
+        }
+    }
+
+    tel_model = TelescopeModel(
+        site=site,
+        telescope_name=telescope_name,
+        model_version=model_version,
+        label="test-telescope-model",
+        overwrite_model_parameter_dict=changes,
+    )
+
+    assert tel_model.get_simulation_software_parameters("corsika")[corsika_parameter][
+        "value"
+    ] == pytest.approx(2.5)
+
+
+def test_load_simulation_software_parameter_uses_parameter_store(telescope_model_lst, mocker):
+    """Test software overwrite path uses parameter_store argument."""
+
+    telescope_copy = copy.deepcopy(telescope_model_lst)
+    telescope_copy.overwrite_model_parameter_dict = {
+        telescope_copy.name: {
+            "correct_nsb_spectrum_to_telescope_altitude": {"value": "nsb_overwrite.dat"}
+        }
+    }
+    overwrite_spy = mocker.spy(TelescopeModel, "overwrite_parameters")
+
+    telescope_copy._load_simulation_software_parameter()
+
+    assert any(
+        call.kwargs.get("parameter_store")
+        is telescope_copy.get_simulation_software_parameters("sim_telarray")
+        for call in overwrite_spy.call_args_list
+        if call.kwargs.get("ignore_collection") is None
+    )
+
+
+def test_check_corsika_overwrite_with_configuration_key(model_version, mock_db_handler):
+    """Test corsika overwrite works when top-level key is configuration_corsika."""
+
+    site = "North"
+    telescope_name = "LSTN-01"
+    corsika_parameter = "corsika_cherenkov_photon_bunch_size"
+    mock_db_handler.get_simulation_configuration_parameters.side_effect = lambda **kwargs: (
+        {corsika_parameter: {"value": 5.0, "type": "float64", "file": False}}
+        if kwargs.get("simulation_software") == "corsika"
+        else {
+            "correct_nsb_spectrum_to_telescope_altitude": {
+                "value": "nsb.dat",
+                "type": "str",
+                "file": True,
+            }
+        }
+    )
+
+    changes = {
+        "configuration_corsika": {
+            corsika_parameter: {
+                "version": "2.0.0",
+                "value": 50.0,
+            }
+        }
+    }
+
+    tel_model = TelescopeModel(
+        site=site,
+        telescope_name=telescope_name,
+        model_version=model_version,
+        label="test-telescope-model",
+        overwrite_model_parameter_dict=changes,
+    )
+
+    assert tel_model.get_simulation_software_parameters("corsika")[corsika_parameter][
+        "value"
+    ] == pytest.approx(50.0)
+
+
 def test__get_key_for_parameter_changes(telescope_model_lst):
     assert telescope_model_lst._get_key_for_parameter_changes("North", None, {}) == "OBS-North"
 

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -224,14 +224,60 @@ def test_resolve_schema_version_raises_for_invalid_version(telescope_model_lst, 
         )
 
 
-def test_overwrite_parameters(telescope_model_lst, mocker):
+def test_overwrite_parameters_flat_dict_forwards_to_parameter_store(telescope_model_lst, mocker):
+    """Test overwrite_parameters forwards flat changes to overwrite_model_parameter."""
     telescope_copy = copy.deepcopy(telescope_model_lst)
     mock_change = mocker.patch.object(TelescopeModel, "overwrite_model_parameter")
+
     telescope_copy.overwrite_parameters(
-        {"camera_pixels": {"value": 9999}, "mirror_focal_length": {"value": 55}}, flat_dict=True
+        {"camera_pixels": {"value": 9999}, "mirror_focal_length": {"value": 55}},
+        flat_dict=True,
     )
-    mock_change.assert_any_call("camera_pixels", 9999, None, None)
-    mock_change.assert_any_call("mirror_focal_length", 55, None, None)
+
+    target_parameters = telescope_copy.parameters
+    mock_change.assert_any_call(
+        "camera_pixels",
+        9999,
+        None,
+        None,
+        parameter_store=target_parameters,
+    )
+    mock_change.assert_any_call(
+        "mirror_focal_length",
+        55,
+        None,
+        None,
+        parameter_store=target_parameters,
+    )
+
+
+def test_overwrite_parameters_skips_ignored_collections(telescope_model_lst, mocker):
+    """Test overwrite_parameters ignores simulation software collections by default."""
+    telescope_copy = copy.deepcopy(telescope_model_lst)
+    mock_change = mocker.patch.object(TelescopeModel, "overwrite_model_parameter")
+
+    telescope_copy.overwrite_parameters(
+        {"correct_nsb_spectrum_to_telescope_altitude": {"value": "overwrite.dat"}},
+        flat_dict=True,
+    )
+
+    mock_change.assert_not_called()
+
+
+def test_overwrite_parameters_selects_changes_by_model_key(telescope_model_lst):
+    """Test overwrite_parameters applies only changes selected for current model key."""
+    telescope_copy = copy.deepcopy(telescope_model_lst)
+    original_num_gains = telescope_copy.parameters["num_gains"]["value"]
+    new_num_gains = 1 if original_num_gains != 1 else 2
+
+    telescope_copy.overwrite_parameters(
+        {
+            "MSTN-01": {"num_gains": {"value": 999}},
+            telescope_copy.name: {"num_gains": {"value": new_num_gains}},
+        }
+    )
+
+    assert telescope_copy.parameters["num_gains"]["value"] == new_num_gains
 
 
 def test_overwrite_parameter_with_schema_metadata(telescope_model_lst, tmp_test_directory, mocker):
@@ -628,6 +674,66 @@ def test_overwrite_parameters_with_changes(telescope_model_lst):
     assert (
         tel_model.parameters["num_gains"]["value"] == changes[tel_model.name]["num_gains"]["value"]
     )
+
+
+def test_overwrite_parameters_raises_for_unknown_parameter(telescope_model_lst):
+    """Test overwrite_parameters raises when attempting to overwrite unknown parameter."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Parameter unknown_parameter not found in model .* cannot overwrite it.",
+    ):
+        tel_model.overwrite_parameters({"unknown_parameter": 1}, flat_dict=True)
+
+
+def test_skip_parameter_by_collection_handles_unknown_parameter_name():
+    """Test collection skip helper returns False for unknown parameter names."""
+    assert (
+        ModelParameter._skip_parameter_by_collection(
+            "unknown_parameter",
+            ("configuration_sim_telarray", "configuration_corsika"),
+        )
+        is False
+    )
+
+
+def test_validate_parameter_exists_raises_for_missing_parameter(telescope_model_lst):
+    """Test helper raises ValueError for missing parameters in target store."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Parameter unknown_parameter not found in model .* cannot overwrite it.",
+    ):
+        tel_model._validate_parameter_exists("unknown_parameter", tel_model.parameters)
+
+
+def test_apply_parameter_overwrite_simple_value_uses_target_store(telescope_model_lst):
+    """Test simple-value overwrite updates target store without mutating self.parameters."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+    target_store = copy.deepcopy(tel_model.parameters)
+
+    original_main_value = tel_model.parameters["num_gains"]["value"]
+    target_store["num_gains"]["value"] = 0
+    new_value = 1 if original_main_value != 1 else 2
+
+    tel_model._apply_parameter_overwrite("num_gains", new_value, target_store)
+
+    assert target_store["num_gains"]["value"] == new_value
+    assert tel_model.parameters["num_gains"]["value"] == original_main_value
+
+
+def test_export_model_files_removes_added_parameter_files_from_export(telescope_model_lst, mocker):
+    """Test export_model_files excludes manually added parameter files from export payload."""
+    tel_model = copy.deepcopy(telescope_model_lst)
+    export_spy = mocker.patch.object(tel_model.db, "export_model_files")
+    tel_model._added_parameter_files = ["num_gains"]
+
+    tel_model.export_model_files(destination_path=Path("/tmp"), update_if_necessary=False)
+
+    exported_parameters = export_spy.call_args.kwargs["parameters"]
+    assert "num_gains" not in exported_parameters
 
 
 def test_check_model_parameter_with_overwrite(model_version):

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -604,76 +604,54 @@ def test_overwrite_model_parameter_updates_exported_files_flag(telescope_model_l
         assert tel_model._is_exported_model_files_up_to_date is False
 
 
-def test_overwrite_parameters_no_changes(telescope_model_lst):
-    """Test overwrite_parameters_from_file when no changes for this model."""
+@pytest.mark.parametrize(
+    ("changes", "expected_version"),
+    [
+        ({"num_gains": 2}, None),
+        ({"num_gains": {"value": 2, "version": "2.0.0"}}, "2.0.0"),
+    ],
+)
+def test_overwrite_parameters_flat_dict_updates_value_and_optional_version(
+    telescope_model_lst,
+    changes,
+    expected_version,
+):
+    """Test flat-dict overwrite for both simple and dict-with-version payloads."""
     tel_model = copy.deepcopy(telescope_model_lst)
+    tel_model.overwrite_parameters(changes, flat_dict=True)
 
-    changes = {
-        "MSTN-01": {
-            "num_gains": {
-                "version": "1.0.0",
-                "value": 123,
-            }
-        }
-    }
+    assert tel_model.parameters["num_gains"]["value"] == 2
+    if expected_version is not None:
+        assert tel_model.parameters["num_gains"]["parameter_version"] == expected_version
 
-    # Should not raise error, just not apply any changes since MSTN-01 != tel_model.name
+
+def test_overwrite_parameters_no_matching_model_key_keeps_parameters_unchanged(telescope_model_lst):
+    """Test overwrite_parameters returns without changes when no model key matches."""
+    tel_model = copy.deepcopy(telescope_model_lst)
     original_params = copy.deepcopy(tel_model.parameters)
-    tel_model.overwrite_parameters(changes)
 
-    # Parameters should be unchanged (unless tel_model.name happens to be MSTN-01)
+    tel_model.overwrite_parameters({"MSTN-01": {"num_gains": {"value": 123}}})
+
     if tel_model.name != "MSTN-01":
         assert tel_model.parameters == original_params
 
 
-def test_overwrite_parameters_with_version_dict(telescope_model_lst):
-    """Test overwrite_parameters with dict containing version key."""
+def test_select_changes_for_overwrite_variants(telescope_model_lst):
+    """Test helper branch selection for empty, flat, and keyed overwrite payloads."""
     tel_model = copy.deepcopy(telescope_model_lst)
 
-    changes = {
-        "num_gains": {
-            "value": 1 if tel_model.parameters["num_gains"]["value"] != 1 else 2,
-            "version": "2.0.0",
-        }
-    }
-
-    tel_model.overwrite_parameters(changes, flat_dict=True)
-
-    assert tel_model.parameters["num_gains"]["value"] == changes["num_gains"]["value"]
-    assert tel_model.parameters["num_gains"]["parameter_version"] == "2.0.0"
-
-
-def test_overwrite_parameters_with_simple_value(telescope_model_lst):
-    """Test overwrite_parameters with simple value (not a dict)."""
-    tel_model = copy.deepcopy(telescope_model_lst)
-
-    # Simple value (not a dict with 'value' or 'version' keys)
-    changes = {"num_gains": 1 if tel_model.parameters["num_gains"]["value"] != 1 else 2}
-
-    tel_model.overwrite_parameters(changes, flat_dict=True)
-
-    assert tel_model.parameters["num_gains"]["value"] == changes["num_gains"]
-
-
-def test_overwrite_parameters_with_changes(telescope_model_lst):
-    """Test overwrite_parameters when changes exist."""
-    tel_model = copy.deepcopy(telescope_model_lst)
-
-    changes = {
-        tel_model.name: {
-            "num_gains": {
-                "version": "1.0.0",
-                "value": 1 if tel_model.parameters["num_gains"]["value"] != 1 else 2,
-            }
-        }
-    }
-
-    tel_model.overwrite_parameters(changes)
-
-    # Parameter should be changed
-    assert (
-        tel_model.parameters["num_gains"]["value"] == changes[tel_model.name]["num_gains"]["value"]
+    assert tel_model._select_changes_for_overwrite({}, True) == (None, {})
+    assert tel_model._select_changes_for_overwrite({"num_gains": 1}, True) == (
+        None,
+        {"num_gains": 1},
     )
+
+    key, selected = tel_model._select_changes_for_overwrite(
+        {tel_model.name: {"num_gains": {"value": 2}}},
+        False,
+    )
+    assert key == tel_model.name
+    assert selected == {"num_gains": {"value": 2}}
 
 
 def test_overwrite_parameters_raises_for_unknown_parameter(telescope_model_lst):

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -745,8 +745,11 @@ def test_check_corsika_simulation_software_parameter_with_overwrite(model_versio
     ] == pytest.approx(2.5)
 
 
-def test_load_simulation_software_parameter_uses_parameter_store(telescope_model_lst, mocker):
-    """Test software overwrite path uses parameter_store argument."""
+def test_load_simulation_software_parameter_overwrites_without_main_parameter_changes(
+    telescope_model_lst,
+    mocker,
+):
+    """Test software overwrite path reuses generic overwrite with simulation parameter store."""
 
     telescope_copy = copy.deepcopy(telescope_model_lst)
     telescope_copy.overwrite_model_parameter_dict = {
@@ -755,9 +758,17 @@ def test_load_simulation_software_parameter_uses_parameter_store(telescope_model
         }
     }
     overwrite_spy = mocker.spy(TelescopeModel, "overwrite_parameters")
+    original_num_gains = telescope_copy.get_parameter_value("num_gains")
 
     telescope_copy._load_simulation_software_parameter()
 
+    assert (
+        telescope_copy.get_simulation_software_parameters("sim_telarray")[
+            "correct_nsb_spectrum_to_telescope_altitude"
+        ]["value"]
+        == "nsb_overwrite.dat"
+    )
+    assert telescope_copy.get_parameter_value("num_gains") == original_num_gains
     assert any(
         call.kwargs.get("parameter_store")
         is telescope_copy.get_simulation_software_parameters("sim_telarray")

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -702,13 +702,15 @@ def test_apply_parameter_overwrite_simple_value_uses_target_store(telescope_mode
     assert tel_model.parameters["num_gains"]["value"] == original_main_value
 
 
-def test_export_model_files_removes_added_parameter_files_from_export(telescope_model_lst, mocker):
+def test_export_model_files_removes_added_parameter_files_from_export(
+    telescope_model_lst, mocker, tmp_test_directory
+):
     """Test export_model_files excludes manually added parameter files from export payload."""
     tel_model = copy.deepcopy(telescope_model_lst)
     export_spy = mocker.patch.object(tel_model.db, "export_model_files")
     tel_model._added_parameter_files = ["num_gains"]
 
-    tel_model.export_model_files(destination_path=Path("/tmp"), update_if_necessary=False)
+    tel_model.export_model_files(destination_path=tmp_test_directory, update_if_necessary=False)
 
     exported_parameters = export_spy.call_args.kwargs["parameters"]
     assert "num_gains" not in exported_parameters

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -609,17 +609,6 @@ def test_overwrite_parameters_with_simple_value(telescope_model_lst):
     assert tel_model.parameters["num_gains"]["value"] == changes["num_gains"]
 
 
-def test_overwrite_parameters_raises_for_unknown_parameter(telescope_model_lst):
-    """Test overwrite_parameters raises when attempting to overwrite unknown parameter."""
-    tel_model = copy.deepcopy(telescope_model_lst)
-
-    with pytest.raises(
-        ValueError,
-        match=r"Parameter unknown_parameter not found in model .* cannot overwrite it.",
-    ):
-        tel_model.overwrite_parameters({"unknown_parameter": 1}, flat_dict=True)
-
-
 def test_overwrite_parameters_with_changes(telescope_model_lst):
     """Test overwrite_parameters when changes exist."""
     tel_model = copy.deepcopy(telescope_model_lst)


### PR DESCRIPTION
This is a similar PR as #2124, with the additional functionality of allowing changes to the CORSIKA configuration parameters. 

I have made a real mess here, sorry:

- base branch is main, while for #2124 it is #2117.
- tried hard to get these changes, #2124, and #2127 together and failed.

My suggestion to disentangle is to merge this branch first to main, then look again at #2124 and #2127.

I've tested the overwrite_model parameter with this file:

```
model_version: "7.0.0"
model_update: "patch_update"
model_version_history:
  - "7.0.0"
description: "Set min_photons=0"
changes:
  configuration_corsika:
    corsika_cherenkov_photon_bunch_size:
      version: "2.0.0"
      value: 50.
  LSTN-design:
    min_photons:
      version: "2.0.0"
      value: 0
```