### PR TITLE
Add functionality to assign valid telescope numbers to additional MSTs in legacy prod6 simulations.

### DIFF
--- a/docs/changes/2171.feature.md
+++ b/docs/changes/2171.feature.md
@@ -1,0 +1,1 @@
+Add functionality to assign valid telescope numbers to additional MSTs in legacy prod6 simulations.

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -158,7 +158,7 @@ def _guess_telescope_name_for_legacy_files(tel_counter, file):
     str, None
         Guessed telescope name or None if not found.
     """
-    telescope_list = _get_telescope_list_from_input_card(file)
+    telescope_list = _legacy_merge_msts(_get_telescope_list_from_input_card(file))
     try:
         return names.validate_array_element_name(telescope_list[tel_counter])
     except (IndexError, ValueError):
@@ -190,13 +190,54 @@ def _get_telescope_list_from_input_card(file):
     list
         List of telescope names as found in CORSIKA input card.
     """
+    tel_re = re.compile(
+        r"^TELESCOPE\s+"
+        r"[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+"
+        r"#\s*\(ID=\d+\)\s+"
+        r"([A-Z0-9]+)\s+"  # MSTS / LSTS / SSTS / MST2 / LSTN / MSTN
+        r"(\d+)\s+"  # numeric telescope id
+        r"[A-Z0-9]+",  # internal label (ignored)
+        re.MULTILINE,
+    )
+
     with EventIOFile(file) as f:
         for o in f:
             if isinstance(o, InputCard):
-                input_card = o.parse().decode("utf-8")
-                regex = (
-                    r"TELESCOPE\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+"
-                    r"# \(ID=\d+\)\s+(LST[N|S]|MST[N|S]|S[S|C]TS)\s+([^\s]+)"
-                )
-                return [f"{m[0]}-{m[1]}" for m in re.findall(regex, input_card)]
+                text = o.parse().decode("utf-8")
+
+                return [f"{tel_type}-{tel_id}" for tel_type, tel_id in tel_re.findall(text)]
+
     return []
+
+
+def _legacy_merge_msts(msts):
+    """
+    Merge MSTS/MSTN + MST2 into a single class-specific MSTS/MSTN list.
+
+    Expect that main list first element is a MSTS/MSTN telescopes.
+    This function is very specific and intended for legacy files
+    generated for prod6, where metadata is incomplete.
+
+    Parameters
+    ----------
+    msts: list
+        List of MSTs
+    mst2: list
+        List of additional MSTs
+
+    Returns
+    -------
+    list
+        List of merged telescopes.
+    """
+    mst2_list = [s for s in msts if re.search(r"MST2", s)]
+    if not mst2_list or len(msts) < 1:
+        return msts
+    mst_list = [s for s in msts if not re.search(r"MST2", s)]
+    mst_numbers = [int(num) for s in mst_list if "MST" in s for num in re.findall(r"\d+", s)]
+    max_mst_id = max(mst_numbers) if mst_numbers else 0
+    site = names.get_site_from_array_element_name(msts[0])
+    site_char = "S" if site.lower() == "south" else "N"
+    mst_list += [f"MST{site_char}-{max_mst_id + i + 1}" for i, _ in enumerate(mst2_list)]
+
+    return mst_list

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -191,7 +191,7 @@ def _get_telescope_list_from_input_card(file):
         List of telescope names as found in CORSIKA input card.
     """
     tel_re = re.compile(
-        r"^TELESCOPE\s+"
+        r"\s*TELESCOPE\s+"
         r"[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+"
         r"#\s*\(ID=\d+\)\s+"
         r"([A-Z0-9]+)\s+"  # MSTS / LSTS / SSTS / MST2 / LSTN / MSTN
@@ -222,8 +222,6 @@ def _legacy_merge_msts(msts):
     ----------
     msts: list
         List of MSTs
-    mst2: list
-        List of additional MSTs
 
     Returns
     -------
@@ -231,13 +229,13 @@ def _legacy_merge_msts(msts):
         List of merged telescopes.
     """
     mst2_list = [s for s in msts if re.search(r"MST2", s)]
-    if not mst2_list or len(msts) < 1:
+    if not mst2_list:
         return msts
     mst_list = [s for s in msts if not re.search(r"MST2", s)]
     mst_numbers = [int(num) for s in mst_list if "MST" in s for num in re.findall(r"\d+", s)]
     max_mst_id = max(mst_numbers) if mst_numbers else 0
     site = names.get_site_from_array_element_name(msts[0])
     site_char = "S" if site.lower() == "south" else "N"
-    mst_list += [f"MST{site_char}-{max_mst_id + i + 1}" for i, _ in enumerate(mst2_list)]
+    mst_list += [f"MST{site_char}-{max_mst_id + i + 1:02d}" for i, _ in enumerate(mst2_list)]
 
     return mst_list

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -228,14 +228,22 @@ def _legacy_merge_msts(msts):
     list
         List of merged telescopes.
     """
-    mst2_list = [s for s in msts if re.search(r"MST2", s)]
-    if not mst2_list:
+    mst2_indices = [index for index, telescope in enumerate(msts) if re.search(r"MST2", telescope)]
+    if not mst2_indices:
         return msts
-    mst_list = [s for s in msts if not re.search(r"MST2", s)]
-    mst_numbers = [int(num) for s in mst_list if "MST" in s for num in re.findall(r"\d+", s)]
+
+    mst_numbers = [
+        int(num)
+        for telescope in msts
+        if "MST" in telescope and not re.search(r"MST2", telescope)
+        for num in re.findall(r"\d+", telescope)
+    ]
     max_mst_id = max(mst_numbers) if mst_numbers else 0
     site = names.get_site_from_array_element_name(msts[0])
     site_char = "S" if site.lower() == "south" else "N"
-    mst_list += [f"MST{site_char}-{max_mst_id + i + 1:02d}" for i, _ in enumerate(mst2_list)]
 
-    return mst_list
+    merged_msts = list(msts)
+    for i, index in enumerate(mst2_indices):
+        merged_msts[index] = f"MST{site_char}-{max_mst_id + i + 1:02d}"
+
+    return merged_msts

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -210,40 +210,42 @@ def _get_telescope_list_from_input_card(file):
     return []
 
 
-def _legacy_merge_msts(msts):
+def _legacy_merge_msts(telescopes):
     """
-    Merge MSTS/MSTN + MST2 into a single class-specific MSTS/MSTN list.
+    Rename additional 'MST2' telescopes to 'MSTS' or 'MSTN' with incremented IDs.
 
-    Expect that main list first element is a MSTS/MSTN telescopes.
+    Expect that main list first element is a telescope with a valid side flag.
     This function is very specific and intended for legacy files
     generated for prod6, where metadata is incomplete.
 
     Parameters
     ----------
-    msts: list
-        List of MSTs
+    telescopes: list
+        List of telescopes
 
     Returns
     -------
     list
-        List of merged telescopes.
+        List of telescopes with 'MST2' renamed to 'MSTS' or 'MSTN' and incremented IDs.
     """
-    mst2_indices = [index for index, telescope in enumerate(msts) if re.search(r"MST2", telescope)]
-    if not mst2_indices:
-        return msts
+    tel2_indices = [
+        index for index, telescope in enumerate(telescopes) if re.search(r"^MST2", telescope)
+    ]
+    if not tel2_indices:
+        return telescopes
 
     mst_numbers = [
         int(num)
-        for telescope in msts
-        if "MST" in telescope and not re.search(r"MST2", telescope)
+        for telescope in telescopes
+        if "MST" in telescope and not re.search(r"^MST2", telescope)
         for num in re.findall(r"\d+", telescope)
     ]
     max_mst_id = max(mst_numbers) if mst_numbers else 0
-    site = names.get_site_from_array_element_name(msts[0])
+    site = names.get_site_from_array_element_name(telescopes[0])
     site_char = "S" if site.lower() == "south" else "N"
 
-    merged_msts = list(msts)
-    for i, index in enumerate(mst2_indices):
-        merged_msts[index] = f"MST{site_char}-{max_mst_id + i + 1:02d}"
+    merged_tels = list(telescopes)
+    for i, index in enumerate(tel2_indices):
+        merged_tels[index] = f"MST{site_char}-{max_mst_id + i + 1:02d}"
 
-    return merged_msts
+    return merged_tels

--- a/tests/unit_tests/simtel/test_simtel_io_metadata.py
+++ b/tests/unit_tests/simtel/test_simtel_io_metadata.py
@@ -223,7 +223,7 @@ def test_get_sim_telarray_telescope_id_to_telescope_name_mapping_value_error(mon
         ),
         (
             ["LSTS-01", "MSTS-01", "MSTS-133", "MST2-05", "SSTS-01"],
-            ["LSTS-01", "MSTS-01", "MSTS-133", "SSTS-01", "MSTS-134"],
+            ["LSTS-01", "MSTS-01", "MSTS-133", "MSTS-134", "SSTS-01"],
         ),
         ([], []),
         (["LSTS-01", "SSTS-01"], ["LSTS-01", "SSTS-01"]),
@@ -231,14 +231,3 @@ def test_get_sim_telarray_telescope_id_to_telescope_name_mapping_value_error(mon
 )
 def test_legacy_merge_msts(msts, expected):
     assert simtel_io_metadata._legacy_merge_msts(msts) == expected
-
-
-def test_legacy_merge_msts_with_malformed_mst2_entry(monkeypatch):
-    msts = ["LSTM-01", 'MSTN-01, "MST2-02']
-
-    monkeypatch.setattr(
-        "simtools.utils.names.get_site_from_array_element_name",
-        lambda _: "North",
-    )
-
-    assert simtel_io_metadata._legacy_merge_msts(msts) == ["LSTM-01", "MSTN-01"]

--- a/tests/unit_tests/simtel/test_simtel_io_metadata.py
+++ b/tests/unit_tests/simtel/test_simtel_io_metadata.py
@@ -101,6 +101,7 @@ def test_get_telescope_list_from_input_card_parses_telescopes(monkeypatch):
                 TELESCOPE   -153.29E2     168.86E2 28.70E2  9.15E2  # (ID=6)   MSTS   02   4B1\n
                 TELESCOPE   -153.29E2     168.86E2 28.70E2  9.15E2  # (ID=6)   SSTS   02   4B1\n
                 TELESCOPE   -153.29E2     168.86E2 28.70E2  9.15E2  # (ID=6)   SCTS   02   4B1\n
+                TELESCOPE   -153.29E2     168.86E2 28.70E2  9.15E2  # (ID=6)   MST2   01   4B1\n
                 """
 
     class FakeEventIOFile:
@@ -123,7 +124,8 @@ def test_get_telescope_list_from_input_card_parses_telescopes(monkeypatch):
     assert "MSTS-02" in result
     assert "SSTS-02" in result
     assert "SCTS-02" in result
-    assert len(result) == 6
+    assert "MST2-01" in result
+    assert len(result) == 7
 
 
 def test_get_telescope_list_from_input_card_no_input_card(monkeypatch):
@@ -210,3 +212,33 @@ def test_get_sim_telarray_telescope_id_to_telescope_name_mapping_value_error(mon
         "dummy4.simtel"
     )
     assert mapping == {1: "FAKE-0", 2: "FAKE-1"}
+
+
+@pytest.mark.parametrize(
+    ("msts", "expected"),
+    [
+        (
+            ["LSTS-01", "MSTS-01", "MSTS-133", "SSTS-01"],
+            ["LSTS-01", "MSTS-01", "MSTS-133", "SSTS-01"],
+        ),
+        (
+            ["LSTS-01", "MSTS-01", "MSTS-133", "MST2-05", "SSTS-01"],
+            ["LSTS-01", "MSTS-01", "MSTS-133", "SSTS-01", "MSTS-134"],
+        ),
+        ([], []),
+        (["LSTS-01", "SSTS-01"], ["LSTS-01", "SSTS-01"]),
+    ],
+)
+def test_legacy_merge_msts(msts, expected):
+    assert simtel_io_metadata._legacy_merge_msts(msts) == expected
+
+
+def test_legacy_merge_msts_with_malformed_mst2_entry(monkeypatch):
+    msts = ["LSTM-01", 'MSTN-01, "MST2-02']
+
+    monkeypatch.setattr(
+        "simtools.utils.names.get_site_from_array_element_name",
+        lambda _: "North",
+    )
+
+    assert simtel_io_metadata._legacy_merge_msts(msts) == ["LSTM-01", "MSTN-01"]


### PR DESCRIPTION
This is very very fine tuned to the current legacy-style prod6 production with less metadata then the simtools produced files.

Additional MSTs labels 'MST2' are added with IDs beyond the nominal MSTs.

Please test and give feedback.