### PR TITLE
Fix IERS download issue in integration tests CI

### DIFF
--- a/docs/changes/2129.bugfix.md
+++ b/docs/changes/2129.bugfix.md
@@ -1,0 +1,1 @@
+Disable Astropy IERS auto-download in offline/test mode to prevent network timeouts and spurious warnings causing test failures.

--- a/src/simtools/application_control.py
+++ b/src/simtools/application_control.py
@@ -7,6 +7,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+from astropy.utils import iers
+
 import simtools.utils.general as gen
 from simtools import dependencies, version
 from simtools.configuration import configurator
@@ -18,6 +20,26 @@ SECRET_ENV_VAR_NAMES = ["SIMTOOLS_DB_API_PW"]
 SECRET_KEY_PATTERNS = [
     r"(?:password|passwd|pwd|secret|token|api[_-]?key|auth)",
 ]
+
+
+def _configure_iers_from_env():
+    """
+    Configure Astropy IERS behavior based on environment variables.
+
+    This disables network access for IERS tables when running in offline mode.
+
+    Controlled via:
+        SIMTOOLS_OFFLINE_IERS=1
+    """
+    if os.getenv("SIMTOOLS_OFFLINE_IERS") != "1":
+        return
+
+    if iers is None:
+        return  # nothing to configure
+
+    iers.conf.auto_download = False
+    iers.conf.use_network = False
+    iers.conf.iers_degraded_accuracy = "warn"
 
 
 def setup_logging(logger_name=None, log_level="INFO", log_file=None):
@@ -282,6 +304,8 @@ def startup_application(
             app_context.logger.info("Starting application")
             # ... rest of application logic
     """
+    _configure_iers_from_env()
+
     args_dict, db_config = parse_function()
     config.load(
         args_dict,

--- a/src/simtools/production_configuration/generate_production_grid.py
+++ b/src/simtools/production_configuration/generate_production_grid.py
@@ -11,7 +11,6 @@ Declination coordinates. The resulting grid points are saved to a file.
 
 import json
 import logging
-import os
 from pathlib import Path
 
 import numpy as np
@@ -19,7 +18,6 @@ from astropy import units as u
 from astropy.coordinates import AltAz, EarthLocation, SkyCoord
 from astropy.table import Table
 from astropy.units import Quantity
-from astropy.utils import iers
 from scipy.interpolate import LinearNDInterpolator, griddata
 from scipy.spatial import QhullError  # pylint: disable=no-name-in-module
 
@@ -73,10 +71,6 @@ class GridGeneration:
             telescope names when matching lookup-table telescope selections.
         """
         self._logger = logging.getLogger(__name__)
-        if os.getenv("SIMTOOLS_OFFLINE_IERS", "0") == "1":
-            iers.conf.auto_download = False
-            iers.conf.auto_max_age = None
-
         self.axes = axes["axes"] if "axes" in axes else axes
         self.coordinate_system = coordinate_system
         self.observing_location = (

--- a/src/simtools/production_configuration/generate_production_grid.py
+++ b/src/simtools/production_configuration/generate_production_grid.py
@@ -11,6 +11,7 @@ Declination coordinates. The resulting grid points are saved to a file.
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import numpy as np
@@ -18,6 +19,7 @@ from astropy import units as u
 from astropy.coordinates import AltAz, EarthLocation, SkyCoord
 from astropy.table import Table
 from astropy.units import Quantity
+from astropy.utils import iers
 from scipy.interpolate import LinearNDInterpolator, griddata
 from scipy.spatial import QhullError  # pylint: disable=no-name-in-module
 
@@ -71,6 +73,9 @@ class GridGeneration:
             telescope names when matching lookup-table telescope selections.
         """
         self._logger = logging.getLogger(__name__)
+        if os.getenv("SIMTOOLS_OFFLINE_IERS", "0") == "1":
+            iers.conf.auto_download = False
+            iers.conf.auto_max_age = None
 
         self.axes = axes["axes"] if "axes" in axes else axes
         self.coordinate_system = coordinate_system

--- a/src/simtools/production_configuration/plot_production_grid.py
+++ b/src/simtools/production_configuration/plot_production_grid.py
@@ -1,6 +1,7 @@
 """Plot production-grid points on sky coordinate projections."""
 
 import logging
+import os
 from pathlib import Path
 
 import astropy.units as u
@@ -9,6 +10,7 @@ import numpy as np
 from astropy.coordinates import AltAz, EarthLocation, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
+from astropy.utils import iers
 
 logger = logging.getLogger(__name__)
 DEFAULT_OUTPUT_FILE_STEM = "production_grid_sky_projection"
@@ -51,6 +53,10 @@ class ProductionGridPlotter:
         output_path,
     ):
         """Initialize the ProductionGridPlotter."""
+        if os.getenv("SIMTOOLS_OFFLINE_IERS", "0") == "1":
+            iers.conf.auto_download = False
+            iers.conf.auto_max_age = None
+
         self.grid_points_file = Path(grid_points_file)
         self.output_path = Path(output_path)
         self.output_path.mkdir(parents=True, exist_ok=True)

--- a/src/simtools/production_configuration/plot_production_grid.py
+++ b/src/simtools/production_configuration/plot_production_grid.py
@@ -1,7 +1,6 @@
 """Plot production-grid points on sky coordinate projections."""
 
 import logging
-import os
 from pathlib import Path
 
 import astropy.units as u
@@ -10,7 +9,6 @@ import numpy as np
 from astropy.coordinates import AltAz, EarthLocation, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-from astropy.utils import iers
 
 logger = logging.getLogger(__name__)
 DEFAULT_OUTPUT_FILE_STEM = "production_grid_sky_projection"
@@ -53,10 +51,6 @@ class ProductionGridPlotter:
         output_path,
     ):
         """Initialize the ProductionGridPlotter."""
-        if os.getenv("SIMTOOLS_OFFLINE_IERS", "0") == "1":
-            iers.conf.auto_download = False
-            iers.conf.auto_max_age = None
-
         self.grid_points_file = Path(grid_points_file)
         self.output_path = Path(output_path)
         self.output_path.mkdir(parents=True, exist_ok=True)

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -3,6 +3,7 @@
 
 import copy
 import logging
+import os
 import subprocess
 from pathlib import Path
 
@@ -69,7 +70,16 @@ def test_applications_from_config(tmp_test_directory, config, request):
         pytest.skip(str(exc))
 
     logger.info(f"Running application: {cmd}")
-    result = subprocess.run(cmd, shell=True, input="y\n", capture_output=True, text=True)
+    env = os.environ.copy()
+    env["SIMTOOLS_OFFLINE_IERS"] = "1"
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        input="y\n",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     assert result.returncode == 0, msg
 

--- a/tests/unit_tests/production_configuration/test_generate_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_generate_production_grid.py
@@ -640,32 +640,28 @@ def test_missing_observing_time(grid_gen):
 
 
 def test_iers_not_modified_without_env(monkeypatch):
-    from astropy.utils import iers
+    from simtools.application_control import _configure_iers_from_env
 
     iers.conf.auto_download = True
-    iers.conf.auto_max_age = 30
 
     monkeypatch.delenv("SIMTOOLS_OFFLINE_IERS", raising=False)
 
-    from simtools.production_configuration.generate_production_grid import GridGeneration
+    _configure_iers_from_env()
 
     GridGeneration(axes={"axes": {}})
 
     assert iers.conf.auto_download is True
-    assert iers.conf.auto_max_age == 30
 
 
 def test_iers_disabled_with_env(monkeypatch):
-    from astropy.utils import iers
+    from simtools.application_control import _configure_iers_from_env
 
     iers.conf.auto_download = True
-    iers.conf.auto_max_age = 30
 
     monkeypatch.setenv("SIMTOOLS_OFFLINE_IERS", "1")
 
-    from simtools.production_configuration.generate_production_grid import GridGeneration
+    _configure_iers_from_env()
 
     GridGeneration(axes={"axes": {}})
 
     assert iers.conf.auto_download is False
-    assert iers.conf.auto_max_age is None

--- a/tests/unit_tests/production_configuration/test_generate_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_generate_production_grid.py
@@ -637,3 +637,35 @@ def test_missing_observing_time(grid_gen):
 
     with pytest.raises(ValueError, match="Observing time is not set"):
         grid_gen.convert_altaz_to_radec(45 * u.deg, 30 * u.deg)
+
+
+def test_iers_not_modified_without_env(monkeypatch):
+    from astropy.utils import iers
+
+    iers.conf.auto_download = True
+    iers.conf.auto_max_age = 30
+
+    monkeypatch.delenv("SIMTOOLS_OFFLINE_IERS", raising=False)
+
+    from simtools.production_configuration.generate_production_grid import GridGeneration
+
+    GridGeneration(axes={"axes": {}})
+
+    assert iers.conf.auto_download is True
+    assert iers.conf.auto_max_age == 30
+
+
+def test_iers_disabled_with_env(monkeypatch):
+    from astropy.utils import iers
+
+    iers.conf.auto_download = True
+    iers.conf.auto_max_age = 30
+
+    monkeypatch.setenv("SIMTOOLS_OFFLINE_IERS", "1")
+
+    from simtools.production_configuration.generate_production_grid import GridGeneration
+
+    GridGeneration(axes={"axes": {}})
+
+    assert iers.conf.auto_download is False
+    assert iers.conf.auto_max_age is None

--- a/tests/unit_tests/production_configuration/test_plot_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_plot_production_grid.py
@@ -410,8 +410,6 @@ def test_plot_inferred_radec_grid_logs_no_tracks(tmp_test_directory, caplog):
 
 
 def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
-    from astropy.utils import iers
-
     from simtools.application_control import _configure_iers_from_env
 
     iers.conf.auto_download = True
@@ -437,8 +435,6 @@ def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
 
 
 def test_iers_not_modified_without_env_plotter(monkeypatch, tmp_test_directory):
-    from astropy.utils import iers
-
     from simtools.application_control import _configure_iers_from_env
 
     iers.conf.auto_download = True

--- a/tests/unit_tests/production_configuration/test_plot_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_plot_production_grid.py
@@ -414,15 +414,13 @@ def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
 
     from simtools.application_control import _configure_iers_from_env
 
-    # Known starting state
     iers.conf.auto_download = True
     iers.conf.auto_max_age = 30
 
     monkeypatch.setenv("SIMTOOLS_OFFLINE_IERS", "1")
 
-    _configure_iers_from_env()  # ← ADD THIS
+    _configure_iers_from_env()
 
-    # Minimal valid grid file
     grid_file = _write_grid_file(
         tmp_test_directory,
         "grid.ecsv",
@@ -443,13 +441,12 @@ def test_iers_not_modified_without_env_plotter(monkeypatch, tmp_test_directory):
 
     from simtools.application_control import _configure_iers_from_env
 
-    # Known starting state
     iers.conf.auto_download = True
     iers.conf.auto_max_age = 30
 
     monkeypatch.delenv("SIMTOOLS_OFFLINE_IERS", raising=False)
 
-    _configure_iers_from_env()  # ← ADD THIS
+    _configure_iers_from_env()
 
     grid_file = _write_grid_file(
         tmp_test_directory,

--- a/tests/unit_tests/production_configuration/test_plot_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_plot_production_grid.py
@@ -412,11 +412,15 @@ def test_plot_inferred_radec_grid_logs_no_tracks(tmp_test_directory, caplog):
 def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
     from astropy.utils import iers
 
+    from simtools.application_control import _configure_iers_from_env
+
     # Known starting state
     iers.conf.auto_download = True
     iers.conf.auto_max_age = 30
 
     monkeypatch.setenv("SIMTOOLS_OFFLINE_IERS", "1")
+
+    _configure_iers_from_env()  # ← ADD THIS
 
     # Minimal valid grid file
     grid_file = _write_grid_file(
@@ -432,17 +436,20 @@ def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
     )
 
     assert iers.conf.auto_download is False
-    assert iers.conf.auto_max_age is None
 
 
 def test_iers_not_modified_without_env_plotter(monkeypatch, tmp_test_directory):
     from astropy.utils import iers
+
+    from simtools.application_control import _configure_iers_from_env
 
     # Known starting state
     iers.conf.auto_download = True
     iers.conf.auto_max_age = 30
 
     monkeypatch.delenv("SIMTOOLS_OFFLINE_IERS", raising=False)
+
+    _configure_iers_from_env()  # ← ADD THIS
 
     grid_file = _write_grid_file(
         tmp_test_directory,
@@ -457,4 +464,3 @@ def test_iers_not_modified_without_env_plotter(monkeypatch, tmp_test_directory):
     )
 
     assert iers.conf.auto_download is True
-    assert iers.conf.auto_max_age == 30

--- a/tests/unit_tests/production_configuration/test_plot_production_grid.py
+++ b/tests/unit_tests/production_configuration/test_plot_production_grid.py
@@ -407,3 +407,54 @@ def test_plot_inferred_radec_grid_logs_no_tracks(tmp_test_directory, caplog):
         assert "No inferred RA/Dec grid tracks available for plotting" in caplog.text
     finally:
         plt.close(figure)
+
+
+def test_iers_disabled_with_env_plotter(monkeypatch, tmp_test_directory):
+    from astropy.utils import iers
+
+    # Known starting state
+    iers.conf.auto_download = True
+    iers.conf.auto_max_age = 30
+
+    monkeypatch.setenv("SIMTOOLS_OFFLINE_IERS", "1")
+
+    # Minimal valid grid file
+    grid_file = _write_grid_file(
+        tmp_test_directory,
+        "grid.ecsv",
+        [{"azimuth": 0.0, "zenith_angle": 0.0}],
+    )
+
+    _create_plotter(
+        grid_file=grid_file,
+        observation_time="2025-01-01 00:00:00",
+        output_path=Path(tmp_test_directory) / "output",
+    )
+
+    assert iers.conf.auto_download is False
+    assert iers.conf.auto_max_age is None
+
+
+def test_iers_not_modified_without_env_plotter(monkeypatch, tmp_test_directory):
+    from astropy.utils import iers
+
+    # Known starting state
+    iers.conf.auto_download = True
+    iers.conf.auto_max_age = 30
+
+    monkeypatch.delenv("SIMTOOLS_OFFLINE_IERS", raising=False)
+
+    grid_file = _write_grid_file(
+        tmp_test_directory,
+        "grid.ecsv",
+        [{"azimuth": 0.0, "zenith_angle": 0.0}],
+    )
+
+    _create_plotter(
+        grid_file=grid_file,
+        observation_time="2025-01-01 00:00:00",
+        output_path=Path(tmp_test_directory) / "output",
+    )
+
+    assert iers.conf.auto_download is True
+    assert iers.conf.auto_max_age == 30


### PR DESCRIPTION
Disable Astropy IERS auto-download in offline/test mode to prevent network timeouts and spurious warnings causing test failures.