### PR TITLE
Allow to specifiy model version dependent configuration parameters in configuration files

### DIFF
--- a/docs/changes/2146.feature.md
+++ b/docs/changes/2146.feature.md
@@ -1,0 +1,1 @@
+Allow to specify model version dependent configuration parameters in configuration files.

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -5,90 +5,12 @@ import logging
 import sys
 
 import astropy.units as u
-from packaging.version import Version
 
 import simtools.configuration.commandline_parser as argparser
+import simtools.version as simtools_version
 from simtools.db.mongo_db import jsonschema_db_dict
 from simtools.io import ascii_handler, io_handler
 from simtools.utils import general as gen
-
-
-def _matches_version_constraint(constraint, version):
-    """
-    Check whether *version* satisfies a single constraint string.
-
-    Parameters
-    ----------
-    constraint : str
-        Constraint string such as "<7.0.0", ">=6.0.0", "==5.2.1".
-    version : packaging.version.Version
-        Parsed version to test.
-
-    Returns
-    -------
-    bool
-        True if the version satisfies the constraint.
-
-    Raises
-    ------
-    ValueError
-        If the constraint string uses an unsupported operator.
-    """
-    operators = [
-        (">=", lambda a, b: a >= b),
-        ("<=", lambda a, b: a <= b),
-        (">", lambda a, b: a > b),
-        ("<", lambda a, b: a < b),
-        ("==", lambda a, b: a == b),
-    ]
-    for op_str, op_fn in operators:
-        if constraint.startswith(op_str):
-            return op_fn(version, Version(constraint[len(op_str) :].strip()))
-    raise ValueError(f"Unsupported version constraint operator in {constraint!r}")
-
-
-def resolve_by_version(config, model_version):
-    """
-    Resolve version-dependent values in a configuration dictionary.
-
-    Fields whose value is a dict with a single ``by_version`` key are replaced
-    by the first matching constraint value.  All other fields are left unchanged.
-
-    Example YAML structure that is resolved::
-
-        array_layout_name:
-          by_version:
-            "<7.0.0": alpha
-            ">=7.0.0": CTAO-North-Alpha
-
-    Parameters
-    ----------
-    config : dict
-        Configuration dictionary (typically loaded from a YAML file).
-    model_version : str
-        Semantic version string used to evaluate constraints (e.g. "6.0.2").
-
-    Returns
-    -------
-    dict
-        New dictionary with all ``by_version`` fields resolved to their
-        matching value, or ``None`` when no constraint matches.
-    """
-    if not model_version:
-        return config
-    version = Version(model_version)
-    resolved = {}
-    for key, value in config.items():
-        if isinstance(value, dict) and list(value) == ["by_version"]:
-            matched = None
-            for constraint, result in value["by_version"].items():
-                if _matches_version_constraint(str(constraint), version):
-                    matched = result
-                    break
-            resolved[key] = matched
-        else:
-            resolved[key] = value
-    return resolved
 
 
 class Configurator:
@@ -308,7 +230,9 @@ class Configurator:
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")
             if "configuration" in _config_dict.get("applications", [{}])[0]:
                 _config_dict = _config_dict["applications"][0]["configuration"]
-            _config_dict = resolve_by_version(_config_dict, _config_dict.get("model_version"))
+            _config_dict = simtools_version.resolve_by_version(
+                _config_dict, _config_dict.get("model_version")
+            )
             return gen.change_dict_keys_case(_config_dict)
         except (TypeError, AttributeError):
             self._logger.debug("No YAML configuration update applied to configuration dictionary.")

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -5,11 +5,90 @@ import logging
 import sys
 
 import astropy.units as u
+from packaging.version import Version
 
 import simtools.configuration.commandline_parser as argparser
 from simtools.db.mongo_db import jsonschema_db_dict
 from simtools.io import ascii_handler, io_handler
 from simtools.utils import general as gen
+
+
+def _matches_version_constraint(constraint, version):
+    """
+    Check whether *version* satisfies a single constraint string.
+
+    Parameters
+    ----------
+    constraint : str
+        Constraint string such as "<7.0.0", ">=6.0.0", "==5.2.1".
+    version : packaging.version.Version
+        Parsed version to test.
+
+    Returns
+    -------
+    bool
+        True if the version satisfies the constraint.
+
+    Raises
+    ------
+    ValueError
+        If the constraint string uses an unsupported operator.
+    """
+    operators = [
+        (">=", lambda a, b: a >= b),
+        ("<=", lambda a, b: a <= b),
+        (">", lambda a, b: a > b),
+        ("<", lambda a, b: a < b),
+        ("==", lambda a, b: a == b),
+    ]
+    for op_str, op_fn in operators:
+        if constraint.startswith(op_str):
+            return op_fn(version, Version(constraint[len(op_str) :].strip()))
+    raise ValueError(f"Unsupported version constraint operator in {constraint!r}")
+
+
+def resolve_by_version(config, model_version):
+    """
+    Resolve version-dependent values in a configuration dictionary.
+
+    Fields whose value is a dict with a single ``by_version`` key are replaced
+    by the first matching constraint value.  All other fields are left unchanged.
+
+    Example YAML structure that is resolved::
+
+        array_layout_name:
+          by_version:
+            "<7.0.0": alpha
+            ">=7.0.0": CTAO-North-Alpha
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary (typically loaded from a YAML file).
+    model_version : str
+        Semantic version string used to evaluate constraints (e.g. "6.0.2").
+
+    Returns
+    -------
+    dict
+        New dictionary with all ``by_version`` fields resolved to their
+        matching value, or ``None`` when no constraint matches.
+    """
+    if not model_version:
+        return config
+    version = Version(model_version)
+    resolved = {}
+    for key, value in config.items():
+        if isinstance(value, dict) and list(value) == ["by_version"]:
+            matched = None
+            for constraint, result in value["by_version"].items():
+                if _matches_version_constraint(str(constraint), version):
+                    matched = result
+                    break
+            resolved[key] = matched
+        else:
+            resolved[key] = value
+    return resolved
 
 
 class Configurator:
@@ -228,7 +307,8 @@ class Configurator:
             )
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")
             if "configuration" in _config_dict.get("applications", [{}])[0]:
-                return gen.change_dict_keys_case(_config_dict["applications"][0]["configuration"])
+                _config_dict = _config_dict["applications"][0]["configuration"]
+            _config_dict = resolve_by_version(_config_dict, _config_dict.get("model_version"))
             return gen.change_dict_keys_case(_config_dict)
         except (TypeError, AttributeError):
             self._logger.debug("No YAML configuration update applied to configuration dictionary.")

--- a/src/simtools/model/site_model.py
+++ b/src/simtools/model/site_model.py
@@ -136,7 +136,7 @@ class SiteModel(ModelParameter):
         """
         layouts = self.get_parameter_value("array_layouts")
         for layout in layouts:
-            if layout["name"] == layout_name.lower():
+            if layout["name"].lower() == layout_name.lower():
                 return layout["elements"]
         raise ValueError(f"Array layout '{layout_name}' not found in '{self.site}' site model.")
 

--- a/src/simtools/version.py
+++ b/src/simtools/version.py
@@ -315,26 +315,27 @@ def resolve_by_version(config, model_version):
     versions = model_version if isinstance(model_version, list) else [model_version]
     parsed_versions = [Version(str(version_item)) for version_item in versions]
 
+    def resolve_by_version_field(by_version_dict, parsed_versions, key):
+        """Resolve a single by_version field for all versions, enforcing consistency."""
+        matched_values = [_resolve_single_version(by_version_dict, pv) for pv in parsed_versions]
+        first_match = matched_values[0]
+        if not all(match == first_match for match in matched_values):
+            raise ValueError(
+                f"Inconsistent by_version resolution for key '{key}' and model versions "
+                f"{versions}: {matched_values}"
+            )
+        return first_match
+
+    def _resolve_single_version(by_version_dict, parsed_version):
+        for constraint, result in by_version_dict.items():
+            if matches_version_constraint(str(constraint), parsed_version):
+                return result
+        return None
+
     resolved = {}
     for key, value in config.items():
         if isinstance(value, dict) and list(value) == ["by_version"]:
-            matched_values = []
-            for parsed_version in parsed_versions:
-                matched = None
-                for constraint, result in value["by_version"].items():
-                    if matches_version_constraint(str(constraint), parsed_version):
-                        matched = result
-                        break
-                matched_values.append(matched)
-
-            first_match = matched_values[0]
-            if not all(match == first_match for match in matched_values):
-                raise ValueError(
-                    f"Inconsistent by_version resolution for key '{key}' and model versions "
-                    f"{versions}: {matched_values}"
-                )
-
-            resolved[key] = first_match
+            resolved[key] = resolve_by_version_field(value["by_version"], parsed_versions, key)
         else:
             resolved[key] = value
     return resolved

--- a/src/simtools/version.py
+++ b/src/simtools/version.py
@@ -269,25 +269,6 @@ def check_version_constraint(version_string, constraint):
     return False
 
 
-def matches_version_constraint(constraint, parsed_version):
-    """
-    Check whether a parsed version satisfies a single constraint string.
-
-    Parameters
-    ----------
-    constraint : str
-        Constraint string such as "<7.0.0", ">=6.0.0", "==5.2.1".
-    parsed_version : packaging.version.Version
-        Parsed version to test.
-
-    Returns
-    -------
-    bool
-        True if the version satisfies the constraint.
-    """
-    return check_version_constraint(str(parsed_version), str(constraint).strip())
-
-
 def resolve_by_version(config, model_version):
     """
     Resolve version-dependent values in a configuration dictionary.
@@ -317,7 +298,7 @@ def resolve_by_version(config, model_version):
 
     def resolve_by_version_field(by_version_dict, parsed_versions, key):
         """Resolve a single by_version field for all versions, enforcing consistency."""
-        matched_values = [_resolve_single_version(by_version_dict, pv) for pv in parsed_versions]
+        matched_values = [resolve_single_version(by_version_dict, pv) for pv in parsed_versions]
         first_match = matched_values[0]
         if not all(match == first_match for match in matched_values):
             raise ValueError(
@@ -326,9 +307,9 @@ def resolve_by_version(config, model_version):
             )
         return first_match
 
-    def _resolve_single_version(by_version_dict, parsed_version):
+    def resolve_single_version(by_version_dict, parsed_version):
         for constraint, result in by_version_dict.items():
-            if matches_version_constraint(str(constraint), parsed_version):
+            if check_version_constraint(str(parsed_version), constraint):
                 return result
         return None
 

--- a/src/simtools/version.py
+++ b/src/simtools/version.py
@@ -267,3 +267,74 @@ def check_version_constraint(version_string, constraint):
     if ver in spec:
         return True
     return False
+
+
+def matches_version_constraint(constraint, parsed_version):
+    """
+    Check whether a parsed version satisfies a single constraint string.
+
+    Parameters
+    ----------
+    constraint : str
+        Constraint string such as "<7.0.0", ">=6.0.0", "==5.2.1".
+    parsed_version : packaging.version.Version
+        Parsed version to test.
+
+    Returns
+    -------
+    bool
+        True if the version satisfies the constraint.
+    """
+    return check_version_constraint(str(parsed_version), str(constraint).strip())
+
+
+def resolve_by_version(config, model_version):
+    """
+    Resolve version-dependent values in a configuration dictionary.
+
+    Fields whose value is a dict with a single ``by_version`` key are replaced
+    by the first matching constraint value. All other fields are left unchanged.
+
+    Parameters
+    ----------
+    config : dict
+        Configuration dictionary (typically loaded from a YAML file).
+    model_version : str or list
+        Semantic version string or list of strings used to evaluate constraints
+        (e.g. "6.0.2" or ["6.0.2", "6.1.1"]).
+
+    Returns
+    -------
+    dict
+        New dictionary with all ``by_version`` fields resolved to their
+        matching value, or ``None`` when no constraint matches.
+    """
+    if not model_version:
+        return config
+
+    versions = model_version if isinstance(model_version, list) else [model_version]
+    parsed_versions = [Version(str(version_item)) for version_item in versions]
+
+    resolved = {}
+    for key, value in config.items():
+        if isinstance(value, dict) and list(value) == ["by_version"]:
+            matched_values = []
+            for parsed_version in parsed_versions:
+                matched = None
+                for constraint, result in value["by_version"].items():
+                    if matches_version_constraint(str(constraint), parsed_version):
+                        matched = result
+                        break
+                matched_values.append(matched)
+
+            first_match = matched_values[0]
+            if not all(match == first_match for match in matched_values):
+                raise ValueError(
+                    f"Inconsistent by_version resolution for key '{key}' and model versions "
+                    f"{versions}: {matched_values}"
+                )
+
+            resolved[key] = first_match
+        else:
+            resolved[key] = value
+    return resolved

--- a/tests/integration_tests/config/db_get_array_layouts_from_db_layout_name.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_layout_name.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-db-get-array-layouts-from-db
   configuration:
-    array_layout_name: test_layout
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     model_version: 6.0.2
     site: North
   test_name: layout_name

--- a/tests/integration_tests/config/derive_trigger_rates_db_arrays_short.yml
+++ b/tests/integration_tests/config/derive_trigger_rates_db_arrays_short.yml
@@ -3,8 +3,13 @@ applications:
 - application: simtools-derive-trigger-rates
   configuration:
     array_layout_name:
-    - 1lst
-    - alpha
+      by_version:
+        "<7.0.0":
+        - 1lst
+        - alpha
+        ">=7.0.0":
+        - LSTN-01
+        - CTAO-North-Alpha
     event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
     model_version: 6.0.2
     output_path: simtools-output

--- a/tests/integration_tests/config/generate_array_config_run.yml
+++ b/tests/integration_tests/config/generate_array_config_run.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-generate-array-config
   configuration:
-    array_layout_name: test_layout
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     model_version: 6.0.2
     output_path: simtools-output
     site: North

--- a/tests/integration_tests/config/plot_array_layout_by_name.yml
+++ b/tests/integration_tests/config/plot_array_layout_by_name.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-plot-array-layout
   configuration:
-    array_layout_name: subsystem_lsts
+    array_layout_name:
+      by_version:
+        "<7.0.0": subsystem_lsts
+        ">=7.0.0": CTAO-North-LSTs
     figure_format:
     - pdf
     - png

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
@@ -3,8 +3,13 @@ applications:
 - application: simtools-production-derive-corsika-limits
   configuration:
     array_layout_name:
-    - 1lst
-    - alpha
+      by_version:
+        "<7.0.0":
+        - 1lst
+        - alpha
+        ">=7.0.0":
+        - LSTN-01
+        - CTAO-North-Alpha
     event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
     loss_fraction: 0.001
     model_version: 6.0.2

--- a/tests/integration_tests/config/simulate_flasher_full_simulation_alpha_north.yml
+++ b/tests/integration_tests/config/simulate_flasher_full_simulation_alpha_north.yml
@@ -7,7 +7,10 @@ applications:
     model_version: 7.0.0
     output_path: simtools-output
     site: North
-    array_layout_name: alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     run_number: 10
     flasher_photons: 1e6
     log_level: DEBUG

--- a/tests/integration_tests/config/simulate_pedestals_20_deg_north.yml
+++ b/tests/integration_tests/config/simulate_pedestals_20_deg_north.yml
@@ -3,7 +3,10 @@ applications:
 - application: simtools-simulate-pedestals
   configuration:
     run_mode: pedestals
-    array_layout_name: alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     label: test-pedestal-production-North
     log_level: DEBUG
     model_version: 6.0.2

--- a/tests/integration_tests/config/simulate_pedestals_dark_20_deg_north.yml
+++ b/tests/integration_tests/config/simulate_pedestals_dark_20_deg_north.yml
@@ -5,8 +5,8 @@ applications:
     run_mode: pedestals_dark
     array_layout_name:
       by_version:
-      - "<7.0.0": 1lst
-      - ">=7.0.0": LSTN-01
+        "<7.0.0": 1lst
+        ">=7.0.0": LSTN-01
     label: test-dark-pedestal-production-North
     log_level: DEBUG
     model_version: 6.0.2

--- a/tests/integration_tests/config/simulate_pedestals_dark_20_deg_north.yml
+++ b/tests/integration_tests/config/simulate_pedestals_dark_20_deg_north.yml
@@ -3,7 +3,10 @@ applications:
 - application: simtools-simulate-pedestals
   configuration:
     run_mode: pedestals_dark
-    array_layout_name: 1lst
+    array_layout_name:
+      by_version:
+      - "<7.0.0": 1lst
+      - ">=7.0.0": LSTN-01
     label: test-dark-pedestal-production-North
     log_level: DEBUG
     model_version: 6.0.2

--- a/tests/integration_tests/config/simulate_pedestals_nsb_only_20_deg_north.yml
+++ b/tests/integration_tests/config/simulate_pedestals_nsb_only_20_deg_north.yml
@@ -3,7 +3,10 @@ applications:
 - application: simtools-simulate-pedestals
   configuration:
     run_mode: pedestals_nsb_only
-    array_layout_name: 1lst
+    array_layout_name:
+      by_version:
+        "<7.0.0": 1lst
+        ">=7.0.0": LSTN-01
     label: test-nsb-only-pedestal-production-North
     log_level: DEBUG
     model_version: 6.0.2

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-simulate-prod
   configuration:
-    array_layout_name: alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     azimuth_angle: South
     core_scatter: 5 700 m
     corsika_seeds: [534, 220, 1104, 382]

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
@@ -2,10 +2,7 @@
 applications:
 - application: simtools-simulate-prod
   configuration:
-    array_layout_name:
-      by_version:
-        "<7.0.0": alpha
-        ">=7.0.0": CTAO-North-Alpha
+    array_layout_name: alpha
     azimuth_angle: South
     core_scatter: 5 700 m
     corsika_seeds: [534, 220, 1104, 382]

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_north_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_north_check_output.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-simulate-prod
   configuration:
-    array_layout_name: alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     azimuth_angle: South
     core_scatter: 2 600 m
     corsika_seeds: [534, 220, 1104, 382]

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_north_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_north_check_output.yml
@@ -2,7 +2,10 @@
 applications:
 - application: simtools-simulate-prod
   configuration:
-    array_layout_name: alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     azimuth_angle: South
     core_scatter: 5 500 m
     corsika_seeds: [534, 220, 1104, 382]

--- a/tests/unit_tests/test_version.py
+++ b/tests/unit_tests/test_version.py
@@ -3,6 +3,7 @@
 import sys
 
 import pytest
+from packaging.version import Version
 
 import simtools.version as version
 
@@ -226,6 +227,80 @@ def test_check_version_constraint():
     assert version.check_version_constraint("6.0.2", "<6.0.2") is False
     assert version.check_version_constraint("7.550", ">7.500")
     assert version.check_version_constraint("2025.100.0", ">=2024.365.0")
+
+
+def test_matches_version_constraint():
+    parsed_version = Version("6.0.2")
+
+    assert version.matches_version_constraint("<7.0.0", parsed_version)
+    assert version.matches_version_constraint(">=7.0.0", parsed_version) is False
+    assert version.matches_version_constraint("<=6.0.2", parsed_version)
+    assert version.matches_version_constraint(">6.0.1", parsed_version)
+    assert version.matches_version_constraint("==6.0.2", parsed_version)
+
+
+def test_resolve_by_version():
+    config = {
+        "array_layout_name": {
+            "by_version": {
+                "<7.0.0": "alpha",
+                ">=7.0.0": "CTAO-North-Alpha",
+            }
+        },
+        "site": "North",
+    }
+
+    assert version.resolve_by_version(config, "6.0.2") == {
+        "array_layout_name": "alpha",
+        "site": "North",
+    }
+    assert version.resolve_by_version(config, "7.0.0") == {
+        "array_layout_name": "CTAO-North-Alpha",
+        "site": "North",
+    }
+
+
+def test_resolve_by_version_no_match():
+    config = {
+        "array_layout_name": {
+            "by_version": {
+                "<5.0.0": "alpha",
+            }
+        }
+    }
+
+    assert version.resolve_by_version(config, "6.0.0") == {"array_layout_name": None}
+
+
+def test_resolve_by_version_list_consistent():
+    config = {
+        "array_layout_name": {
+            "by_version": {
+                "<7.0.0": "alpha",
+                ">=7.0.0": "CTAO-North-Alpha",
+            }
+        },
+        "site": "South",
+    }
+
+    assert version.resolve_by_version(config, ["6.0.2", "6.1.1"]) == {
+        "array_layout_name": "alpha",
+        "site": "South",
+    }
+
+
+def test_resolve_by_version_list_inconsistent_raises():
+    config = {
+        "array_layout_name": {
+            "by_version": {
+                "<7.0.0": "alpha",
+                ">=7.0.0": "CTAO-North-Alpha",
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="Inconsistent by_version resolution"):
+        version.resolve_by_version(config, ["6.0.2", "7.0.0"])
 
 
 def test_is_valid_semantic_version():

--- a/tests/unit_tests/test_version.py
+++ b/tests/unit_tests/test_version.py
@@ -3,7 +3,6 @@
 import sys
 
 import pytest
-from packaging.version import Version
 
 import simtools.version as version
 
@@ -229,14 +228,13 @@ def test_check_version_constraint():
     assert version.check_version_constraint("2025.100.0", ">=2024.365.0")
 
 
-def test_matches_version_constraint():
-    parsed_version = Version("6.0.2")
-
-    assert version.matches_version_constraint("<7.0.0", parsed_version)
-    assert version.matches_version_constraint(">=7.0.0", parsed_version) is False
-    assert version.matches_version_constraint("<=6.0.2", parsed_version)
-    assert version.matches_version_constraint(">6.0.1", parsed_version)
-    assert version.matches_version_constraint("==6.0.2", parsed_version)
+def test_check_version_constraint_with_version_object():
+    version_string = "6.0.2"
+    assert version.check_version_constraint(version_string, "<7.0.0")
+    assert not version.check_version_constraint(version_string, ">=7.0.0")
+    assert version.check_version_constraint(version_string, "<=6.0.2")
+    assert version.check_version_constraint(version_string, ">6.0.1")
+    assert version.check_version_constraint(version_string, "==6.0.2")
 
 
 def test_resolve_by_version():


### PR DESCRIPTION
Add model dependent configuration parameters in the configuration files (used e.g., by integration tests):

```
  array_layout_name:
      by_version:
        "<7.0.0":
        - 1lst
        - alpha
        ">=7.0.0":
        - LSTN-01
        - CTAO-North-Alpha
```

This allows to run integration tests for different model versions, even if parameter versions change. Fixes e.g. [these runs](https://github.com/gammasim/simtools/actions/runs/25160419424/job/73753141659?pr=2132).