### PR TITLE
Add retry-attempts for downloading CORSIKA interaction tables in CI to increase robustness against network issues.

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -72,7 +72,12 @@ jobs:
         run: |
           REPO_URL=https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simulation_software/${IT_NAME}
           export GIT_LFS_SKIP_SMUDGE=1  # disable automatic downloading of all LFS files
-          git clone --depth 1 --branch "$CORSIKA_TABLES" "$REPO_URL" "$IT_NAME"
+          for attempt in 1 2 3; do
+            git clone --depth 1 --branch "$CORSIKA_TABLES" "$REPO_URL" "$IT_NAME" && break
+            echo "Clone attempt $attempt failed. Retrying in 120 seconds..."
+            rm -rf "$IT_NAME"
+            sleep 120
+          done
           git lfs install
           (cd "$IT_NAME" && git lfs pull --exclude="interaction-tables/qgsdat-II-04,interaction-tables/qgsdat-III")
 

--- a/docs/changes/2142.maintenance.md
+++ b/docs/changes/2142.maintenance.md
@@ -1,0 +1,1 @@
+Add retry-attempts for downloading CORSIKA interaction tables in CI to increase robustness against network issues.


### PR DESCRIPTION
Avoids issues like e.g. https://github.com/gammasim/simtools/actions/runs/25087437686/job/73505974505