### PR TITLE
Remove fail fast for unit tests

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -24,6 +24,7 @@ jobs:
   unit_tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/docs/changes/2145.maintenance.md
+++ b/docs/changes/2145.maintenance.md
@@ -1,0 +1,1 @@
+Remove fail fast for unit test for CI unit tests.


### PR DESCRIPTION
There is a bit of instabilities in the github services right now with CI jobs too often.

Remove fail fast from unit test, to allow tests continue to run if e.g. mamba installation fails (as e.g. [this failed unit tests](https://github.com/gammasim/simtools/actions/runs/25143260943/job/73731525638#step:5:72))