### PR TITLE
Run sonar in pip 3.13. matrix step

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -32,7 +32,7 @@ jobs:
             install-method: pip
 
           - os: ubuntu-latest
-            python-version: "3.14"
+            python-version: "3.13"
             install-method: mamba
 
           - os: ubuntu-latest

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -32,13 +32,13 @@ jobs:
             install-method: pip
 
           - os: ubuntu-latest
-            python-version: "3.13"
+            python-version: "3.14"
             install-method: mamba
-            extra-args: ["sonarqube", "random-order"]
 
           - os: ubuntu-latest
             python-version: "3.13"
             install-method: pip
+            extra-args: ["sonarqube", "random-order"]
 
     defaults:
       run:

--- a/docs/changes/2147.maintenance.md
+++ b/docs/changes/2147.maintenance.md
@@ -1,0 +1,1 @@
+Run sonar in pip 3.13. matrix step (was: conda 3.13 step).


### PR DESCRIPTION
Was: conda 3.13 step. This ensure that we have a sonar analysis as long as the mamba installation method fails.