### PR TITLE
Add simtools-docs-produce-production-summary application

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -216,6 +216,10 @@ Every new application added to `src/simtools/applications/` requires:
 4. **Add an integration test config** in `tests/integration_tests/config/<app_name>_run.yml`.
 5. **Add unit tests** in `tests/unit_tests/` mirroring the `src/` structure.
 
+Every new **library module** added to `src/simtools/` (outside `applications/`) requires:
+
+6. **Add an API reference entry** to the relevant `docs/source/api-reference/*.md` file using the `automodule` directive. The CI check `Undocumented module` will fail if this is missing.
+
 ## Opening a Pull Request
 
 1. **Open a draft PR first** to get the PR number before adding the changelog fragment.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -206,6 +206,16 @@ git commit -m "Description"
 git push origin feature/my-feature
 ```
 
+## Adding a New Application
+
+Every new application added to `src/simtools/applications/` requires:
+
+1. **Register the CLI entry point** in `pyproject.toml` under `[project.scripts]`.
+2. **Add a doc page** `docs/source/user-guide/applications/simtools-<app-name>.rst` following the pattern of existing files (one `.. automodule::` directive).
+3. **Add a toctree entry** to `docs/source/user-guide/applications.md` in alphabetical order.
+4. **Add an integration test config** in `tests/integration_tests/config/<app_name>_run.yml`.
+5. **Add unit tests** in `tests/unit_tests/` mirroring the `src/` structure.
+
 ## Opening a Pull Request
 
 1. **Open a draft PR first** to get the PR number before adding the changelog fragment.

--- a/docs/changes/2139.feature.md
+++ b/docs/changes/2139.feature.md
@@ -1,0 +1,1 @@
+Add `simtools-docs-produce-production-summary` application to generate a markdown table of production version descriptions from simulation-models info files.

--- a/docs/source/api-reference/reporting.md
+++ b/docs/source/api-reference/reporting.md
@@ -19,3 +19,11 @@ The reporting modules read model parameter values and descriptions from the data
 .. automodule:: reporting.docs_auto_report_generator
    :members:
 ```
+
+
+## docs_production_summary
+
+```{eval-rst}
+.. automodule:: reporting.docs_production_summary
+   :members:
+```

--- a/docs/source/user-guide/applications.md
+++ b/docs/source/user-guide/applications.md
@@ -71,6 +71,7 @@ simtools-derive-trigger-rates <applications/simtools-derive-trigger-rates>
 simtools-docs-produce-array-element-report <applications/simtools-docs-produce-array-element-report>
 simtools-docs-produce-calibration-reports <applications/simtools-docs-produce-calibration-reports>
 simtools-docs-produce-model-parameter-reports <applications/simtools-docs-produce-model-parameter-reports>
+simtools-docs-produce-production-summary <applications/simtools-docs-produce-production-summary>
 simtools-docs-produce-simulation-configuration-report <applications/simtools-docs-produce-simulation-configuration-report>
 simtools-generate-array-config <applications/simtools-generate-array-config>
 simtools-generate-corsika-histograms <applications/simtools-generate-corsika-histograms>

--- a/docs/source/user-guide/applications/simtools-docs-produce-production-summary.rst
+++ b/docs/source/user-guide/applications/simtools-docs-produce-production-summary.rst
@@ -1,0 +1,6 @@
+
+simtools-docs-produce-production-summary
+=========================================
+
+.. automodule:: docs_produce_production_summary
+   :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ scripts.simtools-derive-trigger-rates = "simtools.applications.derive_trigger_ra
 scripts.simtools-docs-produce-array-element-report = "simtools.applications.docs_produce_array_element_report:main"
 scripts.simtools-docs-produce-calibration-reports = "simtools.applications.docs_produce_calibration_reports:main"
 scripts.simtools-docs-produce-model-parameter-reports = "simtools.applications.docs_produce_model_parameter_reports:main"
+scripts.simtools-docs-produce-production-summary = "simtools.applications.docs_produce_production_summary:main"
 scripts.simtools-docs-produce-simulation-configuration-report = "simtools.applications.docs_produce_simulation_configuration_report:main"
 scripts.simtools-generate-array-config = "simtools.applications.generate_array_config:main"
 scripts.simtools-generate-corsika-histograms = "simtools.applications.generate_corsika_histograms:main"

--- a/src/simtools/applications/docs_produce_production_summary.py
+++ b/src/simtools/applications/docs_produce_production_summary.py
@@ -1,6 +1,31 @@
 #!/usr/bin/python3
 
-r"""Produce a markdown file with production version descriptions."""
+r"""
+Produce a markdown file with production version descriptions.
+
+Reads ``info.yml`` files from the simulation-models productions directory
+and writes a markdown table of production model versions and their short
+descriptions.
+
+Command line arguments
+----------------------
+data_path (str)
+    Path to the simulation-models repository root.
+output_path (str)
+    Directory for the output file.
+output_file (str)
+    Output markdown file name.
+
+Example
+-------
+.. code-block:: console
+
+    simtools-docs-produce-production-summary \\
+        --data_path ../simulation-models \\
+        --output_path simtools-output/reports/productions \\
+        --output_file production_version_descriptions.md
+
+"""
 
 from simtools.application_control import build_application
 from simtools.reporting.docs_production_summary import write_production_summary_markdown

--- a/src/simtools/applications/docs_produce_production_summary.py
+++ b/src/simtools/applications/docs_produce_production_summary.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+r"""Produce a markdown file with production version descriptions."""
+
+from simtools.application_control import build_application
+from simtools.reporting.docs_production_summary import write_production_summary_markdown
+
+
+def main():
+    """See CLI description."""
+    app_context = build_application(
+        initialization_kwargs={"output": True, "require_command_line": True},
+    )
+
+    output_file = app_context.args.get("output_file")
+    if output_file is None:
+        raise ValueError("Missing required argument output_file.")
+
+    output_path = app_context.io_handler.get_output_file(output_file)
+    write_production_summary_markdown(app_context.args["data_path"], output_path)
+
+    app_context.logger.info(f"Production summary written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simtools/applications/docs_produce_production_summary.py
+++ b/src/simtools/applications/docs_produce_production_summary.py
@@ -41,10 +41,10 @@ def main():
     if output_file is None:
         raise ValueError("Missing required argument output_file.")
 
-    output_path = app_context.io_handler.get_output_file(output_file)
-    write_production_summary_markdown(app_context.args["data_path"], output_path)
+    output_file_path = app_context.io_handler.get_output_file(output_file)
+    write_production_summary_markdown(app_context.args["data_path"], output_file_path)
 
-    app_context.logger.info(f"Production summary written to {output_path}")
+    app_context.logger.info(f"Production summary written to {output_file_path}")
 
 
 if __name__ == "__main__":

--- a/src/simtools/reporting/docs_production_summary.py
+++ b/src/simtools/reporting/docs_production_summary.py
@@ -1,0 +1,61 @@
+"""Generate markdown summaries for production descriptions."""
+
+from pathlib import Path
+
+from simtools.io import ascii_handler
+
+
+def collect_production_descriptions(data_path):
+    """Collect production versions and descriptions from simulation-models info files.
+
+    Parameters
+    ----------
+    data_path : str or Path
+        Path to the simulation-models repository root.
+
+    Returns
+    -------
+    list[tuple]
+        List with ``(model_version, description)`` pairs sorted by version string.
+    """
+    productions_path = Path(data_path) / "simulation-models" / "productions"
+
+    info_files = sorted(
+        set(productions_path.glob("*/info.yaml")) | set(productions_path.glob("*/info.yml")),
+        key=lambda path: path.parent.name,
+    )
+
+    descriptions = []
+    for info_file in info_files:
+        info = ascii_handler.collect_data_from_file(info_file)
+        description = str(info.get("description", "")).replace("\n", " ").strip()
+        model_version = str(info.get("model_version", info_file.parent.name))
+        descriptions.append((model_version, description))
+
+    return descriptions
+
+
+def write_production_summary_markdown(data_path, output_file):
+    """Write a markdown table with production versions and short descriptions.
+
+    Parameters
+    ----------
+    data_path : str or Path
+        Path to the simulation-models repository root.
+    output_file : str or Path
+        Markdown file to write.
+    """
+    lines = [
+        "# Descriptions of productions",
+        "",
+        "| Production Model Version | Short Description                     |",
+        "|---------------------------|---------------------------------------|",
+    ]
+
+    for model_version, description in collect_production_descriptions(data_path):
+        escaped_description = description.replace("|", "\\|")
+        lines.append(f"| {model_version} | {escaped_description} |")
+
+    output_file = Path(output_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/src/simtools/reporting/docs_production_summary.py
+++ b/src/simtools/reporting/docs_production_summary.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 from simtools.io import ascii_handler
 
 
@@ -20,9 +22,15 @@ def collect_production_descriptions(data_path):
     """
     productions_path = Path(data_path) / "simulation-models" / "productions"
 
+    def _version_sort_key(path):
+        try:
+            return (0, Version(path.parent.name))
+        except InvalidVersion:
+            return (1, path.parent.name)
+
     info_files = sorted(
         set(productions_path.glob("*/info.yaml")) | set(productions_path.glob("*/info.yml")),
-        key=lambda path: path.parent.name,
+        key=_version_sort_key,
     )
 
     descriptions = []

--- a/tests/integration_tests/config/docs_produce_production_summary_run.yml
+++ b/tests/integration_tests/config/docs_produce_production_summary_run.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- application: simtools-docs-produce-production-summary
+  configuration:
+    data_path: ../simulation-models
+    output_path: simtools-output/reports/productions/
+    output_file: production_version_descriptions.md
+  integration_tests:
+  - output_file: production_version_descriptions.md
+  test_name: run
+schema_name: application_workflow.metaschema
+schema_version: 0.4.0

--- a/tests/unit_tests/reporting/test_docs_production_summary.py
+++ b/tests/unit_tests/reporting/test_docs_production_summary.py
@@ -25,6 +25,18 @@ def test_collect_production_descriptions_reads_info_files(tmp_test_directory):
     assert descriptions == [("6.0.0", "Prod6 dark"), ("6.1.0", "Prod6 half-moon")]
 
 
+def test_collect_production_descriptions_semantic_version_ordering(tmp_test_directory):
+    data_path = Path(tmp_test_directory)
+    _write_info_file(data_path, "10.0.0", "Prod10")
+    _write_info_file(data_path, "6.0.0", "Prod6")
+    _write_info_file(data_path, "9.2.0", "Prod9")
+
+    descriptions = collect_production_descriptions(data_path)
+
+    versions = [v for v, _ in descriptions]
+    assert versions == ["6.0.0", "9.2.0", "10.0.0"]
+
+
 def test_write_production_summary_markdown_writes_table(tmp_test_directory):
     data_path = Path(tmp_test_directory)
     _write_info_file(data_path, "5.0.0", "Prod5 | dark")

--- a/tests/unit_tests/reporting/test_docs_production_summary.py
+++ b/tests/unit_tests/reporting/test_docs_production_summary.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from simtools.reporting.docs_production_summary import (
+    collect_production_descriptions,
+    write_production_summary_markdown,
+)
+
+
+def _write_info_file(base_path, model_version, description, suffix="yml"):
+    production_path = base_path / "simulation-models" / "productions" / model_version
+    production_path.mkdir(parents=True, exist_ok=True)
+    (production_path / f"info.{suffix}").write_text(
+        f'model_version: "{model_version}"\ndescription: "{description}"\n',
+        encoding="utf-8",
+    )
+
+
+def test_collect_production_descriptions_reads_info_files(tmp_test_directory):
+    data_path = Path(tmp_test_directory)
+    _write_info_file(data_path, "6.0.0", "Prod6 dark")
+    _write_info_file(data_path, "6.1.0", "Prod6 half-moon", suffix="yaml")
+
+    descriptions = collect_production_descriptions(data_path)
+
+    assert descriptions == [("6.0.0", "Prod6 dark"), ("6.1.0", "Prod6 half-moon")]
+
+
+def test_write_production_summary_markdown_writes_table(tmp_test_directory):
+    data_path = Path(tmp_test_directory)
+    _write_info_file(data_path, "5.0.0", "Prod5 | dark")
+    _write_info_file(data_path, "6.0.0", "Prod6 dark")
+
+    output_file = data_path / "output" / "production_version_descriptions.md"
+    write_production_summary_markdown(data_path, output_file)
+
+    content = output_file.read_text(encoding="utf-8")
+
+    assert "# Descriptions of productions" in content
+    assert "| Production Model Version | Short Description                     |" in content
+    assert "| 5.0.0 | Prod5 \\| dark |" in content
+    assert "| 6.0.0 | Prod6 dark |" in content


### PR DESCRIPTION
Add a new CLI application `simtools-docs-produce-production-summary` that scans `info.yml`/`info.yaml` files from the simulation-models productions directory and generates a markdown table of production versions and short descriptions.

- `src/simtools/reporting/docs_production_summary.py`: helper that collects descriptions and writes the markdown table
- `src/simtools/applications/docs_produce_production_summary.py`: thin CLI wrapper
- `pyproject.toml`: CLI entry point registered
- `docs/source/user-guide/applications/simtools-docs-produce-production-summary.rst`: doc page
- `docs/source/user-guide/applications.md`: toctree entry added
- `tests/unit_tests/reporting/test_docs_production_summary.py`: unit tests (100% coverage)
- `tests/integration_tests/config/docs_produce_production_summary_run.yml`: integration test config
- `.github/copilot-instructions.md`: doc and toctree steps added to "Adding a New Application"

Required for https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/work_items/41

See also https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/124