### PR TITLE
Re-enable markdown linter in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,12 +59,12 @@ repos:
       "--ignore-words-list=als",
     ]
 # markdownlint
-# - repo: https://github.com/igorshubovych/markdownlint-cli
-#  rev: v0.48.0
-#  hooks:
-#  - id: markdownlint
-#    args: ["--disable", "MD041"]
-#    language_version: 22.11.0
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.48.0
+  hooks:
+  - id: markdownlint
+    args: ["--disable", "MD041"]
+    language_version: 25.9.0
 # yamllint
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.38.0


### PR DESCRIPTION
Apparently node.js is the issue.

Closes #2099 