### PR TITLE
Use dotenv linter action instead of direct install and download

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -67,10 +67,10 @@ jobs:
         run: |
           pip install -e '.[tests,dev,doc]'
 
-      - name: Install and run dotenv-linter
-        run: |
-          curl -sSfL https://git.io/JLbXn | sh -s
-          ./bin/dotenv-linter check -i UnorderedKey .env*
+      - name: Dotenv linter
+        uses: dotenv-linter/action-dotenv-linter@v2
+        with:
+          args: check -i UnorderedKey .env*
 
       - name: Restore pre-commit cache
         uses: actions/cache@v5

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Dotenv linter
         uses: dotenv-linter/action-dotenv-linter@v2
         with:
-          args: check -i UnorderedKey .env*
+          dotenv_linter_flags: check -i UnorderedKey .env*
 
       - name: Restore pre-commit cache
         uses: actions/cache@v5

--- a/docs/changes/2144.maintenance.md
+++ b/docs/changes/2144.maintenance.md
@@ -1,0 +1,1 @@
+Use github action for dotenv linter instead direct installation and call.

--- a/docs/changes/2144.maintenance.md
+++ b/docs/changes/2144.maintenance.md
@@ -1,1 +1,1 @@
-Use github action for dotenv linter instead direct installation and call.
+Use a GitHub Action for dotenv linting instead of direct installation and execution.


### PR DESCRIPTION
Maybe this solves the issue of e.g. https://github.com/gammasim/simtools/actions/runs/25103673807/job/73559252311 (seen a couple of times now).

There is also a pre-commit tool for dotenv linter, but this requires to have docker installed (which I don't want to assume on any developer machine; e.g., I have podman).