### PR TITLE
Improve simulate_prod_htcondor_generator to allow to generate job configurations for a parameter grid

### DIFF
--- a/docs/changes/2174.feature.md
+++ b/docs/changes/2174.feature.md
@@ -1,0 +1,1 @@
+Add functionality to allow to generate job configurations for a parameter grid to `simulate_prod_htcondor_generator`.

--- a/docs/changes/2174.feature.md
+++ b/docs/changes/2174.feature.md
@@ -1,1 +1,1 @@
-Add functionality to allow to generate job configurations for a parameter grid to `simulate_prod_htcondor_generator`.
+Add functionality for generating job configurations for a parameter grid to `simulate_prod_htcondor_generator`.

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -48,13 +48,6 @@ priority (int, optional)
 from simtools.application_control import build_application
 from simtools.job_execution import htcondor_script_generator
 
-_INITIALIZATION_KWARGS = {
-    "db_config": False,
-    "preserve_by_version_keys": ["array_layout_name"],
-    "simulation_model": ["site", "layout", "telescope", "model_version"],
-    "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
-}
-
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
@@ -77,7 +70,12 @@ def _add_arguments(parser):
 def main():
     """See CLI description."""
     app_context = build_application(
-        initialization_kwargs=_INITIALIZATION_KWARGS,
+        initialization_kwargs={
+            "db_config": False,
+            "preserve_by_version_keys": ["array_layout_name"],
+            "simulation_model": ["site", "layout", "telescope", "model_version"],
+            "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
+        },
     )
 
     htcondor_script_generator.generate_submission_script(app_context.args)

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -59,12 +59,6 @@ def _add_arguments(parser):
         default=1,
     )
     parser.add_argument(
-        "--apptainer_image",
-        help="Apptainer image to use for the simulation (full path).",
-        type=str,
-        required=False,
-    )
-    parser.add_argument(
         "--priority",
         help="Job priority.",
         type=int,

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -65,6 +65,13 @@ def _add_arguments(parser):
         required=False,
         default=1,
     )
+    parser.add_argument(
+        "--htcondor_log_path",
+        help="Directory for HTCondor output files (default: output_path/htcondor_logs).",
+        type=str,
+        required=False,
+        default=None,
+    )
 
 
 def main():

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -79,6 +79,13 @@ def _add_arguments(parser):
         required=False,
         default="./simtools-output",
     )
+    parser.add_argument(
+        "--corsika_limits",
+        help="Path to an ECSV file with CORSIKA limits.",
+        type=str,
+        required=False,
+        default=None,
+    )
 
 
 def main():

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -72,6 +72,13 @@ def _add_arguments(parser):
         required=False,
         default=None,
     )
+    parser.add_argument(
+        "--simulation_output",
+        help="Output path for simulation data (default: ./simtools-output).",
+        type=str,
+        required=False,
+        default="./simtools-output",
+    )
 
 
 def main():

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -48,6 +48,13 @@ priority (int, optional)
 from simtools.application_control import build_application
 from simtools.job_execution import htcondor_script_generator
 
+_INITIALIZATION_KWARGS = {
+    "db_config": False,
+    "preserve_by_version_keys": ["array_layout_name"],
+    "simulation_model": ["site", "layout", "telescope", "model_version"],
+    "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
+}
+
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
@@ -70,11 +77,7 @@ def _add_arguments(parser):
 def main():
     """See CLI description."""
     app_context = build_application(
-        initialization_kwargs={
-            "db_config": False,
-            "simulation_model": ["site", "layout", "telescope", "model_version"],
-            "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
-        },
+        initialization_kwargs=_INITIALIZATION_KWARGS,
     )
 
     htcondor_script_generator.generate_submission_script(app_context.args)

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -3,41 +3,52 @@
 r"""
 Generate a run script and submit file for HT Condor job submission of a simulation production.
 
-This tool facilitates the submission of multiple simulations to the HT Condor batch system,
-enabling:
+This tool generates HTCondor submission files for one or more simulation production grids and
+supports either a single Apptainer image or a label-to-image mapping for multi-image submissions.
+For each image label, it writes a dedicated ``simulate_prod.submit.<label>.condor`` file and a
+matching ``simulate_prod.submit.<label>.params.txt`` file. When only one default image is used,
+the unsuffixed ``simulate_prod.submit.condor`` and ``simulate_prod.submit.params.txt`` names are
+kept.
 
-- Execution of simulations using the "simtools-simulate-prod" application.
-- 'number_of_runs' jobs are submitted to the HT Condor batch system.
-- Utilization of an Apptainer image containing the SimPipe simulation software and tools.
-- Packaging of data and histogram files, and writing them to a specified directory.
+HTCondor log files are written below ``htcondor_logs/`` by default, or below the directory given
+with ``--htcondor_log_path``. The generator creates the ``log``, ``error``, and ``output``
+subdirectories there and points the submit file at those locations.
 
-This tool is intended for use in an HT Condor environment. Jobs run in a container universe
-using the Apptainer image specified in the command line ('--apptainer_image'). Output is written
-to the 'output_path' directory, with 'simtools-output' and 'logs' subdirectories.
+The ``--simulation_output`` option controls the base directory that is passed to the simulation
+production as ``pack_for_grid_register``. Each image label gets its own subdirectory under that
+base path, allowing different grids or images to keep their output packages separate.
 
 Requirements for the 'simtools-simulate-prod-htcondor-generator' application:
 
-- Availability of an Apptainer image for production (obtainable from the package registry on
-  GitHub, e.g., via 'apptainer pull --force docker://ghcr.io/gammasim/simtools-<tag>:latest').
+- Availability of an Apptainer image for production, either as a single path or as a mapping from
+  labels to image paths (obtainable from the package registry on GitHub, e.g., via
+  'apptainer pull --force docker://ghcr.io/gammasim/simtools-<tag>:latest').
 - Environment parameters required to run CORSIKA and sim_telarray, as well as DB access
   credentials.  These should be listed similarly to a '.env' file and copied to
   'output_path/env.txt'.  Ensure that the path to the simulation software is correctly set to
   'SIMTOOLS_SIM_TELARRAY_PATH=/workdir/sim_telarray'.
 
-To submit jobs, change to the output directory and run:
+To submit jobs, change to the output directory and run the generated submit file:
 
 .. code-block:: console
 
-    condor_submit simulate_prod.submit
+    condor_submit simulate_prod.submit.<label>.condor
 
-Simulation data products will be stored in the output directory.
+For the single-image default case, use ``condor_submit simulate_prod.submit.condor``.
+
+Simulation data products are written to the directory controlled by ``--simulation_output``.
 
 Command line arguments
 ----------------------
 output_path (str, required)
-    Directory where the output and the simulation data files will be written.
-apptainer_image (str, optional)
-    Apptainer image to use for the simulation (full path).
+    Directory where the HTCondor submission files are written.
+apptainer_image (str or dict, required)
+    Apptainer image to use for the simulation. A single string selects one image for all jobs;
+    a dictionary maps labels to image paths and generates one submission pair per label.
+htcondor_log_path (str, optional)
+    Directory for HTCondor log files. Defaults to ``output_path/htcondor_logs``.
+simulation_output (str, optional)
+    Base directory for simulation output packages passed through as ``pack_for_grid_register``.
 priority (int, optional)
     Job priority (default: 1).
 

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -185,10 +185,7 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         _job_group.add_argument(
             "--apptainer_image",
-            help=(
-                "Apptainer image path or a dictionary mapping labels to image paths. "
-                "This is primarily used by HTCondor submission generators."
-            ),
+            help="Apptainer image path or a dictionary mapping labels to image paths.",
             type=CommandLineParser.string_or_dict,
             default=None,
         )

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -869,6 +869,11 @@ class QuantityPairAction(argparse.Action):
                 for item in values
             ):
                 parsed = [CommandLineParser.parse_quantity_pair(item) for item in values]
+            elif len(values) > 2 and len(values) % 2 == 0:
+                parsed = tuple(
+                    u.Quantity(f"{values[index]} {values[index + 1]}")
+                    for index in range(0, len(values), 2)
+                )
             elif len(values) == 2:
                 parsed = (u.Quantity(values[0]), u.Quantity(values[1]))
             else:

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -1,6 +1,7 @@
 """Command line parser for applications."""
 
 import argparse
+import ast
 import logging
 import re
 from pathlib import Path
@@ -181,6 +182,15 @@ class CommandLineParser(argparse.ArgumentParser):
             type=str,
             nargs="+",
             default=["png"],
+        )
+        _job_group.add_argument(
+            "--apptainer_image",
+            help=(
+                "Apptainer image path or a dictionary mapping labels to image paths. "
+                "This is primarily used by HTCondor submission generators."
+            ),
+            type=CommandLineParser.string_or_dict,
+            default=None,
         )
         _job_group.add_argument(
             "--version", action="version", version=f"%(prog)s {simtools.version.__version__}"
@@ -366,6 +376,8 @@ class CommandLineParser(argparse.ArgumentParser):
                     "use '--primary_ID_type' to use other particle ID types)."
                 ),
                 "type": str.lower,
+                "action": OneOrManyAction,
+                "nargs": "+",
                 "required": True,
             },
             "primary_id_type": {
@@ -381,11 +393,15 @@ class CommandLineParser(argparse.ArgumentParser):
                     "North is 0 degrees and the azimuth grows clockwise (East is 90 degrees)."
                 ),
                 "type": CommandLineParser.azimuth_angle,
+                "action": OneOrManyAction,
+                "nargs": "+",
                 "default": 0 * u.deg,
             },
             "zenith_angle": {
                 "help": "Zenith angle in degrees (between 0 and 180).",
                 "type": CommandLineParser.zenith_angle,
+                "action": OneOrManyAction,
+                "nargs": "+",
                 "default": 20 * u.deg,
             },
             "nshow": {
@@ -815,6 +831,55 @@ class CommandLineParser(argparse.ArgumentParser):
 
         return bounded_int_type
 
+    @staticmethod
+    def string_or_dict(value):
+        """Parse argument as plain string or dictionary literal."""
+        if not isinstance(value, str):
+            return value
+
+        stripped = value.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return value
+            if isinstance(parsed, dict):
+                return parsed
+        return value
+
+
+class OneOrManyAction(argparse.Action):
+    """Store one value as scalar and multiple values as list."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Store parsed values as scalar (single) or list (multiple)."""
+        if isinstance(values, list) and len(values) == 1:
+            setattr(namespace, self.dest, values[0])
+            return
+        setattr(namespace, self.dest, values)
+
+
+class QuantityPairAction(argparse.Action):
+    """Parse either one quantity-pair string or two quantity values."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        """Parse quantity-pair inputs and store tuple or list of tuples."""
+        try:
+            if len(values) == 1:
+                parsed = CommandLineParser.parse_quantity_pair(values[0])
+            elif all(
+                isinstance(item, str) and len(re.findall(r"[A-Za-z]+", item)) >= 2
+                for item in values
+            ):
+                parsed = [CommandLineParser.parse_quantity_pair(item) for item in values]
+            elif len(values) == 2:
+                parsed = (u.Quantity(values[0]), u.Quantity(values[1]))
+            else:
+                raise argparse.ArgumentTypeError("Expected one pair string or exactly two values.")
+        except Exception as exc:
+            raise argparse.ArgumentError(self, f"Invalid quantity pair: {exc}") from exc
+        setattr(namespace, self.dest, parsed)
+
 
 _SHOWER_ARGS = {
     "eslope": {
@@ -824,8 +889,9 @@ _SHOWER_ARGS = {
     },
     "energy_range": {
         "help": "Energy range of the primary particle (min/max value, e'g', '10 GeV 5 TeV').",
-        "type": CommandLineParser.parse_quantity_pair,
-        "default": ["3 GeV 330 TeV"],
+        "action": QuantityPairAction,
+        "nargs": "+",
+        "default": (3 * u.GeV, 330 * u.TeV),
     },
     "view_cone": {
         "help": (
@@ -876,6 +942,8 @@ _CORSIKA_ARGS = {
             f"(default fallback: {defaults.CORSIKA_HE_INTERACTION})."
         ),
         "type": str,
+        "action": OneOrManyAction,
+        "nargs": "+",
         "default": None,
     },
     "corsika_le_interaction": {
@@ -884,6 +952,8 @@ _CORSIKA_ARGS = {
             f"(default fallback: {defaults.CORSIKA_LE_INTERACTION})."
         ),
         "type": str,
+        "action": OneOrManyAction,
+        "nargs": "+",
         "default": None,
     },
 }

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -95,6 +95,7 @@ class Configurator:
         simulation_model=None,
         simulation_configuration=None,
         db_config=False,
+        preserve_by_version_keys=None,
     ):
         """
         Initialize application configuration.
@@ -118,6 +119,9 @@ class Configurator:
             Dict of simulation software configuration parameters to add to list of args.
         db_config: bool
             Add database configuration parameters to list of args.
+        preserve_by_version_keys: list
+            Top-level configuration keys whose ``by_version`` dictionaries should be preserved
+            during initial YAML loading.
 
         Returns
         -------
@@ -144,7 +148,15 @@ class Configurator:
         self.config = vars(self.parser.parse_args([]))
         self.config.update(self._config_from_env(_env_file))
         self.config.update(gen.change_dict_keys_case(self.config_class_init or {}))
-        self.config.update(self._config_from_file(_config_file))
+        if preserve_by_version_keys:
+            self.config.update(
+                self._config_from_file(
+                    _config_file,
+                    preserve_by_version_keys=preserve_by_version_keys,
+                )
+            )
+        else:
+            self.config.update(self._config_from_file(_config_file))
         self._fill_config(_cli_arglist)
 
         if self.config.get("activity_id", None) is None:
@@ -203,7 +215,7 @@ class Configurator:
         for action in self.parser._actions:  # pylint: disable=protected-access
             action.required = False
 
-    def _config_from_file(self, config_file):
+    def _config_from_file(self, config_file, preserve_by_version_keys=None):
         """
         Read configuration from yaml file and return as dictionary.
 
@@ -211,6 +223,8 @@ class Configurator:
         ----------
         config_file: str
             Name of configuration file.
+        preserve_by_version_keys: list
+            Top-level configuration keys whose ``by_version`` dictionaries should be preserved.
 
         Returns
         -------
@@ -230,9 +244,20 @@ class Configurator:
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")
             if "configuration" in _config_dict.get("applications", [{}])[0]:
                 _config_dict = _config_dict["applications"][0]["configuration"]
+
+            preserved_by_version = {}
+            for key in preserve_by_version_keys or []:
+                value = _config_dict.get(key)
+                if isinstance(value, dict) and list(value) == ["by_version"]:
+                    preserved_by_version[key] = value
+
+            for key in preserved_by_version:
+                _config_dict.pop(key)
+
             _config_dict = simtools_version.resolve_by_version(
                 _config_dict, _config_dict.get("model_version")
             )
+            _config_dict.update(preserved_by_version)
             return gen.change_dict_keys_case(_config_dict)
         except (TypeError, AttributeError):
             self._logger.debug("No YAML configuration update applied to configuration dictionary.")

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -189,7 +189,7 @@ def _build_job_specs(args_dict, image_labels):
     """Build backend-agnostic job specs from comparison and production grids."""
     grid_axes = _normalize_grid_axes(args_dict)
     energy_ranges = _normalize_energy_ranges(args_dict["energy_range"])
-    base_pack_dir = args_dict.get("pack_for_grid_register") or "simtools-output"
+    base_pack_dir = args_dict.get("simulation_output") or "simtools-output"
 
     combinations = list(
         itertools.product(

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -296,9 +296,17 @@ def generate_submission_script(args_dict):
     grouped_job_specs = _group_job_specs_by_label(job_specs)
 
     work_dir = Path(args_dict["output_path"])
-    log_dir = work_dir / "logs"
+    htcondor_log_path = Path(
+        args_dict["htcondor_log_path"]
+        if args_dict.get("htcondor_log_path")
+        else work_dir / "htcondor_logs"
+    )
+    log_dir = htcondor_log_path / "log"
+    error_dir = htcondor_log_path / "error"
+    output_dir = htcondor_log_path / "output"
     work_dir.mkdir(parents=True, exist_ok=True)
-    log_dir.mkdir(parents=True, exist_ok=True)
+    for subdir in (log_dir, error_dir, output_dir):
+        subdir.mkdir(parents=True, exist_ok=True)
     submit_file_name = "simulate_prod.submit"
     _logger.info(f"Generating HT Condor submission scripts (path: {work_dir})")
 
@@ -320,6 +328,9 @@ def generate_submission_script(args_dict):
                     apptainer_images[label],
                     args_dict["priority"],
                     params_file_name,
+                    log_dir=log_dir,
+                    error_dir=error_dir,
+                    output_dir=output_dir,
                 )
             )
 
@@ -329,7 +340,9 @@ def generate_submission_script(args_dict):
     Path(work_dir / f"{submit_file_name}.sh").chmod(0o755)
 
 
-def _get_submit_file(executable, apptainer_image, priority, params_file_name):
+def _get_submit_file(
+    executable, apptainer_image, priority, params_file_name, log_dir, error_dir, output_dir
+):
     """
     Return HTCondor submit file.
 
@@ -345,6 +358,12 @@ def _get_submit_file(executable, apptainer_image, priority, params_file_name):
         Priority of the job.
     params_file_name: str
         Name of the params file for queue-from submission.
+    log_dir: Path
+        Directory for HTCondor log files.
+    error_dir: Path
+        Directory for HTCondor error files.
+    output_dir: Path
+        Directory for HTCondor output files.
 
     Returns
     -------
@@ -359,9 +378,9 @@ container_image = {apptainer_image}
 transfer_container = false
 
 executable = {executable}
-error      = logs/err.$(cluster)_$(process)
-output     = logs/out.$(cluster)_$(process)
-log        = logs/log.$(cluster)_$(process)
+error      = {error_dir}/err.$(cluster)_$(process)
+output     = {output_dir}/out.$(cluster)_$(process)
+log        = {log_dir}/log.$(cluster)_$(process)
 
 priority = {priority}
 arguments = "{arguments_string}"
@@ -435,7 +454,7 @@ corsika_le_interaction="{corsika_le_interaction_idx}"
 corsika_he_interaction="{corsika_he_interaction_idx}"
 run_number="{run_number_idx}"
 pack_for_grid_register="{pack_for_grid_register_idx}"
-    energy_range_tag="{energy_range_tag}"
+energy_range_tag="{energy_range_tag}"
 job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -1,4 +1,12 @@
-"""HT Condor script generator for simulation production."""
+"""
+HTCondor script generator for simulation production.
+
+Generates three files in the specified output directory:
+- '.condor': HTCondor submit file with queue-from syntax.
+- 'params.txt': Parameters file consumed by the submit file.
+- 'submit.sh': Executable script that runs the simulation command with parameters
+
+"""
 
 import ast
 import itertools
@@ -20,6 +28,23 @@ _GRID_AXES = [
     "corsika_he_interaction",
 ]
 
+_PARAMS_FIELDS = [
+    "apptainer_label",
+    "primary",
+    "azimuth_angle",
+    "zenith_angle",
+    "energy_min_value",
+    "energy_min_unit",
+    "energy_max_value",
+    "energy_max_unit",
+    "model_version",
+    "array_layout_name",
+    "corsika_le_interaction",
+    "corsika_he_interaction",
+    "run_number",
+    "pack_for_grid_register",
+]
+
 
 def _normalize_to_list(value):
     """Normalize scalar values to lists of length one."""
@@ -32,17 +57,16 @@ def _normalize_to_list(value):
 
 def _normalize_grid_axes(args_dict):
     """Return normalized grid axes for cartesian product expansion."""
-    normalized = {}
-    for axis in _GRID_AXES:
-        if axis in args_dict and args_dict[axis] is not None:
-            normalized[axis] = _normalize_to_list(args_dict[axis])
-        else:
-            normalized[axis] = [None]
-    return normalized
+    return {
+        axis: _normalize_to_list(args_dict[axis])
+        if axis in args_dict and args_dict[axis] is not None
+        else [None]
+        for axis in _GRID_AXES
+    }
 
 
 def _normalize_energy_ranges(energy_range):
-    """Normalize energy range argument to a list of (emin, emax) pairs."""
+    """Normalize energy range argument to a list of (e_min, e_max) pairs."""
     if isinstance(energy_range, tuple) and len(energy_range) == 2:
         return [energy_range]
 
@@ -52,11 +76,26 @@ def _normalize_energy_ranges(energy_range):
         if all(isinstance(item, (list, tuple)) and len(item) == 2 for item in energy_range):
             return [tuple(item) for item in energy_range]
 
-    raise ValueError("energy_range must be one pair (emin, emax) or a list of (emin, emax) pairs.")
+    raise ValueError(
+        "energy_range must be one pair (e_min, e_max) or a list of (e_min, e_max) pairs."
+    )
 
 
 def _resolve_apptainer_images(apptainer_image_arg):
-    """Resolve and validate apptainer image configuration."""
+    """
+    Resolve and validate apptainer image configuration.
+
+    Parameters
+    ----------
+    apptainer_image_arg: str or dict
+        Either a string path to a single apptainer image or a dictionary
+        mapping labels to image paths.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping labels to resolved Path objects for apptainer images.
+    """
     if apptainer_image_arg is None:
         raise ValueError("Missing required apptainer_image path.")
 
@@ -82,28 +121,39 @@ def _resolve_apptainer_images(apptainer_image_arg):
     raise ValueError("apptainer_image must be either a string path or a label-to-path dictionary.")
 
 
-def _format_grid_value(value, unit):
-    """Format scalar values for params files with stable unit conversion."""
+def _format_param_value(value, field_name):
+    """
+    Format a value for params file output.
+
+    For energy fields, returns (value_str, unit_str) tuple.
+    For other fields, returns value_str.
+
+    Parameters
+    ----------
+    value : any
+        Value to format.
+    field_name : str
+        Field name to determine formatting and default units.
+
+    Returns
+    -------
+    str or tuple
+        Formatted value(s).
+    """
     if value is None:
-        return ""
-    if hasattr(value, "to"):
-        return f"{value.to(unit).value}"
+        raise ValueError(f"Missing required value for field '{field_name}'.")
+
+    if field_name in ("energy_min_value", "energy_max_value"):
+        if isinstance(value, u.Quantity):
+            return f"{value.value}", f"{value.unit}"
+        return f"{value}", str(u.GeV)
+
+    if field_name in ("azimuth_angle", "zenith_angle"):
+        if isinstance(value, u.Quantity):
+            return f"{value.to(u.deg).value}"
+        return f"{value}"
+
     return f"{value}"
-
-
-def _format_quantity_value_and_unit(value, default_unit=None):
-    """Return quantity as separate value and unit strings for params files."""
-    if value is None:
-        if default_unit is None:
-            return "", ""
-        return "", f"{default_unit}"
-
-    if hasattr(value, "unit"):
-        return f"{value.value}", f"{value.unit}"
-
-    if default_unit is None:
-        return f"{value}", ""
-    return f"{value}", f"{default_unit}"
 
 
 def _sanitize_label_for_filename(label):
@@ -118,7 +168,6 @@ def _resolve_array_layout_name(array_layout_name, model_version):
         array_layout_name = array_layout_name[0]
 
     # Configurator/_fill_config stringifies dict values when rebuilding argparse arguments.
-    # Accept that serialized form so by_version mappings still resolve per model version.
     if isinstance(array_layout_name, str) and array_layout_name.strip().startswith("{"):
         try:
             parsed_layout = ast.literal_eval(array_layout_name)
@@ -200,32 +249,34 @@ def _group_job_specs_by_label(job_specs):
 
 
 def _write_params_file(params_file_path, label_job_specs):
-    """Write params file consumed by HTCondor queue-from syntax."""
+    """Write parameter file consumed by HTCondor queue-from syntax."""
     with open(params_file_path, "w", encoding="utf-8") as params_file_handle:
         for job_spec in label_job_specs:
             array_layout_name = _resolve_array_layout_name(
                 job_spec["array_layout_name"], job_spec["model_version"]
             )
-            energy_min_value, energy_min_unit = _format_quantity_value_and_unit(
-                job_spec["energy_min"], default_unit=u.GeV
+
+            energy_min_value, energy_min_unit = _format_param_value(
+                job_spec["energy_min"], "energy_min_value"
             )
-            energy_max_value, energy_max_unit = _format_quantity_value_and_unit(
-                job_spec["energy_max"], default_unit=u.GeV
+            energy_max_value, energy_max_unit = _format_param_value(
+                job_spec["energy_max"], "energy_max_value"
             )
+
             row = [
-                job_spec["apptainer_label"],
-                _format_grid_value(job_spec["primary"], None),
-                _format_grid_value(job_spec["azimuth_angle"], u.deg),
-                _format_grid_value(job_spec["zenith_angle"], u.deg),
+                _format_param_value(job_spec["apptainer_label"], "apptainer_label"),
+                _format_param_value(job_spec["primary"], "primary"),
+                _format_param_value(job_spec["azimuth_angle"], "azimuth_angle"),
+                _format_param_value(job_spec["zenith_angle"], "zenith_angle"),
                 energy_min_value,
                 energy_min_unit,
                 energy_max_value,
                 energy_max_unit,
-                _format_grid_value(job_spec["model_version"], None),
-                _format_grid_value(array_layout_name, None),
-                _format_grid_value(job_spec["corsika_le_interaction"], None),
-                _format_grid_value(job_spec["corsika_he_interaction"], None),
-                _format_grid_value(job_spec["run_number"], None),
+                _format_param_value(job_spec["model_version"], "model_version"),
+                _format_param_value(array_layout_name, "array_layout_name"),
+                _format_param_value(job_spec["corsika_le_interaction"], "corsika_le_interaction"),
+                _format_param_value(job_spec["corsika_he_interaction"], "corsika_he_interaction"),
+                _format_param_value(job_spec["run_number"], "run_number"),
                 job_spec["pack_for_grid_register"],
             ]
             params_file_handle.write(" ".join(row) + "\n")
@@ -280,7 +331,7 @@ def generate_submission_script(args_dict):
 
 def _get_submit_file(executable, apptainer_image, priority, params_file_name):
     """
-    Return HT Condor submit file.
+    Return HTCondor submit file.
 
     Database access variables are passed through the environment file.
 
@@ -298,22 +349,10 @@ def _get_submit_file(executable, apptainer_image, priority, params_file_name):
     Returns
     -------
     str
-        HT Condor submit file content.
+        HTCondor submit file content.
     """
-    arguments_string = (
-        "$(process) env.txt "
-        "$(apptainer_label) $(primary) $(azimuth_angle) $(zenith_angle) "
-        "$(energy_min_value) $(energy_min_unit) $(energy_max_value) $(energy_max_unit) "
-        "$(model_version) $(array_layout_name) "
-        "$(corsika_le_interaction) $(corsika_he_interaction) "
-        "$(run_number) $(pack_for_grid_register)"
-    )
-    queue_string = (
-        "apptainer_label,primary,azimuth_angle,zenith_angle,"
-        "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit,"
-        "model_version,array_layout_name,corsika_le_interaction,corsika_he_interaction,"
-        "run_number,pack_for_grid_register"
-    )
+    arguments_string = "$(process) env.txt " + " ".join(f"$({field})" for field in _PARAMS_FIELDS)
+    queue_string = ",".join(_PARAMS_FIELDS)
 
     return f"""universe = container
 container_image = {apptainer_image}
@@ -333,7 +372,7 @@ queue {queue_string} from {params_file_name}
 
 def _get_submit_script(args_dict):
     """
-    Return HT Condor submit script.
+    Return HTCondor submit script.
 
     Parameters
     ----------
@@ -343,19 +382,44 @@ def _get_submit_script(args_dict):
     Returns
     -------
     str
-        HT Condor submit script content.
+        HTCondor submit script content.
     """
-    azimuth_angle_string = '"$5"'
-    zenith_angle_string = '"$6"'
-    energy_range_string = '"$7 $8 $9 ${10}"'
+    # Map _PARAMS_FIELDS to bash positional indices ($3, $4, etc.)
+    # Indices 1-2 are reserved for: $1=process_id, $2=env_file
+    bash_indices = {}
+    for i, field in enumerate(_PARAMS_FIELDS):
+        idx = 3 + i
+        bash_indices[field] = f"${{{idx}}}"
+
     core_scatter = args_dict["core_scatter"]
     core_scatter_string = f'"{core_scatter[0]} {core_scatter[1].to(u.m).value} m"'
     view_cone = args_dict["view_cone"]
     view_cone_string = f'"{view_cone[0].to(u.deg)} {view_cone[1].to(u.deg)}"'
 
     label = args_dict["label"] if args_dict["label"] else "simulate-prod"
-
     run_number_offset = args_dict["run_number_offset"] or 1
+
+    azimuth_angle_idx = bash_indices["azimuth_angle"]
+    zenith_angle_idx = bash_indices["zenith_angle"]
+    energy_min_value_idx = bash_indices["energy_min_value"]
+    energy_min_unit_idx = bash_indices["energy_min_unit"]
+    energy_max_value_idx = bash_indices["energy_max_value"]
+    energy_max_unit_idx = bash_indices["energy_max_unit"]
+    model_version_idx = bash_indices["model_version"]
+    array_layout_name_idx = bash_indices["array_layout_name"]
+    corsika_le_interaction_idx = bash_indices["corsika_le_interaction"]
+    corsika_he_interaction_idx = bash_indices["corsika_he_interaction"]
+    run_number_idx = bash_indices["run_number"]
+    pack_for_grid_register_idx = bash_indices["pack_for_grid_register"]
+
+    energy_range_string = (
+        f'"{energy_min_value_idx} {energy_min_unit_idx} '
+        f'{energy_max_value_idx} {energy_max_unit_idx}"'
+    )
+    energy_range_tag = (
+        f"erange-{energy_min_value_idx}{energy_min_unit_idx}-"
+        f"{energy_max_value_idx}{energy_max_unit_idx}"
+    )
 
     return f"""#!/usr/bin/env bash
 
@@ -363,15 +427,15 @@ def _get_submit_script(args_dict):
 process_id="$1"
 # Load environment variables (for DB access)
 set -a; source "$2"
-apptainer_label="$3"
-primary="$4"
-model_version="${{11}}"
-array_layout_name="${{12}}"
-corsika_le_interaction="${{13}}"
-corsika_he_interaction="${{14}}"
-run_number="${{15}}"
-pack_for_grid_register="${{16}}"
-energy_range_tag="erange-$7$8-$9${{10}}"
+apptainer_label="{bash_indices["apptainer_label"]}"
+primary="{bash_indices["primary"]}"
+model_version="{model_version_idx}"
+array_layout_name="{array_layout_name_idx}"
+corsika_le_interaction="{corsika_le_interaction_idx}"
+corsika_he_interaction="{corsika_he_interaction_idx}"
+run_number="{run_number_idx}"
+pack_for_grid_register="{pack_for_grid_register_idx}"
+    energy_range_tag="{energy_range_tag}"
 job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
@@ -381,8 +445,8 @@ simtools-simulate-prod \\
     --site {args_dict["site"]} \\
     --array_layout_name "$array_layout_name" \\
     --primary "$primary" \\
-    --azimuth_angle {azimuth_angle_string} \\
-    --zenith_angle {zenith_angle_string} \\
+    --azimuth_angle "{azimuth_angle_idx}" \\
+    --zenith_angle "{zenith_angle_idx}" \\
     --nshow {args_dict["nshow"]} \\
     --energy_range {energy_range_string} \\
     --core_scatter {core_scatter_string} \\
@@ -391,6 +455,7 @@ simtools-simulate-prod \\
     --corsika_he_interaction "$corsika_he_interaction" \\
     --run_number "$run_number" \\
     --run_number_offset {run_number_offset} \\
+    --save_reduced_event_lists \\
     --output_path /tmp/simtools-output \\
     --log_level {args_dict["log_level"]} \\
     --pack_for_grid_register "$pack_for_grid_register"

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -11,11 +11,13 @@ Generates three files in the specified output directory:
 import ast
 import itertools
 import logging
+import re
 from pathlib import Path
 
 import astropy.units as u
 
 import simtools.version as simtools_version
+from simtools.configuration import defaults
 
 _logger = logging.getLogger(__name__)
 
@@ -27,6 +29,11 @@ _GRID_AXES = [
     "corsika_le_interaction",
     "corsika_he_interaction",
 ]
+
+_GRID_AXIS_DEFAULTS = {
+    "corsika_le_interaction": defaults.CORSIKA_LE_INTERACTION,
+    "corsika_he_interaction": defaults.CORSIKA_HE_INTERACTION,
+}
 
 _PARAMS_FIELDS = [
     "apptainer_label",
@@ -61,9 +68,13 @@ def _normalize_to_list(value):
 def _normalize_grid_axes(args_dict):
     """Return normalized grid axes for cartesian product expansion."""
     return {
-        axis: _normalize_to_list(args_dict[axis])
-        if axis in args_dict and args_dict[axis] is not None
-        else [None]
+        axis: (
+            _normalize_to_list(args_dict[axis])
+            if axis in args_dict and args_dict[axis] is not None
+            else [_GRID_AXIS_DEFAULTS[axis]]
+            if axis in _GRID_AXIS_DEFAULTS
+            else [None]
+        )
         for axis in _GRID_AXES
     }
 
@@ -136,6 +147,9 @@ def _format_param_value(value, field_name):
     if value is None:
         raise ValueError(f"Missing required value for field '{field_name}'.")
 
+    if field_name in ("apptainer_label", "pack_for_grid_register"):
+        return _sanitize_label_for_params(value)
+
     if field_name in ("energy_min_value", "energy_max_value"):
         return _format_quantity(value, default_unit=u.GeV)
 
@@ -158,6 +172,11 @@ def _sanitize_label_for_filename(label):
     """Sanitize image labels for use in file names."""
     label_string = str(label).strip().replace(" ", "_")
     return "".join(ch if ch.isalnum() or ch in ["-", "_", "."] else "_" for ch in label_string)
+
+
+def _sanitize_label_for_params(label):
+    """Sanitize image labels for whitespace-separated params files."""
+    return re.sub(r"\s+", "_", str(label).strip())
 
 
 def _resolve_array_layout_name(array_layout_name, model_version):
@@ -239,6 +258,7 @@ def _build_job_specs(args_dict, image_labels):
 
     job_specs = []
     for label in image_labels:
+        params_label = _sanitize_label_for_params(label)
         row_index = 0
         for (
             primary,
@@ -281,7 +301,7 @@ def _build_job_specs(args_dict, image_labels):
                         "energy_max": selected_energy_range_pair[1],
                         "core_scatter_max": selected_core_scatter_max,
                         "nshow": selected_nshow,
-                        "pack_for_grid_register": f"{base_pack_dir}/{label}",
+                        "pack_for_grid_register": f"{base_pack_dir}/{params_label}",
                         "run_number": run_number + row_index,
                     }
                 )

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -315,7 +315,7 @@ def _get_submit_script(args_dict):
     """
     azimuth_angle_string = '"$5"'
     zenith_angle_string = '"$6"'
-    energy_range_string = '"$7 $8 $9 $10"'
+    energy_range_string = '"$7 $8 $9 ${10}"'
     core_scatter = args_dict["core_scatter"]
     core_scatter_string = f'"{core_scatter[0]} {core_scatter[1].to(u.m).value} m"'
     view_cone = args_dict["view_cone"]
@@ -345,7 +345,7 @@ corsika_le_interaction="${{12}}"
 corsika_he_interaction="${{13}}"
 run_number="${{14}}"
 pack_for_grid_register="${{15}}"
-energy_range_tag="erange-$7$8-$9$10"
+energy_range_tag="erange-$7$8-$9${10}"
 job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -1,10 +1,13 @@
 """HT Condor script generator for simulation production."""
 
+import ast
 import itertools
 import logging
 from pathlib import Path
 
 import astropy.units as u
+
+import simtools.version as simtools_version
 
 _logger = logging.getLogger(__name__)
 
@@ -109,6 +112,30 @@ def _sanitize_label_for_filename(label):
     return "".join(ch if ch.isalnum() or ch in ["-", "_", "."] else "_" for ch in label_string)
 
 
+def _resolve_array_layout_name(array_layout_name, model_version):
+    """Resolve array layout configuration for a specific model version."""
+    if isinstance(array_layout_name, list) and len(array_layout_name) == 1:
+        array_layout_name = array_layout_name[0]
+
+    # Configurator/_fill_config stringifies dict values when rebuilding argparse arguments.
+    # Accept that serialized form so by_version mappings still resolve per model version.
+    if isinstance(array_layout_name, str) and array_layout_name.strip().startswith("{"):
+        try:
+            parsed_layout = ast.literal_eval(array_layout_name)
+            if isinstance(parsed_layout, dict):
+                array_layout_name = parsed_layout
+        except (SyntaxError, ValueError):
+            return array_layout_name
+
+    if not isinstance(array_layout_name, dict) or list(array_layout_name) != ["by_version"]:
+        return array_layout_name
+
+    resolved = simtools_version.resolve_by_version(
+        {"array_layout_name": array_layout_name}, model_version
+    )
+    return resolved["array_layout_name"]
+
+
 def _build_job_specs(args_dict, image_labels):
     """Build backend-agnostic job specs from comparison and production grids."""
     grid_axes = _normalize_grid_axes(args_dict)
@@ -150,6 +177,7 @@ def _build_job_specs(args_dict, image_labels):
                         "azimuth_angle": azimuth,
                         "zenith_angle": zenith,
                         "model_version": model_version,
+                        "array_layout_name": args_dict.get("array_layout_name"),
                         "corsika_le_interaction": corsika_le,
                         "corsika_he_interaction": corsika_he,
                         "energy_min": energy_range_pair[0],
@@ -175,6 +203,9 @@ def _write_params_file(params_file_path, label_job_specs):
     """Write params file consumed by HTCondor queue-from syntax."""
     with open(params_file_path, "w", encoding="utf-8") as params_file_handle:
         for job_spec in label_job_specs:
+            array_layout_name = _resolve_array_layout_name(
+                job_spec["array_layout_name"], job_spec["model_version"]
+            )
             energy_min_value, energy_min_unit = _format_quantity_value_and_unit(
                 job_spec["energy_min"], default_unit=u.GeV
             )
@@ -191,6 +222,7 @@ def _write_params_file(params_file_path, label_job_specs):
                 energy_max_value,
                 energy_max_unit,
                 _format_grid_value(job_spec["model_version"], None),
+                _format_grid_value(array_layout_name, None),
                 _format_grid_value(job_spec["corsika_le_interaction"], None),
                 _format_grid_value(job_spec["corsika_he_interaction"], None),
                 _format_grid_value(job_spec["run_number"], None),
@@ -272,14 +304,14 @@ def _get_submit_file(executable, apptainer_image, priority, params_file_name):
         "$(process) env.txt "
         "$(apptainer_label) $(primary) $(azimuth_angle) $(zenith_angle) "
         "$(energy_min_value) $(energy_min_unit) $(energy_max_value) $(energy_max_unit) "
-        "$(model_version) "
+        "$(model_version) $(array_layout_name) "
         "$(corsika_le_interaction) $(corsika_he_interaction) "
         "$(run_number) $(pack_for_grid_register)"
     )
     queue_string = (
         "apptainer_label,primary,azimuth_angle,zenith_angle,"
         "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit,"
-        "model_version,corsika_le_interaction,corsika_he_interaction,"
+        "model_version,array_layout_name,corsika_le_interaction,corsika_he_interaction,"
         "run_number,pack_for_grid_register"
     )
 
@@ -323,13 +355,6 @@ def _get_submit_script(args_dict):
 
     label = args_dict["label"] if args_dict["label"] else "simulate-prod"
 
-    array_layout_name = (
-        args_dict["array_layout_name"][0]
-        if isinstance(args_dict["array_layout_name"], list)
-        and len(args_dict["array_layout_name"]) == 1
-        else args_dict["array_layout_name"]
-    )
-
     run_number_offset = args_dict["run_number_offset"] or 1
 
     return f"""#!/usr/bin/env bash
@@ -341,10 +366,11 @@ set -a; source "$2"
 apptainer_label="$3"
 primary="$4"
 model_version="${{11}}"
-corsika_le_interaction="${{12}}"
-corsika_he_interaction="${{13}}"
-run_number="${{14}}"
-pack_for_grid_register="${{15}}"
+array_layout_name="${{12}}"
+corsika_le_interaction="${{13}}"
+corsika_he_interaction="${{14}}"
+run_number="${{15}}"
+pack_for_grid_register="${{16}}"
 energy_range_tag="erange-$7$8-$9${{10}}"
 job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
@@ -353,7 +379,7 @@ simtools-simulate-prod \\
     --label "$job_label" \\
     --model_version "$model_version" \\
     --site {args_dict["site"]} \\
-    --array_layout_name {array_layout_name} \\
+    --array_layout_name "$array_layout_name" \\
     --primary "$primary" \\
     --azimuth_angle {azimuth_angle_string} \\
     --zenith_angle {zenith_angle_string} \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -88,6 +88,21 @@ def _format_grid_value(value, unit):
     return f"{value}"
 
 
+def _format_quantity_value_and_unit(value, default_unit=None):
+    """Return quantity as separate value and unit strings for params files."""
+    if value is None:
+        if default_unit is None:
+            return "", ""
+        return "", f"{default_unit}"
+
+    if hasattr(value, "unit"):
+        return f"{value.value}", f"{value.unit}"
+
+    if default_unit is None:
+        return f"{value}", ""
+    return f"{value}", f"{default_unit}"
+
+
 def _sanitize_label_for_filename(label):
     """Sanitize image labels for use in file names."""
     label_string = str(label).strip().replace(" ", "_")
@@ -117,6 +132,7 @@ def _build_job_specs(args_dict, image_labels):
 
     job_specs = []
     for label in image_labels:
+        row_index = 0
         for (
             primary,
             azimuth,
@@ -126,7 +142,7 @@ def _build_job_specs(args_dict, image_labels):
             corsika_he,
             energy_range_pair,
         ) in combinations:
-            for run_index in range(number_of_runs):
+            for _ in range(number_of_runs):
                 job_specs.append(
                     {
                         "apptainer_label": str(label),
@@ -139,9 +155,10 @@ def _build_job_specs(args_dict, image_labels):
                         "energy_min": energy_range_pair[0],
                         "energy_max": energy_range_pair[1],
                         "pack_for_grid_register": f"{base_pack_dir}/{label}",
-                        "run_number": run_number + run_index,
+                        "run_number": run_number + row_index,
                     }
                 )
+                row_index += 1
     return job_specs
 
 
@@ -158,13 +175,21 @@ def _write_params_file(params_file_path, label_job_specs):
     """Write params file consumed by HTCondor queue-from syntax."""
     with open(params_file_path, "w", encoding="utf-8") as params_file_handle:
         for job_spec in label_job_specs:
+            energy_min_value, energy_min_unit = _format_quantity_value_and_unit(
+                job_spec["energy_min"], default_unit=u.GeV
+            )
+            energy_max_value, energy_max_unit = _format_quantity_value_and_unit(
+                job_spec["energy_max"], default_unit=u.GeV
+            )
             row = [
                 job_spec["apptainer_label"],
                 _format_grid_value(job_spec["primary"], None),
                 _format_grid_value(job_spec["azimuth_angle"], u.deg),
                 _format_grid_value(job_spec["zenith_angle"], u.deg),
-                _format_grid_value(job_spec["energy_min"], u.GeV),
-                _format_grid_value(job_spec["energy_max"], u.GeV),
+                energy_min_value,
+                energy_min_unit,
+                energy_max_value,
+                energy_max_unit,
                 _format_grid_value(job_spec["model_version"], None),
                 _format_grid_value(job_spec["corsika_le_interaction"], None),
                 _format_grid_value(job_spec["corsika_he_interaction"], None),
@@ -246,12 +271,14 @@ def _get_submit_file(executable, apptainer_image, priority, params_file_name):
     arguments_string = (
         "$(process) env.txt "
         "$(apptainer_label) $(primary) $(azimuth_angle) $(zenith_angle) "
-        "$(energy_min) $(energy_max) $(model_version) "
+        "$(energy_min_value) $(energy_min_unit) $(energy_max_value) $(energy_max_unit) "
+        "$(model_version) "
         "$(corsika_le_interaction) $(corsika_he_interaction) "
         "$(run_number) $(pack_for_grid_register)"
     )
     queue_string = (
-        "apptainer_label,primary,azimuth_angle,zenith_angle,energy_min,energy_max,"
+        "apptainer_label,primary,azimuth_angle,zenith_angle,"
+        "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit,"
         "model_version,corsika_le_interaction,corsika_he_interaction,"
         "run_number,pack_for_grid_register"
     )
@@ -288,7 +315,7 @@ def _get_submit_script(args_dict):
     """
     azimuth_angle_string = '"$5"'
     zenith_angle_string = '"$6"'
-    energy_range_string = '"$7 GeV $8 GeV"'
+    energy_range_string = '"$7 $8 $9 $10"'
     core_scatter = args_dict["core_scatter"]
     core_scatter_string = f'"{core_scatter[0]} {core_scatter[1].to(u.m).value} m"'
     view_cone = args_dict["view_cone"]
@@ -313,15 +340,17 @@ process_id="$1"
 set -a; source "$2"
 apptainer_label="$3"
 primary="$4"
-model_version="$9"
-corsika_le_interaction="${{10}}"
-corsika_he_interaction="${{11}}"
-run_number="${{12}}"
-pack_for_grid_register="${{13}}"
+model_version="${{11}}"
+corsika_le_interaction="${{12}}"
+corsika_he_interaction="${{13}}"
+run_number="${{14}}"
+pack_for_grid_register="${{15}}"
+energy_range_tag="erange-$7$8-$9$10"
+job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
     --simulation_software {args_dict["simulation_software"]} \\
-    --label {label} \\
+    --label "$job_label" \\
     --model_version "$model_version" \\
     --site {args_dict["site"]} \\
     --array_layout_name {array_layout_name} \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -37,6 +37,9 @@ _PARAMS_FIELDS = [
     "energy_min_unit",
     "energy_max_value",
     "energy_max_unit",
+    "core_scatter_max_value",
+    "core_scatter_max_unit",
+    "nshow",
     "model_version",
     "array_layout_name",
     "corsika_le_interaction",
@@ -96,61 +99,56 @@ def _resolve_apptainer_images(apptainer_image_arg):
     dict
         Dictionary mapping labels to resolved Path objects for apptainer images.
     """
-    if apptainer_image_arg is None:
+    if not apptainer_image_arg:
         raise ValueError("Missing required apptainer_image path.")
 
     if isinstance(apptainer_image_arg, str):
-        if not apptainer_image_arg.strip():
-            raise ValueError("Missing required apptainer_image path.")
-        image_path = Path(apptainer_image_arg)
+        apptainer_image_arg = {"default": apptainer_image_arg}
+
+    if not isinstance(apptainer_image_arg, dict):
+        raise TypeError("apptainer_image must be a string path or a label-to-path dictionary.")
+
+    resolved = {}
+    for label, path in apptainer_image_arg.items():
+        image_path = Path(path)
         if not image_path.is_file():
             raise FileNotFoundError(f"Apptainer image file not found: {image_path}")
-        return {"default": image_path}
+        resolved[str(label)] = image_path
 
-    if isinstance(apptainer_image_arg, dict):
-        resolved = {}
-        for label, path in apptainer_image_arg.items():
-            image_path = Path(path)
-            if not image_path.is_file():
-                raise FileNotFoundError(f"Apptainer image file not found: {image_path}")
-            resolved[str(label)] = image_path
-        if not resolved:
-            raise ValueError("At least one apptainer image label/path must be configured.")
-        return resolved
+    if not resolved:
+        raise ValueError("At least one apptainer image label/path must be configured.")
 
-    raise ValueError("apptainer_image must be either a string path or a label-to-path dictionary.")
+    return resolved
+
+
+def _format_quantity(value, default_unit=None, convert_to=None):
+    """Format scalar or Quantity value."""
+    if isinstance(value, u.Quantity):
+        if convert_to is not None:
+            value = value.to(convert_to)
+        return f"{value.value}", f"{value.unit}"
+
+    return f"{value}", str(default_unit) if default_unit else None
 
 
 def _format_param_value(value, field_name):
-    """
-    Format a value for params file output.
-
-    For energy fields, returns (value_str, unit_str) tuple.
-    For other fields, returns value_str.
-
-    Parameters
-    ----------
-    value : any
-        Value to format.
-    field_name : str
-        Field name to determine formatting and default units.
-
-    Returns
-    -------
-    str or tuple
-        Formatted value(s).
-    """
+    """Format a value or Quantity for params file output."""
     if value is None:
         raise ValueError(f"Missing required value for field '{field_name}'.")
 
     if field_name in ("energy_min_value", "energy_max_value"):
-        if isinstance(value, u.Quantity):
-            return f"{value.value}", f"{value.unit}"
-        return f"{value}", str(u.GeV)
+        return _format_quantity(value, default_unit=u.GeV)
+
+    if field_name == "core_scatter_max_value":
+        return _format_quantity(
+            value,
+            default_unit=u.m,
+            convert_to=u.m,
+        )
 
     if field_name in ("azimuth_angle", "zenith_angle"):
         if isinstance(value, u.Quantity):
-            return f"{value.to(u.deg).value}"
+            value = value.to(u.deg).value
         return f"{value}"
 
     return f"{value}"
@@ -185,11 +183,44 @@ def _resolve_array_layout_name(array_layout_name, model_version):
     return resolved["array_layout_name"]
 
 
+def _get_energy_range_for_zenith_angle(zenith_angle, energy_range_pair, corsika_limits):
+    """
+    Return a zenith-dependent energy range pair or None to skip the simulation step.
+
+    Dummy function - to be implemented.
+    """
+    _ = (zenith_angle, corsika_limits)
+    return energy_range_pair
+
+
+def _get_core_scatter_max_for_zenith_angle(zenith_angle, core_scatter, corsika_limits):
+    """Return zenith-dependent max core-scatter value.
+
+    Dummy function - to be implemented.
+    """
+    _ = (zenith_angle, corsika_limits)
+    return core_scatter[1]
+
+
+def _get_nshow_for_energy_range_and_zenith_angle(
+    energy_range_pair, zenith_angle, nshow, corsika_limits
+):
+    """Return nshow that may depend on energy range and zenith angle.
+
+    Dummy function - to be implemented.
+    """
+    _ = (energy_range_pair, zenith_angle, corsika_limits)
+    return nshow
+
+
 def _build_job_specs(args_dict, image_labels):
     """Build backend-agnostic job specs from comparison and production grids."""
     grid_axes = _normalize_grid_axes(args_dict)
     energy_ranges = _normalize_energy_ranges(args_dict["energy_range"])
     base_pack_dir = args_dict.get("simulation_output") or "simtools-output"
+    corsika_limits = args_dict.get("corsika_limits")
+    core_scatter = args_dict["core_scatter"]
+    nshow = args_dict["nshow"]
 
     combinations = list(
         itertools.product(
@@ -218,6 +249,23 @@ def _build_job_specs(args_dict, image_labels):
             corsika_he,
             energy_range_pair,
         ) in combinations:
+            selected_energy_range_pair = energy_range_pair
+            selected_core_scatter_max = core_scatter[1]
+            selected_nshow = nshow
+
+            if corsika_limits is not None:
+                selected_energy_range_pair = _get_energy_range_for_zenith_angle(
+                    zenith, energy_range_pair, corsika_limits
+                )
+                if selected_energy_range_pair is None:
+                    continue
+                selected_core_scatter_max = _get_core_scatter_max_for_zenith_angle(
+                    zenith, core_scatter, corsika_limits
+                )
+                selected_nshow = _get_nshow_for_energy_range_and_zenith_angle(
+                    selected_energy_range_pair, zenith, nshow, corsika_limits
+                )
+
             for _ in range(number_of_runs):
                 job_specs.append(
                     {
@@ -229,8 +277,10 @@ def _build_job_specs(args_dict, image_labels):
                         "array_layout_name": args_dict.get("array_layout_name"),
                         "corsika_le_interaction": corsika_le,
                         "corsika_he_interaction": corsika_he,
-                        "energy_min": energy_range_pair[0],
-                        "energy_max": energy_range_pair[1],
+                        "energy_min": selected_energy_range_pair[0],
+                        "energy_max": selected_energy_range_pair[1],
+                        "core_scatter_max": selected_core_scatter_max,
+                        "nshow": selected_nshow,
                         "pack_for_grid_register": f"{base_pack_dir}/{label}",
                         "run_number": run_number + row_index,
                     }
@@ -262,6 +312,9 @@ def _write_params_file(params_file_path, label_job_specs):
             energy_max_value, energy_max_unit = _format_param_value(
                 job_spec["energy_max"], "energy_max_value"
             )
+            core_scatter_max_value, core_scatter_max_unit = _format_param_value(
+                job_spec["core_scatter_max"], "core_scatter_max_value"
+            )
 
             row = [
                 _format_param_value(job_spec["apptainer_label"], "apptainer_label"),
@@ -272,6 +325,9 @@ def _write_params_file(params_file_path, label_job_specs):
                 energy_min_unit,
                 energy_max_value,
                 energy_max_unit,
+                core_scatter_max_value,
+                core_scatter_max_unit,
+                _format_param_value(job_spec["nshow"], "nshow"),
                 _format_param_value(job_spec["model_version"], "model_version"),
                 _format_param_value(array_layout_name, "array_layout_name"),
                 _format_param_value(job_spec["corsika_le_interaction"], "corsika_le_interaction"),
@@ -411,7 +467,7 @@ def _get_submit_script(args_dict):
         bash_indices[field] = f"${{{idx}}}"
 
     core_scatter = args_dict["core_scatter"]
-    core_scatter_string = f'"{core_scatter[0]} {core_scatter[1].to(u.m).value} m"'
+    n_core_scatter = core_scatter[0]
     view_cone = args_dict["view_cone"]
     view_cone_string = f'"{view_cone[0].to(u.deg)} {view_cone[1].to(u.deg)}"'
 
@@ -424,6 +480,9 @@ def _get_submit_script(args_dict):
     energy_min_unit_idx = bash_indices["energy_min_unit"]
     energy_max_value_idx = bash_indices["energy_max_value"]
     energy_max_unit_idx = bash_indices["energy_max_unit"]
+    core_scatter_max_value_idx = bash_indices["core_scatter_max_value"]
+    core_scatter_max_unit_idx = bash_indices["core_scatter_max_unit"]
+    nshow_idx = bash_indices["nshow"]
     model_version_idx = bash_indices["model_version"]
     array_layout_name_idx = bash_indices["array_layout_name"]
     corsika_le_interaction_idx = bash_indices["corsika_le_interaction"]
@@ -434,6 +493,9 @@ def _get_submit_script(args_dict):
     energy_range_string = (
         f'"{energy_min_value_idx} {energy_min_unit_idx} '
         f'{energy_max_value_idx} {energy_max_unit_idx}"'
+    )
+    core_scatter_string = (
+        f'"{n_core_scatter} {core_scatter_max_value_idx} {core_scatter_max_unit_idx}"'
     )
     energy_range_tag = (
         f"erange-{energy_min_value_idx}{energy_min_unit_idx}-"
@@ -466,7 +528,7 @@ simtools-simulate-prod \\
     --primary "$primary" \\
     --azimuth_angle "{azimuth_angle_idx}" \\
     --zenith_angle "{zenith_angle_idx}" \\
-    --nshow {args_dict["nshow"]} \\
+    --nshow "{nshow_idx}" \\
     --energy_range {energy_range_string} \\
     --core_scatter {core_scatter_string} \\
     --view_cone {view_cone_string} \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -1,11 +1,177 @@
 """HT Condor script generator for simulation production."""
 
+import itertools
 import logging
 from pathlib import Path
 
 import astropy.units as u
 
 _logger = logging.getLogger(__name__)
+
+_GRID_AXES = [
+    "primary",
+    "azimuth_angle",
+    "zenith_angle",
+    "model_version",
+    "corsika_le_interaction",
+    "corsika_he_interaction",
+]
+
+
+def _normalize_to_list(value):
+    """Normalize scalar values to lists of length one."""
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _normalize_grid_axes(args_dict):
+    """Return normalized grid axes for cartesian product expansion."""
+    normalized = {}
+    for axis in _GRID_AXES:
+        if axis in args_dict and args_dict[axis] is not None:
+            normalized[axis] = _normalize_to_list(args_dict[axis])
+        else:
+            normalized[axis] = [None]
+    return normalized
+
+
+def _normalize_energy_ranges(energy_range):
+    """Normalize energy range argument to a list of (emin, emax) pairs."""
+    if isinstance(energy_range, tuple) and len(energy_range) == 2:
+        return [energy_range]
+
+    if isinstance(energy_range, list):
+        if len(energy_range) == 2 and all(hasattr(item, "to") for item in energy_range):
+            return [(energy_range[0], energy_range[1])]
+        if all(isinstance(item, (list, tuple)) and len(item) == 2 for item in energy_range):
+            return [tuple(item) for item in energy_range]
+
+    raise ValueError("energy_range must be one pair (emin, emax) or a list of (emin, emax) pairs.")
+
+
+def _resolve_apptainer_images(apptainer_image_arg):
+    """Resolve and validate apptainer image configuration."""
+    if apptainer_image_arg is None:
+        raise ValueError("Missing required apptainer_image path.")
+
+    if isinstance(apptainer_image_arg, str):
+        if not apptainer_image_arg.strip():
+            raise ValueError("Missing required apptainer_image path.")
+        image_path = Path(apptainer_image_arg)
+        if not image_path.is_file():
+            raise FileNotFoundError(f"Apptainer image file not found: {image_path}")
+        return {"default": image_path}
+
+    if isinstance(apptainer_image_arg, dict):
+        resolved = {}
+        for label, path in apptainer_image_arg.items():
+            image_path = Path(path)
+            if not image_path.is_file():
+                raise FileNotFoundError(f"Apptainer image file not found: {image_path}")
+            resolved[str(label)] = image_path
+        if not resolved:
+            raise ValueError("At least one apptainer image label/path must be configured.")
+        return resolved
+
+    raise ValueError("apptainer_image must be either a string path or a label-to-path dictionary.")
+
+
+def _format_grid_value(value, unit):
+    """Format scalar values for params files with stable unit conversion."""
+    if value is None:
+        return ""
+    if hasattr(value, "to"):
+        return f"{value.to(unit).value}"
+    return f"{value}"
+
+
+def _sanitize_label_for_filename(label):
+    """Sanitize image labels for use in file names."""
+    label_string = str(label).strip().replace(" ", "_")
+    return "".join(ch if ch.isalnum() or ch in ["-", "_", "."] else "_" for ch in label_string)
+
+
+def _build_job_specs(args_dict, image_labels):
+    """Build backend-agnostic job specs from comparison and production grids."""
+    grid_axes = _normalize_grid_axes(args_dict)
+    energy_ranges = _normalize_energy_ranges(args_dict["energy_range"])
+    base_pack_dir = args_dict.get("pack_for_grid_register") or "simtools-output"
+
+    combinations = list(
+        itertools.product(
+            grid_axes["primary"],
+            grid_axes["azimuth_angle"],
+            grid_axes["zenith_angle"],
+            grid_axes["model_version"],
+            grid_axes["corsika_le_interaction"],
+            grid_axes["corsika_he_interaction"],
+            energy_ranges,
+        )
+    )
+
+    number_of_runs = args_dict.get("number_of_runs", 1)
+    run_number = int(args_dict.get("run_number") or 1)
+
+    job_specs = []
+    for label in image_labels:
+        for (
+            primary,
+            azimuth,
+            zenith,
+            model_version,
+            corsika_le,
+            corsika_he,
+            energy_range_pair,
+        ) in combinations:
+            for run_index in range(number_of_runs):
+                job_specs.append(
+                    {
+                        "apptainer_label": str(label),
+                        "primary": primary,
+                        "azimuth_angle": azimuth,
+                        "zenith_angle": zenith,
+                        "model_version": model_version,
+                        "corsika_le_interaction": corsika_le,
+                        "corsika_he_interaction": corsika_he,
+                        "energy_min": energy_range_pair[0],
+                        "energy_max": energy_range_pair[1],
+                        "pack_for_grid_register": f"{base_pack_dir}/{label}",
+                        "run_number": run_number + run_index,
+                    }
+                )
+    return job_specs
+
+
+def _group_job_specs_by_label(job_specs):
+    """Group job specs by apptainer image label."""
+    grouped = {}
+    for job_spec in job_specs:
+        label = job_spec["apptainer_label"]
+        grouped.setdefault(label, []).append(job_spec)
+    return grouped
+
+
+def _write_params_file(params_file_path, label_job_specs):
+    """Write params file consumed by HTCondor queue-from syntax."""
+    with open(params_file_path, "w", encoding="utf-8") as params_file_handle:
+        for job_spec in label_job_specs:
+            row = [
+                job_spec["apptainer_label"],
+                _format_grid_value(job_spec["primary"], None),
+                _format_grid_value(job_spec["azimuth_angle"], u.deg),
+                _format_grid_value(job_spec["zenith_angle"], u.deg),
+                _format_grid_value(job_spec["energy_min"], u.GeV),
+                _format_grid_value(job_spec["energy_max"], u.GeV),
+                _format_grid_value(job_spec["model_version"], None),
+                _format_grid_value(job_spec["corsika_le_interaction"], None),
+                _format_grid_value(job_spec["corsika_he_interaction"], None),
+                _format_grid_value(job_spec["run_number"], None),
+                job_spec["pack_for_grid_register"],
+            ]
+            params_file_handle.write(" ".join(row) + "\n")
 
 
 def generate_submission_script(args_dict):
@@ -17,15 +183,9 @@ def generate_submission_script(args_dict):
     args_dict: dict
         Arguments dictionary.
     """
-    apptainer_image_arg = args_dict["apptainer_image"]
-    if apptainer_image_arg is None or (
-        isinstance(apptainer_image_arg, str) and not apptainer_image_arg.strip()
-    ):
-        raise ValueError("Missing required apptainer_image path.")
-
-    apptainer_image = Path(apptainer_image_arg)
-    if not apptainer_image.is_file():
-        raise FileNotFoundError(f"Apptainer image file not found: {apptainer_image}")
+    apptainer_images = _resolve_apptainer_images(args_dict["apptainer_image"])
+    job_specs = _build_job_specs(args_dict, list(apptainer_images.keys()))
+    grouped_job_specs = _group_job_specs_by_label(job_specs)
 
     work_dir = Path(args_dict["output_path"])
     log_dir = work_dir / "logs"
@@ -34,15 +194,26 @@ def generate_submission_script(args_dict):
     submit_file_name = "simulate_prod.submit"
     _logger.info(f"Generating HT Condor submission scripts (path: {work_dir})")
 
-    with open(work_dir / f"{submit_file_name}.condor", "w", encoding="utf-8") as submit_file_handle:
-        submit_file_handle.write(
-            _get_submit_file(
-                f"{submit_file_name}.sh",
-                apptainer_image,
-                args_dict["priority"],
-                +args_dict["number_of_runs"],
-            )
+    for label, label_job_specs in grouped_job_specs.items():
+        suffix = (
+            ""
+            if len(grouped_job_specs) == 1 and label == "default"
+            else f".{_sanitize_label_for_filename(label)}"
         )
+        condor_file_name = f"{submit_file_name}{suffix}.condor"
+        params_file_name = f"{submit_file_name}{suffix}.params.txt"
+
+        _write_params_file(work_dir / params_file_name, label_job_specs)
+
+        with open(work_dir / condor_file_name, "w", encoding="utf-8") as submit_file_handle:
+            submit_file_handle.write(
+                _get_submit_file(
+                    f"{submit_file_name}.sh",
+                    apptainer_images[label],
+                    args_dict["priority"],
+                    params_file_name,
+                )
+            )
 
     with open(work_dir / f"{submit_file_name}.sh", "w", encoding="utf-8") as submit_script_handle:
         submit_script_handle.write(_get_submit_script(args_dict))
@@ -50,7 +221,7 @@ def generate_submission_script(args_dict):
     Path(work_dir / f"{submit_file_name}.sh").chmod(0o755)
 
 
-def _get_submit_file(executable, apptainer_image, priority, n_jobs):
+def _get_submit_file(executable, apptainer_image, priority, params_file_name):
     """
     Return HT Condor submit file.
 
@@ -64,14 +235,27 @@ def _get_submit_file(executable, apptainer_image, priority, n_jobs):
         Path to the Apptainer image.
     priority: int
         Priority of the job.
-    n_jobs: int
-        Number of jobs to queue.
+    params_file_name: str
+        Name of the params file for queue-from submission.
 
     Returns
     -------
     str
         HT Condor submit file content.
     """
+    arguments_string = (
+        "$(process) env.txt "
+        "$(apptainer_label) $(primary) $(azimuth_angle) $(zenith_angle) "
+        "$(energy_min) $(energy_max) $(model_version) "
+        "$(corsika_le_interaction) $(corsika_he_interaction) "
+        "$(run_number) $(pack_for_grid_register)"
+    )
+    queue_string = (
+        "apptainer_label,primary,azimuth_angle,zenith_angle,energy_min,energy_max,"
+        "model_version,corsika_le_interaction,corsika_he_interaction,"
+        "run_number,pack_for_grid_register"
+    )
+
     return f"""universe = container
 container_image = {apptainer_image}
 transfer_container = false
@@ -82,9 +266,9 @@ output     = logs/out.$(cluster)_$(process)
 log        = logs/log.$(cluster)_$(process)
 
 priority = {priority}
-arguments = "$(process) env.txt"
+arguments = "{arguments_string}"
 
-queue {n_jobs}
+queue {queue_string} from {params_file_name}
 """
 
 
@@ -102,12 +286,9 @@ def _get_submit_script(args_dict):
     str
         HT Condor submit script content.
     """
-    azimuth_angle_string = f"{args_dict['azimuth_angle'].to(u.deg).value}"
-    zenith_angle_string = f"{args_dict['zenith_angle'].to(u.deg).value}"
-    energy_range = args_dict["energy_range"]
-    energy_range_string = (
-        f'"{energy_range[0].to(u.GeV).value} GeV {energy_range[1].to(u.GeV).value} GeV"'
-    )
+    azimuth_angle_string = '"$5"'
+    zenith_angle_string = '"$6"'
+    energy_range_string = '"$7 GeV $8 GeV"'
     core_scatter = args_dict["core_scatter"]
     core_scatter_string = f'"{core_scatter[0]} {core_scatter[1].to(u.m).value} m"'
     view_cone = args_dict["view_cone"]
@@ -130,23 +311,32 @@ def _get_submit_script(args_dict):
 process_id="$1"
 # Load environment variables (for DB access)
 set -a; source "$2"
+apptainer_label="$3"
+primary="$4"
+model_version="$9"
+corsika_le_interaction="${{10}}"
+corsika_he_interaction="${{11}}"
+run_number="${{12}}"
+pack_for_grid_register="${{13}}"
 
 simtools-simulate-prod \\
     --simulation_software {args_dict["simulation_software"]} \\
     --label {label} \\
-    --model_version {args_dict["model_version"]} \\
+    --model_version "$model_version" \\
     --site {args_dict["site"]} \\
     --array_layout_name {array_layout_name} \\
-    --primary {args_dict["primary"]} \\
+    --primary "$primary" \\
     --azimuth_angle {azimuth_angle_string} \\
     --zenith_angle {zenith_angle_string} \\
     --nshow {args_dict["nshow"]} \\
     --energy_range {energy_range_string} \\
     --core_scatter {core_scatter_string} \\
     --view_cone {view_cone_string} \\
-    --run_number $((process_id)) \\
+    --corsika_le_interaction "$corsika_le_interaction" \\
+    --corsika_he_interaction "$corsika_he_interaction" \\
+    --run_number "$run_number" \\
     --run_number_offset {run_number_offset} \\
     --output_path /tmp/simtools-output \\
     --log_level {args_dict["log_level"]} \\
-    --pack_for_grid_register simtools-output
+    --pack_for_grid_register "$pack_for_grid_register"
 """

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -472,7 +472,8 @@ def _get_submit_script(args_dict):
     view_cone_string = f'"{view_cone[0].to(u.deg)} {view_cone[1].to(u.deg)}"'
 
     label = args_dict["label"] if args_dict["label"] else "simulate-prod"
-    run_number_offset = args_dict["run_number_offset"] or 1
+    run_number_offset_arg = args_dict["run_number_offset"]
+    run_number_offset = 0 if run_number_offset_arg is None else run_number_offset_arg
 
     azimuth_angle_idx = bash_indices["azimuth_angle"]
     zenith_angle_idx = bash_indices["zenith_angle"]

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -345,7 +345,7 @@ corsika_le_interaction="${{12}}"
 corsika_he_interaction="${{13}}"
 run_number="${{14}}"
 pack_for_grid_register="${{15}}"
-energy_range_tag="erange-$7$8-$9${10}"
+energy_range_tag="erange-$7$8-$9${{10}}"
 job_label="{label}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -353,7 +353,7 @@ def _write_params_file(params_file_path, label_job_specs):
                 _format_param_value(job_spec["corsika_le_interaction"], "corsika_le_interaction"),
                 _format_param_value(job_spec["corsika_he_interaction"], "corsika_he_interaction"),
                 _format_param_value(job_spec["run_number"], "run_number"),
-                job_spec["pack_for_grid_register"],
+                _format_param_value(job_spec["pack_for_grid_register"], "pack_for_grid_register"),
             ]
             params_file_handle.write(" ".join(row) + "\n")
 

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_north.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_north.yml
@@ -30,6 +30,8 @@ applications:
   - test_output_files:
     - file: simulate_prod.submit.condor
       path_descriptor: output_path
+    - file: simulate_prod.submit.params.txt
+      path_descriptor: output_path
     - file: simulate_prod.submit.sh
       path_descriptor: output_path
   test_name: htcondor-gamma_20_deg_north

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
@@ -15,7 +15,7 @@ applications:
     core_scatter: 10 500 m
     corsika_he_interaction:
     - epos
-    - qgsjet
+    - qgs3
     corsika_le_interaction: urqmd
     energy_range:
     - 30 GeV 30 GeV

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
@@ -10,7 +10,9 @@ applications:
     - North
     - South
     core_scatter: 10 500 m
-    corsika_he_interaction: epos
+    corsika_he_interaction:
+    - epos
+    - qgsjet
     corsika_le_interaction: urqmd
     energy_range:
     - 30 GeV 30 GeV
@@ -25,7 +27,9 @@ applications:
     nshow: 5
     number_of_runs: 2
     output_path: htcondor_submit
-    primary: gamma
+    primary:
+    - gamma
+    - proton
     priority: 5
     run_number: 10
     simulation_software: corsika_sim_telarray

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
@@ -5,7 +5,10 @@ applications:
     apptainer_image:
       0.30.0: tests/resources/dummy_apptainer_image.sif
       0.29.0: tests/resources/dummy_apptainer_image.sif
-    array_layout_name: CTAO-North-Alpha
+    array_layout_name:
+      by_version:
+        "<7.0.0": alpha
+        ">=7.0.0": CTAO-North-Alpha
     azimuth_angle:
     - North
     - South

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
@@ -1,0 +1,50 @@
+---
+applications:
+- application: simtools-simulate-prod-htcondor-generator
+  configuration:
+    apptainer_image:
+      0.30.0: tests/resources/dummy_apptainer_image.sif
+      0.29.0: tests/resources/dummy_apptainer_image.sif
+    array_layout_name: CTAO-North-Alpha
+    azimuth_angle:
+    - North
+    - South
+    core_scatter: 10 500 m
+    corsika_he_interaction: epos
+    corsika_le_interaction: urqmd
+    energy_range:
+    - 30 GeV 30 GeV
+    - 300 GeV 300 GeV
+    view_cone: 0 deg 10 deg
+    eslope: -2.0
+    label: test-production-grid
+    log_level: DEBUG
+    model_version:
+    - 6.3.0
+    - 7.0.0
+    nshow: 5
+    number_of_runs: 2
+    output_path: htcondor_submit
+    primary: gamma
+    priority: 5
+    run_number: 10
+    simulation_software: corsika_sim_telarray
+    site: North
+    zenith_angle:
+    - 20
+    - 40
+  integration_tests:
+  - test_output_files:
+    - file: simulate_prod.submit.0.30.0.condor
+      path_descriptor: output_path
+    - file: simulate_prod.submit.0.30.0.params.txt
+      path_descriptor: output_path
+    - file: simulate_prod.submit.0.29.0.condor
+      path_descriptor: output_path
+    - file: simulate_prod.submit.0.29.0.params.txt
+      path_descriptor: output_path
+    - file: simulate_prod.submit.sh
+      path_descriptor: output_path
+  test_name: htcondor-grid-example
+schema_name: application_workflow.metaschema
+schema_version: 0.4.0

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml
@@ -35,6 +35,7 @@ applications:
     - proton
     priority: 5
     run_number: 10
+    simulation_output: ./simulation_output_path
     simulation_software: corsika_sim_telarray
     site: North
     zenith_angle:

--- a/tests/unit_tests/applications/test_simulate_prod_htcondor_generator.py
+++ b/tests/unit_tests/applications/test_simulate_prod_htcondor_generator.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python3
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import simtools.applications.simulate_prod_htcondor_generator as app
+
+
+@patch(
+    "simtools.applications.simulate_prod_htcondor_generator.htcondor_script_generator.generate_submission_script"
+)
+@patch("simtools.applications.simulate_prod_htcondor_generator.build_application")
+def test_main_uses_standard_build_application(
+    mock_build_application, mock_generate_submission_script
+):
+    mock_build_application.return_value = SimpleNamespace(args={"output_path": "htcondor_submit"})
+
+    app.main()
+
+    assert mock_build_application.call_args.kwargs["initialization_kwargs"] == {
+        "db_config": False,
+        "preserve_by_version_keys": ["array_layout_name"],
+        "simulation_model": ["site", "layout", "telescope", "model_version"],
+        "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
+    }
+    mock_generate_submission_script.assert_called_once_with({"output_path": "htcondor_submit"})

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -268,16 +268,22 @@ def test_initialize_default_arguments_accepts_figure_format():
     assert args.figure_format == ["png", "pdf"]
 
 
-def test_initialize_default_arguments_accepts_apptainer_image_dict():
+def test_initialize_default_arguments_accepts_apptainer_image_dict(tmp_test_directory):
     parser_with_defaults = parser.CommandLineParser()
     parser_with_defaults.initialize_default_arguments()
 
+    image_v7 = tmp_test_directory / "v7.sif"
+    image_v63 = tmp_test_directory / "v63.sif"
+
     args = parser_with_defaults.parse_args(
-        ["--apptainer_image", "{'7.0.0': '/tmp/v7.sif', '6.3.0': '/tmp/v63.sif'}"]
+        [
+            "--apptainer_image",
+            f"{{'7.0.0': '{image_v7}', '6.3.0': '{image_v63}'}}",
+        ]
     )
 
     assert isinstance(args.apptainer_image, dict)
-    assert args.apptainer_image == {"7.0.0": "/tmp/v7.sif", "6.3.0": "/tmp/v63.sif"}
+    assert args.apptainer_image == {"7.0.0": str(image_v7), "6.3.0": str(image_v63)}
 
 
 def test_initialize_application_arguments():

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -783,6 +783,12 @@ def test_quantity_pair_action():
     assert_quantity_allclose(args.energy_range[0], 50 * u.GeV)
     assert_quantity_allclose(args.energy_range[1], 5 * u.TeV)
 
+    # Test unquoted token stream from the shell
+    args = test_parser.parse_args(["--energy_range", "30", "GeV", "300", "GeV"])
+    assert len(args.energy_range) == 2
+    assert_quantity_allclose(args.energy_range[0], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1], 300 * u.GeV)
+
     # Test multiple pair strings (list of pairs)
     args = test_parser.parse_args(["--energy_range", "30 GeV 30 GeV", "300 GeV 300 GeV"])
     assert len(args.energy_range) == 2

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -268,6 +268,18 @@ def test_initialize_default_arguments_accepts_figure_format():
     assert args.figure_format == ["png", "pdf"]
 
 
+def test_initialize_default_arguments_accepts_apptainer_image_dict():
+    parser_with_defaults = parser.CommandLineParser()
+    parser_with_defaults.initialize_default_arguments()
+
+    args = parser_with_defaults.parse_args(
+        ["--apptainer_image", "{'7.0.0': '/tmp/v7.sif', '6.3.0': '/tmp/v63.sif'}"]
+    )
+
+    assert isinstance(args.apptainer_image, dict)
+    assert args.apptainer_image == {"7.0.0": "/tmp/v7.sif", "6.3.0": "/tmp/v63.sif"}
+
+
 def test_initialize_application_arguments():
     app_parser = parser.CommandLineParser()
     app_parser.initialize_application_arguments(
@@ -458,6 +470,99 @@ def test_simulation_configuration_uses_defaults_for_optional_arguments():
     assert args.run_number == 1
 
 
+def test_simulation_configuration_accepts_grid_list_values():
+    test_parser = parser.CommandLineParser()
+    test_parser.initialize_default_arguments(
+        simulation_configuration={
+            "software": None,
+            "corsika_configuration": [
+                "primary",
+                "azimuth_angle",
+                "zenith_angle",
+                "corsika_le_interaction",
+                "corsika_he_interaction",
+            ],
+        }
+    )
+
+    args = test_parser.parse_args(
+        [
+            "--primary",
+            "gamma",
+            "proton",
+            "--azimuth_angle",
+            "north",
+            "south",
+            "--zenith_angle",
+            "20",
+            "40",
+            "--corsika_le_interaction",
+            "urqmd",
+            "fluka",
+            "--corsika_he_interaction",
+            "epos",
+            "qgsjet",
+        ]
+    )
+
+    assert args.primary == ["gamma", "proton"]
+    assert_quantity_allclose(args.azimuth_angle[0], 0 * u.deg)
+    assert_quantity_allclose(args.azimuth_angle[1], 180 * u.deg)
+    assert_quantity_allclose(args.zenith_angle[0], 20 * u.deg)
+    assert_quantity_allclose(args.zenith_angle[1], 40 * u.deg)
+    assert args.corsika_le_interaction == ["urqmd", "fluka"]
+    assert args.corsika_he_interaction == ["epos", "qgsjet"]
+
+
+def test_simulation_configuration_accepts_energy_range_list_pair():
+    test_parser = parser.CommandLineParser()
+    test_parser.initialize_default_arguments(
+        simulation_configuration={
+            "software": None,
+            "corsika_configuration": ["primary", "energy_range"],
+        }
+    )
+
+    args = test_parser.parse_args(
+        [
+            "--primary",
+            "gamma",
+            "--energy_range",
+            "30 GeV",
+            "300 GeV",
+        ]
+    )
+
+    assert_quantity_allclose(args.energy_range[0], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1], 300 * u.GeV)
+
+
+def test_simulation_configuration_accepts_energy_range_list_of_pairs():
+    test_parser = parser.CommandLineParser()
+    test_parser.initialize_default_arguments(
+        simulation_configuration={
+            "software": None,
+            "corsika_configuration": ["primary", "energy_range"],
+        }
+    )
+
+    args = test_parser.parse_args(
+        [
+            "--primary",
+            "gamma",
+            "--energy_range",
+            "30 GeV 30 GeV",
+            "300 GeV 300 GeV",
+        ]
+    )
+
+    assert len(args.energy_range) == 2
+    assert_quantity_allclose(args.energy_range[0][0], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[0][1], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1][0], 300 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1][1], 300 * u.GeV)
+
+
 def test_initialize_db_config_arguments_strip_string():
     parser_10 = parser.CommandLineParser()
     parser_10.initialize_db_config_arguments()
@@ -484,6 +589,8 @@ def test_get_dictionary_with_corsika_configuration(mocker):
     assert "helium" in corsika_config["primary"]["help"]
     assert "iron" in corsika_config["primary"]["help"]
     assert corsika_config["primary"]["type"] is str.lower
+    assert corsika_config["primary"]["action"] is parser.OneOrManyAction
+    assert corsika_config["primary"]["nargs"] == "+"
     assert corsika_config["primary"]["required"] is True
 
     # Test the "primary_id_type" key
@@ -499,12 +606,16 @@ def test_get_dictionary_with_corsika_configuration(mocker):
         "Telescope pointing direction in azimuth."
     )
     assert corsika_config["azimuth_angle"]["type"] == parser.CommandLineParser.azimuth_angle
+    assert corsika_config["azimuth_angle"]["action"] is parser.OneOrManyAction
+    assert corsika_config["azimuth_angle"]["nargs"] == "+"
     assert corsika_config["azimuth_angle"]["default"] == 0 * u.deg
 
     # Test the "zenith_angle" key
     assert "zenith_angle" in corsika_config
     assert corsika_config["zenith_angle"]["help"] == "Zenith angle in degrees (between 0 and 180)."
     assert corsika_config["zenith_angle"]["type"] == parser.CommandLineParser.zenith_angle
+    assert corsika_config["zenith_angle"]["action"] is parser.OneOrManyAction
+    assert corsika_config["zenith_angle"]["nargs"] == "+"
     assert corsika_config["zenith_angle"]["default"] == 20 * u.deg
 
     # Test the "nshow" key

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -701,3 +701,86 @@ def test_bounded_int():
 
     with pytest.raises(ValueError, match=r"1001 not in \[100,1000\]"):
         bounded_int_checker_large(1001)
+
+
+def test_string_or_dict():
+    """Test CommandLineParser.string_or_dict parsing."""
+    # Test plain string
+    assert parser.CommandLineParser.string_or_dict("plain_string") == "plain_string"
+
+    # Test string that looks like a dict but is invalid
+    assert parser.CommandLineParser.string_or_dict("{invalid}") == "{invalid}"
+
+    # Test valid dict string
+    dict_str = "{'key1': 'value1', 'key2': 'value2'}"
+    result = parser.CommandLineParser.string_or_dict(dict_str)
+    assert isinstance(result, dict)
+    assert result == {"key1": "value1", "key2": "value2"}
+
+    # Test valid dict string with numbers
+    dict_str_nums = "{'1.0': '/path/v1.sif', '2.0': '/path/v2.sif'}"
+    result = parser.CommandLineParser.string_or_dict(dict_str_nums)
+    assert isinstance(result, dict)
+    assert result == {"1.0": "/path/v1.sif", "2.0": "/path/v2.sif"}
+
+    # Test non-string input (should return as-is)
+    test_dict = {"already": "dict"}
+    assert parser.CommandLineParser.string_or_dict(test_dict) == test_dict
+
+    # Test whitespace handling
+    dict_str_spaces = "  {'a': 'b'}  "
+    result = parser.CommandLineParser.string_or_dict(dict_str_spaces)
+    assert isinstance(result, dict)
+    assert result == {"a": "b"}
+
+
+def test_one_or_many_action():
+    """Test OneOrManyAction stores single value as scalar and multiple as list."""
+    test_parser = parser.CommandLineParser()
+    test_parser.initialize_default_arguments(
+        simulation_configuration={
+            "software": None,
+            "corsika_configuration": ["primary"],
+        }
+    )
+
+    # Test single value (should be scalar, not list)
+    args = test_parser.parse_args(["--primary", "gamma"])
+    assert args.primary == "gamma"
+    assert isinstance(args.primary, str)
+
+    # Test multiple values (should be list)
+    args = test_parser.parse_args(["--primary", "gamma", "proton"])
+    assert args.primary == ["gamma", "proton"]
+    assert isinstance(args.primary, list)
+
+
+def test_quantity_pair_action():
+    """Test QuantityPairAction parses energy ranges correctly."""
+    test_parser = parser.CommandLineParser()
+    test_parser.initialize_default_arguments(
+        simulation_configuration={
+            "software": None,
+            "corsika_configuration": ["energy_range"],
+        }
+    )
+
+    # Test single pair string (two quantities with units in one string)
+    args = test_parser.parse_args(["--energy_range", "30 GeV 300 GeV"])
+    assert len(args.energy_range) == 2
+    assert_quantity_allclose(args.energy_range[0], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1], 300 * u.GeV)
+
+    # Test two separate quantity values
+    args = test_parser.parse_args(["--energy_range", "50 GeV", "5 TeV"])
+    assert len(args.energy_range) == 2
+    assert_quantity_allclose(args.energy_range[0], 50 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1], 5 * u.TeV)
+
+    # Test multiple pair strings (list of pairs)
+    args = test_parser.parse_args(["--energy_range", "30 GeV 30 GeV", "300 GeV 300 GeV"])
+    assert len(args.energy_range) == 2
+    assert_quantity_allclose(args.energy_range[0][0], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[0][1], 30 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1][0], 300 * u.GeV)
+    assert_quantity_allclose(args.energy_range[1][1], 300 * u.GeV)

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -82,6 +82,42 @@ def test_config_file_applies_when_no_command_line(tmp_test_directory, monkeypatc
     assert config["log_level"] == "debug"
 
 
+def test_config_from_file_preserves_selected_by_version_keys(tmp_test_directory):
+    config_dict = {
+        "applications": [
+            {
+                "application": "simtools-simulate-prod-htcondor-generator",
+                "configuration": {
+                    "model_version": ["6.3.0", "7.0.0"],
+                    "array_layout_name": {
+                        "by_version": {
+                            "<7.0.0": "alpha",
+                            ">=7.0.0": "CTAO-North-Alpha",
+                        }
+                    },
+                },
+            }
+        ]
+    }
+    config_file = tmp_test_directory / "configuration-preserve-by-version.yml"
+    with open(config_file, "w", encoding="utf-8") as output:
+        yaml.safe_dump(config_dict, output, sort_keys=False)
+
+    config_builder = Configurator()
+    loaded_config = config_builder._config_from_file(
+        config_file,
+        preserve_by_version_keys=["array_layout_name"],
+    )
+
+    assert loaded_config["model_version"] == ["6.3.0", "7.0.0"]
+    assert loaded_config["array_layout_name"] == {
+        "by_version": {
+            "<7.0.0": "alpha",
+            ">=7.0.0": "CTAO-North-Alpha",
+        }
+    }
+
+
 def test_initialize_io_handler(configurator, tmp_test_directory):
     # io_handler is a Singleton, so configurator changes should
     # be reflected in the io_handler

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -95,7 +95,7 @@ corsika_le_interaction="${{12}}"
 corsika_he_interaction="${{13}}"
 run_number="${{14}}"
 pack_for_grid_register="${{15}}"
-energy_range_tag="erange-$7$8-$9$10"
+energy_range_tag="erange-$7$8-$9${10}"
 job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
@@ -108,7 +108,7 @@ simtools-simulate-prod \\
     --azimuth_angle "$5" \\
     --zenith_angle "$6" \\
     --nshow {args_dict["nshow"]} \\
-    --energy_range "$7 $8 $9 $10" \
+    --energy_range "$7 $8 $9 ${10}" \
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
     --corsika_le_interaction "$corsika_le_interaction" \\

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -91,10 +91,11 @@ set -a; source "$2"
 apptainer_label="$3"
 primary="$4"
 model_version="${{11}}"
-corsika_le_interaction="${{12}}"
-corsika_he_interaction="${{13}}"
-run_number="${{14}}"
-pack_for_grid_register="${{15}}"
+array_layout_name="${{12}}"
+corsika_le_interaction="${{13}}"
+corsika_he_interaction="${{14}}"
+run_number="${{15}}"
+pack_for_grid_register="${{16}}"
 energy_range_tag="erange-$7$8-$9${{10}}"
 job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
@@ -103,7 +104,7 @@ simtools-simulate-prod \\
     --label "$job_label" \\
     --model_version "$model_version" \\
     --site {args_dict["site"]} \\
-    --array_layout_name {args_dict["array_layout_name"]} \\
+    --array_layout_name "$array_layout_name" \\
     --primary "$primary" \\
     --azimuth_angle "$5" \\
     --zenith_angle "$6" \\
@@ -133,6 +134,7 @@ def test_get_submit_file_uses_queue_from_params():
 
     assert "queue apptainer_label,primary" in content
     assert "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit" in content
+    assert "model_version,array_layout_name,corsika_le_interaction" in content
     assert "from simulate_prod.submit.params.txt" in content
     assert 'arguments = "$(process) env.txt' in content
 
@@ -183,6 +185,52 @@ def test_build_job_specs_increments_run_number(args_dict):
     assert run_numbers == [10, 11, 12, 13]
 
 
+def test_write_params_file_resolves_array_layout_name_by_model_version(
+    args_dict, tmp_test_directory
+):
+    args_dict["number_of_runs"] = 1
+    args_dict["model_version"] = ["6.3.0", "7.0.0"]
+    args_dict["array_layout_name"] = {
+        "by_version": {
+            "<7.0.0": "alpha",
+            ">=7.0.0": "CTAO-North-Alpha",
+        }
+    }
+
+    params_file_path = Path(tmp_test_directory) / "params.txt"
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+
+    _write_params_file(params_file_path, job_specs)
+
+    params_lines = params_file_path.read_text(encoding="utf-8").splitlines()
+
+    assert "6.3.0 alpha urqmd epos 1 simtools-output/7.0.0" in params_lines[0]
+    assert "7.0.0 CTAO-North-Alpha urqmd epos 2 simtools-output/7.0.0" in params_lines[1]
+
+
+def test_write_params_file_resolves_stringified_by_version_layout(args_dict, tmp_test_directory):
+    args_dict["number_of_runs"] = 1
+    args_dict["model_version"] = ["6.3.0", "7.0.0"]
+    args_dict["array_layout_name"] = str(
+        {
+            "by_version": {
+                "<7.0.0": "alpha",
+                ">=7.0.0": "CTAO-North-Alpha",
+            }
+        }
+    )
+
+    params_file_path = Path(tmp_test_directory) / "params.txt"
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+
+    _write_params_file(params_file_path, job_specs)
+
+    params_lines = params_file_path.read_text(encoding="utf-8").splitlines()
+
+    assert "6.3.0 alpha urqmd epos 1 simtools-output/7.0.0" in params_lines[0]
+    assert "7.0.0 CTAO-North-Alpha urqmd epos 2 simtools-output/7.0.0" in params_lines[1]
+
+
 def test_write_params_file_keeps_energy_units(tmp_test_directory):
     params_file_path = Path(tmp_test_directory) / "params.txt"
     label_job_specs = [
@@ -194,6 +242,12 @@ def test_write_params_file_keeps_energy_units(tmp_test_directory):
             "energy_min": 30 * u.GeV,
             "energy_max": 10 * u.TeV,
             "model_version": "7.0.0",
+            "array_layout_name": {
+                "by_version": {
+                    "<7.0.0": "alpha",
+                    ">=7.0.0": "CTAO-North-Alpha",
+                }
+            },
             "corsika_le_interaction": "urqmd",
             "corsika_he_interaction": "epos",
             "run_number": 10,
@@ -204,5 +258,5 @@ def test_write_params_file_keeps_energy_units(tmp_test_directory):
     _write_params_file(params_file_path, label_job_specs)
 
     assert params_file_path.read_text(encoding="utf-8") == (
-        "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 7.0.0 urqmd epos 10 simtools-output/7.0.0\n"
+        "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 7.0.0 CTAO-North-Alpha urqmd epos 10 simtools-output/7.0.0\n"
     )

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -5,7 +5,10 @@ import astropy.units as u
 import pytest
 
 from simtools.job_execution.htcondor_script_generator import (
+    _build_job_specs,
+    _get_submit_file,
     _get_submit_script,
+    _resolve_apptainer_images,
     generate_submission_script,
 )
 
@@ -32,6 +35,9 @@ def args_dict():
         "run_number": 1,
         "number_of_runs": 10,
         "log_level": "INFO",
+        "pack_for_grid_register": "simtools-output",
+        "corsika_le_interaction": "urqmd",
+        "corsika_he_interaction": "epos",
     }
 
 
@@ -50,6 +56,7 @@ def test_generate_submission_script(mock_is_file, mock_chmod, mock_open, mock_mk
 
     # Check if files are created and written
     mock_open.assert_any_call(work_dir / f"{submit_file_name}.condor", "w", encoding="utf-8")
+    mock_open.assert_any_call(work_dir / f"{submit_file_name}.params.txt", "w", encoding="utf-8")
     mock_open.assert_any_call(work_dir / f"{submit_file_name}.sh", "w", encoding="utf-8")
 
     # Check if chmod is called
@@ -69,9 +76,6 @@ def test_generate_submission_script_raises_for_missing_apptainer_image(
 
 
 def test_get_submit_script(args_dict):
-    # Use abbreviated argument names to avoid overly long lines
-    e_range_low = args_dict["energy_range"][0].to(u.GeV).value
-    e_range_high = args_dict["energy_range"][1].to(u.GeV).value
     core_scatter_low = args_dict["core_scatter"][0]
     core_scatter_high = args_dict["core_scatter"][1].to(u.m).value
     view_cone_low = args_dict["view_cone"][0].to(u.deg).value
@@ -83,25 +87,92 @@ def test_get_submit_script(args_dict):
 process_id="$1"
 # Load environment variables (for DB access)
 set -a; source "$2"
+apptainer_label="$3"
+primary="$4"
+model_version="$9"
+corsika_le_interaction="${{10}}"
+corsika_he_interaction="${{11}}"
+run_number="${{12}}"
+pack_for_grid_register="${{13}}"
 
 simtools-simulate-prod \\
     --simulation_software {args_dict["simulation_software"]} \\
     --label {args_dict["label"]} \\
-    --model_version {args_dict["model_version"]} \\
+    --model_version "$model_version" \\
     --site {args_dict["site"]} \\
     --array_layout_name {args_dict["array_layout_name"]} \\
-    --primary {args_dict["primary"]} \\
-    --azimuth_angle {args_dict["azimuth_angle"].to(u.deg).value} \\
-    --zenith_angle {args_dict["zenith_angle"].to(u.deg).value} \\
+    --primary "$primary" \\
+    --azimuth_angle "$5" \\
+    --zenith_angle "$6" \\
     --nshow {args_dict["nshow"]} \\
-    --energy_range "{e_range_low} GeV {e_range_high} GeV" \\
+    --energy_range "$7 GeV $8 GeV" \\
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
-    --run_number $((process_id)) \\
+    --corsika_le_interaction "$corsika_le_interaction" \\
+    --corsika_he_interaction "$corsika_he_interaction" \\
+    --run_number "$run_number" \\
     --run_number_offset {args_dict["run_number_offset"]} \\
     --output_path /tmp/simtools-output \\
     --log_level {args_dict["log_level"]} \\
-    --pack_for_grid_register simtools-output
+    --pack_for_grid_register "$pack_for_grid_register"
 """
     generated_script = _get_submit_script(args_dict)
     assert generated_script == expected_script
+
+
+def test_get_submit_file_uses_queue_from_params():
+    content = _get_submit_file(
+        executable="simulate_prod.submit.sh",
+        apptainer_image=Path("/tmp/image.sif"),
+        priority=1,
+        params_file_name="simulate_prod.submit.params.txt",
+    )
+
+    assert "queue apptainer_label,primary" in content
+    assert "from simulate_prod.submit.params.txt" in content
+    assert 'arguments = "$(process) env.txt' in content
+
+
+@mock.patch("simtools.job_execution.htcondor_script_generator.Path.is_file", return_value=True)
+def test_resolve_apptainer_images_dict(mock_is_file):
+    images = _resolve_apptainer_images({"7.0.0": "/tmp/v7.sif", "6.3.0": "/tmp/v63.sif"})
+
+    assert set(images.keys()) == {"7.0.0", "6.3.0"}
+    assert mock_is_file.call_count == 2
+
+
+def test_build_job_specs_expands_model_version_list(args_dict):
+    args_dict["model_version"] = ["6.3.0", "7.0.0"]
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+    model_versions = {job_spec["model_version"] for job_spec in job_specs}
+
+    assert model_versions == {"6.3.0", "7.0.0"}
+    assert len(job_specs) == 2 * args_dict["number_of_runs"]
+
+
+def test_build_job_specs_expands_energy_range_list_of_pairs(args_dict):
+    args_dict["number_of_runs"] = 1
+    args_dict["energy_range"] = [
+        (30 * u.GeV, 30 * u.GeV),
+        (300 * u.GeV, 300 * u.GeV),
+    ]
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+    energy_pairs = {(job_spec["energy_min"], job_spec["energy_max"]) for job_spec in job_specs}
+
+    assert len(job_specs) == 2
+    assert energy_pairs == {
+        (30 * u.GeV, 30 * u.GeV),
+        (300 * u.GeV, 300 * u.GeV),
+    }
+
+
+def test_build_job_specs_increments_run_number(args_dict):
+    args_dict["number_of_runs"] = 2
+    args_dict["run_number"] = 10
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+    run_numbers = sorted({job_spec["run_number"] for job_spec in job_specs})
+
+    assert run_numbers == [10, 11]

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -95,7 +95,7 @@ corsika_le_interaction="${{12}}"
 corsika_he_interaction="${{13}}"
 run_number="${{14}}"
 pack_for_grid_register="${{15}}"
-energy_range_tag="erange-$7$8-$9${10}"
+energy_range_tag="erange-$7$8-$9${{10}}"
 job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
@@ -108,7 +108,7 @@ simtools-simulate-prod \\
     --azimuth_angle "$5" \\
     --zenith_angle "$6" \\
     --nshow {args_dict["nshow"]} \\
-    --energy_range "$7 $8 $9 ${10}" \
+    --energy_range "$7 $8 $9 ${{10}}" \\
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
     --corsika_le_interaction "$corsika_le_interaction" \\

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -81,6 +81,7 @@ def test_get_submit_script(args_dict):
     core_scatter_high = args_dict["core_scatter"][1].to(u.m).value
     view_cone_low = args_dict["view_cone"][0].to(u.deg).value
     view_cone_high = args_dict["view_cone"][1].to(u.deg).value
+    container_output_path = str(Path("/", "tmp", "simtools-output"))
 
     expected_script = f"""#!/usr/bin/env bash
 
@@ -88,15 +89,15 @@ def test_get_submit_script(args_dict):
 process_id="$1"
 # Load environment variables (for DB access)
 set -a; source "$2"
-apptainer_label="$3"
-primary="$4"
+apptainer_label="${{3}}"
+primary="${{4}}"
 model_version="${{11}}"
 array_layout_name="${{12}}"
 corsika_le_interaction="${{13}}"
 corsika_he_interaction="${{14}}"
 run_number="${{15}}"
 pack_for_grid_register="${{16}}"
-energy_range_tag="erange-$7$8-$9${{10}}"
+energy_range_tag="erange-${{7}}${{8}}-${{9}}${{10}}"
 job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
@@ -106,17 +107,18 @@ simtools-simulate-prod \\
     --site {args_dict["site"]} \\
     --array_layout_name "$array_layout_name" \\
     --primary "$primary" \\
-    --azimuth_angle "$5" \\
-    --zenith_angle "$6" \\
+    --azimuth_angle "${{5}}" \\
+    --zenith_angle "${{6}}" \\
     --nshow {args_dict["nshow"]} \\
-    --energy_range "$7 $8 $9 ${{10}}" \\
+    --energy_range "${{7}} ${{8}} ${{9}} ${{10}}" \\
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
     --corsika_le_interaction "$corsika_le_interaction" \\
     --corsika_he_interaction "$corsika_he_interaction" \\
     --run_number "$run_number" \\
     --run_number_offset {args_dict["run_number_offset"]} \\
-    --output_path /tmp/simtools-output \\
+    --save_reduced_event_lists \\
+    --output_path {container_output_path} \\
     --log_level {args_dict["log_level"]} \\
     --pack_for_grid_register "$pack_for_grid_register"
 """
@@ -124,10 +126,11 @@ simtools-simulate-prod \\
     assert generated_script == expected_script
 
 
-def test_get_submit_file_uses_queue_from_params():
+def test_get_submit_file_uses_queue_from_params(tmp_test_directory):
+    apptainer_image = Path(tmp_test_directory) / "image.sif"
     content = _get_submit_file(
         executable="simulate_prod.submit.sh",
-        apptainer_image=Path("/tmp/image.sif"),
+        apptainer_image=apptainer_image,
         priority=1,
         params_file_name="simulate_prod.submit.params.txt",
     )
@@ -140,8 +143,13 @@ def test_get_submit_file_uses_queue_from_params():
 
 
 @mock.patch("simtools.job_execution.htcondor_script_generator.Path.is_file", return_value=True)
-def test_resolve_apptainer_images_dict(mock_is_file):
-    images = _resolve_apptainer_images({"7.0.0": "/tmp/v7.sif", "6.3.0": "/tmp/v63.sif"})
+def test_resolve_apptainer_images_dict(mock_is_file, tmp_test_directory):
+    images = _resolve_apptainer_images(
+        {
+            "7.0.0": str(Path(tmp_test_directory) / "v7.sif"),
+            "6.3.0": str(Path(tmp_test_directory) / "v63.sif"),
+        }
+    )
 
     assert set(images.keys()) == {"7.0.0", "6.3.0"}
     assert mock_is_file.call_count == 2

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -9,6 +9,7 @@ from simtools.job_execution.htcondor_script_generator import (
     _get_submit_file,
     _get_submit_script,
     _resolve_apptainer_images,
+    _write_params_file,
     generate_submission_script,
 )
 
@@ -89,15 +90,17 @@ process_id="$1"
 set -a; source "$2"
 apptainer_label="$3"
 primary="$4"
-model_version="$9"
-corsika_le_interaction="${{10}}"
-corsika_he_interaction="${{11}}"
-run_number="${{12}}"
-pack_for_grid_register="${{13}}"
+model_version="${{11}}"
+corsika_le_interaction="${{12}}"
+corsika_he_interaction="${{13}}"
+run_number="${{14}}"
+pack_for_grid_register="${{15}}"
+energy_range_tag="erange-$7$8-$9$10"
+job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
 simtools-simulate-prod \\
     --simulation_software {args_dict["simulation_software"]} \\
-    --label {args_dict["label"]} \\
+    --label "$job_label" \\
     --model_version "$model_version" \\
     --site {args_dict["site"]} \\
     --array_layout_name {args_dict["array_layout_name"]} \\
@@ -105,7 +108,7 @@ simtools-simulate-prod \\
     --azimuth_angle "$5" \\
     --zenith_angle "$6" \\
     --nshow {args_dict["nshow"]} \\
-    --energy_range "$7 GeV $8 GeV" \\
+    --energy_range "$7 $8 $9 $10" \
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
     --corsika_le_interaction "$corsika_le_interaction" \\
@@ -129,6 +132,7 @@ def test_get_submit_file_uses_queue_from_params():
     )
 
     assert "queue apptainer_label,primary" in content
+    assert "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit" in content
     assert "from simulate_prod.submit.params.txt" in content
     assert 'arguments = "$(process) env.txt' in content
 
@@ -171,8 +175,34 @@ def test_build_job_specs_expands_energy_range_list_of_pairs(args_dict):
 def test_build_job_specs_increments_run_number(args_dict):
     args_dict["number_of_runs"] = 2
     args_dict["run_number"] = 10
+    args_dict["model_version"] = ["6.3.0", "7.0.0"]
 
     job_specs = _build_job_specs(args_dict, ["7.0.0"])
-    run_numbers = sorted({job_spec["run_number"] for job_spec in job_specs})
+    run_numbers = [job_spec["run_number"] for job_spec in job_specs]
 
-    assert run_numbers == [10, 11]
+    assert run_numbers == [10, 11, 12, 13]
+
+
+def test_write_params_file_keeps_energy_units(tmp_test_directory):
+    params_file_path = Path(tmp_test_directory) / "params.txt"
+    label_job_specs = [
+        {
+            "apptainer_label": "7.0.0",
+            "primary": "gamma",
+            "azimuth_angle": 0 * u.deg,
+            "zenith_angle": 20 * u.deg,
+            "energy_min": 30 * u.GeV,
+            "energy_max": 10 * u.TeV,
+            "model_version": "7.0.0",
+            "corsika_le_interaction": "urqmd",
+            "corsika_he_interaction": "epos",
+            "run_number": 10,
+            "pack_for_grid_register": "simtools-output/7.0.0",
+        }
+    ]
+
+    _write_params_file(params_file_path, label_job_specs)
+
+    assert params_file_path.read_text(encoding="utf-8") == (
+        "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 7.0.0 urqmd epos 10 simtools-output/7.0.0\n"
+    )

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -6,9 +6,11 @@ import pytest
 
 from simtools.job_execution.htcondor_script_generator import (
     _build_job_specs,
+    _format_quantity,
     _get_submit_file,
     _get_submit_script,
     _resolve_apptainer_images,
+    _sanitize_label_for_filename,
     _write_params_file,
     generate_submission_script,
 )
@@ -77,8 +79,7 @@ def test_generate_submission_script_raises_for_missing_apptainer_image(
 
 
 def test_get_submit_script(args_dict):
-    core_scatter_low = args_dict["core_scatter"][0]
-    core_scatter_high = args_dict["core_scatter"][1].to(u.m).value
+    n_core_scatter = args_dict["core_scatter"][0]
     view_cone_low = args_dict["view_cone"][0].to(u.deg).value
     view_cone_high = args_dict["view_cone"][1].to(u.deg).value
     container_output_path = str(Path("/", "tmp", "simtools-output"))
@@ -91,12 +92,12 @@ process_id="$1"
 set -a; source "$2"
 apptainer_label="${{3}}"
 primary="${{4}}"
-model_version="${{11}}"
-array_layout_name="${{12}}"
-corsika_le_interaction="${{13}}"
-corsika_he_interaction="${{14}}"
-run_number="${{15}}"
-pack_for_grid_register="${{16}}"
+model_version="${{14}}"
+array_layout_name="${{15}}"
+corsika_le_interaction="${{16}}"
+corsika_he_interaction="${{17}}"
+run_number="${{18}}"
+pack_for_grid_register="${{19}}"
 energy_range_tag="erange-${{7}}${{8}}-${{9}}${{10}}"
 job_label="{args_dict["label"]}_${{corsika_he_interaction}}-${{corsika_le_interaction}}_${{energy_range_tag}}"
 
@@ -109,9 +110,9 @@ simtools-simulate-prod \\
     --primary "$primary" \\
     --azimuth_angle "${{5}}" \\
     --zenith_angle "${{6}}" \\
-    --nshow {args_dict["nshow"]} \\
+    --nshow "${{13}}" \\
     --energy_range "${{7}} ${{8}} ${{9}} ${{10}}" \\
-    --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
+    --core_scatter "{n_core_scatter} ${{11}} ${{12}}" \\
     --view_cone "{view_cone_low} deg {view_cone_high} deg" \\
     --corsika_le_interaction "$corsika_le_interaction" \\
     --corsika_he_interaction "$corsika_he_interaction" \\
@@ -143,6 +144,8 @@ def test_get_submit_file_uses_queue_from_params(tmp_test_directory):
 
     assert "queue apptainer_label,primary" in content
     assert "energy_min_value,energy_min_unit,energy_max_value,energy_max_unit" in content
+    assert "core_scatter_max_value,core_scatter_max_unit" in content
+    assert "nshow,model_version,array_layout_name" in content
     assert "model_version,array_layout_name,corsika_le_interaction" in content
     assert "from simulate_prod.submit.params.txt" in content
     assert 'arguments = "$(process) env.txt' in content
@@ -162,6 +165,68 @@ def test_resolve_apptainer_images_dict(mock_is_file, tmp_test_directory):
 
     assert set(images.keys()) == {"7.0.0", "6.3.0"}
     assert mock_is_file.call_count == 2
+
+
+def test_resolve_apptainer_images_string(tmp_test_directory):
+    image_path = Path(tmp_test_directory) / "image.sif"
+    image_path.touch()
+
+    images = _resolve_apptainer_images(str(image_path))
+
+    assert images == {"default": image_path}
+
+
+def test_resolve_apptainer_images_none():
+    with pytest.raises(ValueError, match="Missing required apptainer_image path"):
+        _resolve_apptainer_images(None)
+
+
+def test_resolve_apptainer_images_blank_string():
+    with pytest.raises(FileNotFoundError, match="Apptainer image file not found"):
+        _resolve_apptainer_images("   ")
+
+
+def test_resolve_apptainer_images_empty_dict():
+    with pytest.raises(ValueError, match="Missing required apptainer_image path"):
+        _resolve_apptainer_images({})
+
+
+def test_resolve_apptainer_images_invalid_type():
+    with pytest.raises(
+        TypeError, match="apptainer_image must be a string path or a label-to-path dictionary"
+    ):
+        _resolve_apptainer_images(["/tmp/image.sif"])
+
+
+def test_resolve_apptainer_images_raises_for_missing_file(tmp_test_directory):
+    missing_path = Path(tmp_test_directory) / "missing.sif"
+
+    with pytest.raises(FileNotFoundError, match="Apptainer image file not found"):
+        _resolve_apptainer_images(str(missing_path))
+
+
+def test_format_quantity_full_coverage():
+    value, unit = _format_quantity(5 * u.TeV)
+    assert float(value) == pytest.approx(5.0)
+    assert unit == "TeV"
+
+    value, unit = _format_quantity(100 * u.cm, convert_to=u.m)
+    assert float(value) == pytest.approx(1.0)
+    assert unit == "m"
+
+    value, unit = _format_quantity(42, default_unit=u.GeV)
+    assert value == "42"
+    assert unit == "GeV"
+
+    value, unit = _format_quantity("abc")
+    assert value == "abc"
+    assert unit is None
+
+
+def test_sanitize_label_for_filename():
+    assert _sanitize_label_for_filename("  my label:7/0*0?  ") == "my_label_7_0_0_"
+    assert _sanitize_label_for_filename("v7.0.0-beta_1") == "v7.0.0-beta_1"
+    assert _sanitize_label_for_filename(42) == "42"
 
 
 def test_build_job_specs_expands_model_version_list(args_dict):
@@ -258,6 +323,8 @@ def test_write_params_file_keeps_energy_units(tmp_test_directory):
             "zenith_angle": 20 * u.deg,
             "energy_min": 30 * u.GeV,
             "energy_max": 10 * u.TeV,
+            "core_scatter_max": 200 * u.m,
+            "nshow": 1000,
             "model_version": "7.0.0",
             "array_layout_name": {
                 "by_version": {
@@ -275,5 +342,35 @@ def test_write_params_file_keeps_energy_units(tmp_test_directory):
     _write_params_file(params_file_path, label_job_specs)
 
     assert params_file_path.read_text(encoding="utf-8") == (
-        "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 7.0.0 CTAO-North-Alpha urqmd epos 10 simtools-output/7.0.0\n"
+        "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 200.0 m "
+        "1000 7.0.0 CTAO-North-Alpha urqmd epos 10 simtools-output/7.0.0\n"
     )
+
+
+@mock.patch(
+    "simtools.job_execution.htcondor_script_generator._get_energy_range_for_zenith_angle",
+    return_value=None,
+)
+def test_build_job_specs_skips_entries_when_energy_range_is_none(mock_energy_range, args_dict):
+    args_dict["corsika_limits"] = "limits.ecsv"
+    args_dict["number_of_runs"] = 1
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+
+    assert job_specs == []
+    mock_energy_range.assert_called_once()
+
+
+@mock.patch(
+    "simtools.job_execution.htcondor_script_generator._get_nshow_for_energy_range_and_zenith_angle",
+    return_value=777,
+)
+def test_build_job_specs_uses_dummy_nshow_when_corsika_limits_set(mock_nshow, args_dict):
+    args_dict["corsika_limits"] = "limits.ecsv"
+    args_dict["number_of_runs"] = 1
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+
+    assert len(job_specs) == 1
+    assert job_specs[0]["nshow"] == 777
+    mock_nshow.assert_called_once()

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -128,11 +128,17 @@ simtools-simulate-prod \\
 
 def test_get_submit_file_uses_queue_from_params(tmp_test_directory):
     apptainer_image = Path(tmp_test_directory) / "image.sif"
+    log_dir = Path(tmp_test_directory) / "htcondor_logs" / "log"
+    error_dir = Path(tmp_test_directory) / "htcondor_logs" / "error"
+    output_dir = Path(tmp_test_directory) / "htcondor_logs" / "output"
     content = _get_submit_file(
         executable="simulate_prod.submit.sh",
         apptainer_image=apptainer_image,
         priority=1,
         params_file_name="simulate_prod.submit.params.txt",
+        log_dir=log_dir,
+        error_dir=error_dir,
+        output_dir=output_dir,
     )
 
     assert "queue apptainer_label,primary" in content
@@ -140,6 +146,9 @@ def test_get_submit_file_uses_queue_from_params(tmp_test_directory):
     assert "model_version,array_layout_name,corsika_le_interaction" in content
     assert "from simulate_prod.submit.params.txt" in content
     assert 'arguments = "$(process) env.txt' in content
+    assert str(log_dir) in content
+    assert str(error_dir) in content
+    assert str(output_dir) in content
 
 
 @mock.patch("simtools.job_execution.htcondor_script_generator.Path.is_file", return_value=True)

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -191,11 +191,11 @@ def test_resolve_apptainer_images_empty_dict():
         _resolve_apptainer_images({})
 
 
-def test_resolve_apptainer_images_invalid_type():
+def test_resolve_apptainer_images_invalid_type(tmp_test_directory):
     with pytest.raises(
         TypeError, match="apptainer_image must be a string path or a label-to-path dictionary"
     ):
-        _resolve_apptainer_images(["/tmp/image.sif"])
+        _resolve_apptainer_images([str(Path(tmp_test_directory) / "tmp/image.sif")])
 
 
 def test_resolve_apptainer_images_raises_for_missing_file(tmp_test_directory):
@@ -254,6 +254,16 @@ def test_build_job_specs_expands_energy_range_list_of_pairs(args_dict):
         (30 * u.GeV, 30 * u.GeV),
         (300 * u.GeV, 300 * u.GeV),
     }
+
+
+def test_build_job_specs_uses_default_interaction_models_when_missing(args_dict):
+    args_dict.pop("corsika_le_interaction")
+    args_dict.pop("corsika_he_interaction")
+
+    job_specs = _build_job_specs(args_dict, ["7.0.0"])
+
+    assert {job_spec["corsika_le_interaction"] for job_spec in job_specs} == {"urqmd"}
+    assert {job_spec["corsika_he_interaction"] for job_spec in job_specs} == {"epos"}
 
 
 def test_build_job_specs_increments_run_number(args_dict):
@@ -344,6 +354,35 @@ def test_write_params_file_keeps_energy_units(tmp_test_directory):
     assert params_file_path.read_text(encoding="utf-8") == (
         "7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 200.0 m "
         "1000 7.0.0 CTAO-North-Alpha urqmd epos 10 simtools-output/7.0.0\n"
+    )
+
+
+def test_write_params_file_replaces_whitespace_in_apptainer_label(tmp_test_directory):
+    params_file_path = Path(tmp_test_directory) / "params.txt"
+    label_job_specs = [
+        {
+            "apptainer_label": "grid label 7.0.0",
+            "primary": "gamma",
+            "azimuth_angle": 0 * u.deg,
+            "zenith_angle": 20 * u.deg,
+            "energy_min": 30 * u.GeV,
+            "energy_max": 10 * u.TeV,
+            "core_scatter_max": 200 * u.m,
+            "nshow": 1000,
+            "model_version": "7.0.0",
+            "array_layout_name": "CTAO-North-Alpha",
+            "corsika_le_interaction": "urqmd",
+            "corsika_he_interaction": "epos",
+            "run_number": 10,
+            "pack_for_grid_register": "simtools-output/grid label 7.0.0",
+        }
+    ]
+
+    _write_params_file(params_file_path, label_job_specs)
+
+    assert params_file_path.read_text(encoding="utf-8") == (
+        "grid_label_7.0.0 gamma 0.0 20.0 30.0 GeV 10.0 TeV 200.0 m "
+        "1000 7.0.0 CTAO-North-Alpha urqmd epos 10 simtools-output/grid_label_7.0.0\n"
     )
 
 


### PR DESCRIPTION
First step for long-integration tests: allow to generate job configurations for a parameter grid

Add grid-style HTCondor submission support to `simtools-simulate-prod-htcondor-generator`.

This change expands selected production and comparison parameters into a `params.txt` file, writes HTCondor submit files that queue from those params, and updates the submit script to consume per-job values from HTCondor arguments instead of hardcoded values.

## What Changed

- allow grid axes such as `primary`, `azimuth_angle`, `zenith_angle`, `model_version`, and interaction models to be provided as lists
- support `apptainer_image` as either a single image path or a label-to-image mapping
- generate one HTCondor params file row per expanded job and one condor file per apptainer label
- pass job-specific values, including resolved `array_layout_name`, through the params file into the submit script
- preserve energy units in the params file and forward them correctly to `simtools-simulate-prod`
- add unit and integration coverage for parser behavior and HTCondor grid generation
- added dummy functions to allow for integration of reading corsika limit from file and apply energy/zenith angle dependent core scatter limits and number of events

## Example Config

See the grid example in:

`tests/integration_tests/config/simulate_prod_htcondor_generator_grid_example.yml`

This is related to the discussion [here](https://notes.desy.de/fwpE1ug_TyusSP0RN2cIxA?view) (section 1).