### PR TITLE
CORSIKA v7.850 in simtools-prod; fix filling of iact_atmo_version field.

### DIFF
--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -26,7 +26,7 @@ jobs:
       generic_tag: ${{ steps.export-tags.outputs.generic_tag }}
     strategy:
       matrix:
-        corsika: ['v78010']
+        corsika: ['v78010', 'v78050']
         sim_telarray: ['v2025-11-30-rc']
         avx_flag: ['generic', 'avx2', 'avx512f', 'sse4']
     env:

--- a/docker/Dockerfile-corsika7
+++ b/docker/Dockerfile-corsika7
@@ -74,6 +74,7 @@ RUN yum update -y --setopt=tsflags=nodocs && \
 
 WORKDIR /workdir/simulation_software
 COPY --from=source_preparation /src .
+COPY --from=source_preparation /src/corsika7/bernlohr/iact.c /tmp/iact.c
 
 # Install autoconf 2.71 - needed to apply CORSIKA patches
 WORKDIR /workdir/simulation_software/autoconf-2.71
@@ -126,7 +127,10 @@ RUN ls ../config_*.h && for config_file in ../config_*.h; do \
 
 # Generate build_opts.yml with build information
 RUN CORSIKA_RUN_DIR="/workdir/corsika-run" && \
-    IACT_ATMO_VERSION=$(grep -o '#define IACT_ATMO_VERSION "[^"]*"' bernlohr/iact.c | sed 's/#define IACT_ATMO_VERSION "\(.*\)"/\1/' || echo "unknown") && \
+    IACT_ATMO_VERSION=$(awk '/#[[:space:]]*define[[:space:]]+IACT_ATMO_VERSION[[:space:]]+"/{match($0, /"[^"]*"/); if (RSTART) {print substr($0, RSTART + 1, RLENGTH - 2); exit}}' /tmp/iact.c) && \
+    if [ -z "${IACT_ATMO_VERSION}" ]; then \
+        IACT_ATMO_VERSION="unknown"; \
+    fi && \
     { \
         echo "corsika_version: \"${CORSIKA_VERSION}\""; \
         echo "corsika_opt_patch_version: \"${CORSIKA_OPT_PATCH_VERSION}\""; \

--- a/docs/changes/2169.bugfix.md
+++ b/docs/changes/2169.bugfix.md
@@ -1,0 +1,1 @@
+Fill `iact_atmo_version` field correctly in the CORSIKA7 building option file (`build_opts.yml`).

--- a/docs/changes/2169.feature.md
+++ b/docs/changes/2169.feature.md
@@ -1,0 +1,1 @@
+Add CORSIKA v7.850 to simtools-prod image generation pipeline.


### PR DESCRIPTION
Two items:

- Add CORSIKA v7.850 to simtools-prod image generation pipeline (keep v7.810)
- Fill `iact_atmo_version` field correctly in the CORSIKA7 building option file (`build_opts.yml`). The iact atmo version is read from the sim_telarray source file and is a bit fragile for changes in format in sim_telarray.

As a reminder, /workdir/simulation_software/corsika7/build_opts.yml contains useful information:

```
corsika_version: "78010"
corsika_opt_patch_version: "v1.1.0"
corsika_config_version: "v0.1.0"
avx_flag: "generic"
iact_atmo_version: "1.69 (2025-02-27), IACT_NO_GRID"
variant:
  - executable: "corsika_epos_urqmd_curved"
    config: "config_epos_urqmd_curved"
    atmosphere_geometry: "curved"
    he_hadronic_model: "epos"
    le_hadronic_model: "urqmd"
  - executable: "corsika_epos_urqmd_flat"
    config: "config_epos_urqmd_flat"
    atmosphere_geometry: "flat"
    he_hadronic_model: "epos"
    le_hadronic_model: "urqmd"
  - executable: "corsika_qgs3_urqmd_curved"
    config: "config_qgs3_urqmd_curved"
    atmosphere_geometry: "curved"
    he_hadronic_model: "qgs3"
    le_hadronic_model: "urqmd"
  - executable: "corsika_qgs3_urqmd_flat"
    config: "config_qgs3_urqmd_flat"
    atmosphere_geometry: "flat"
    he_hadronic_model: "qgs3"
    le_hadronic_model: "urqmd"
```