### PR TITLE
Eventdata file input as glob pattern

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,6 +102,7 @@ pytest --no-cov tests/integration_tests/    # Integration tests
 - Fixtures: shared in `tests/conftest.py`, module-specific at top of file
 - Use `tmp_test_directory` fixture for file I/O (NOT `tmp_path`)
 - Mock external dependencies (DB, file I/O, network)
+- Never use direct `==` checks for floats or quantities in tests
 - Use `pytest.approx()` for float comparisons
 - Use `astropy.tests.helper.assert_quantity_allclose` for units
 
@@ -145,6 +146,7 @@ pylint src/simtools/model/       # Check module
 - Validate names with `simtools.utils.names` functions
 - Use semantic versions without "v" prefix ("1.0.0", not "v1.0.0")
 - Do not use **type hints** on function signatures
+- Keep function cognitive complexity below 15 by extracting private helpers before adding more branches, loops, or mixed responsibilities
 
 **Docstrings (MANDATORY):** NumPy style with Parameters, Returns, Raises, Examples sections. 70%+ coverage required for all public functions/methods. Private functions can have single-line docstring if self-explanatory.
 

--- a/docs/changes/2176.feature.md
+++ b/docs/changes/2176.feature.md
@@ -1,1 +1,1 @@
-Add functionality to `production_derive_corsika_limits` and `plot_simulated_event_distributions` to read in several event data file using globular patterns.
+Add functionality to `production_derive_corsika_limits` and `plot_simulated_event_distributions` to read in several event data files using glob patterns.

--- a/docs/changes/2176.feature.md
+++ b/docs/changes/2176.feature.md
@@ -1,0 +1,1 @@
+Add functionality to `production_derive_corsika_limits` and `plot_simulated_event_distributions` to read in several event data file using globular patterns.

--- a/src/simtools/applications/derive_trigger_rates.py
+++ b/src/simtools/applications/derive_trigger_rates.py
@@ -43,13 +43,7 @@ from simtools.telescope_trigger_rates import telescope_trigger_rates
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
-    parser.initialize_application_arguments(["telescope_ids"])
-    parser.add_argument(
-        "--event_data_file",
-        type=str,
-        required=True,
-        help="Event data file containing reduced event data.",
-    )
+    parser.initialize_application_arguments(["telescope_ids", "event_data_file"])
     parser.add_argument(
         "--plot_histograms",
         help="Plot histograms of the event data.",

--- a/src/simtools/applications/plot_simulated_event_distributions.py
+++ b/src/simtools/applications/plot_simulated_event_distributions.py
@@ -32,12 +32,7 @@ from simtools.visualization import plot_simtel_event_histograms
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
-    parser.add_argument(
-        "--event_data_file",
-        type=str,
-        required=True,
-        help="Event data file or glob pattern containing reduced event data.",
-    )
+    parser.initialize_application_arguments(["event_data_file"])
 
 
 def main():

--- a/src/simtools/applications/plot_simulated_event_distributions.py
+++ b/src/simtools/applications/plot_simulated_event_distributions.py
@@ -8,7 +8,7 @@ core distance distributions.
 
 Command line arguments
 ----------------------
-input_file (str, required)
+event_data_file (str, required)
     Input file path.
 output_path (str, required)
     Output directory for the generated plots.

--- a/src/simtools/applications/plot_simulated_event_distributions.py
+++ b/src/simtools/applications/plot_simulated_event_distributions.py
@@ -19,7 +19,7 @@ Generate plots from a given input file:
 
 .. code-block:: console
 
-    simtools-plot-simulated-event-distributions --input_file path/to/simtel_file.hdf5 \
+    simtools-plot-simulated-event-distributions --event_data_file path/to/simtel_file.hdf5 \
                                                 --output_path simtools_output/
 
 
@@ -32,7 +32,12 @@ from simtools.visualization import plot_simtel_event_histograms
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
-    parser.add_argument("--input_file", type=str, required=True, help="Input file path")
+    parser.add_argument(
+        "--event_data_file",
+        type=str,
+        required=True,
+        help="Event data file or glob pattern containing reduced event data.",
+    )
 
 
 def main():
@@ -40,9 +45,9 @@ def main():
     app_context = build_application(
         initialization_kwargs={"db_config": False, "output": True},
     )
-    app_context.logger.info(f"Loading input file from: {app_context.args['input_file']}")
+    app_context.logger.info(f"Loading event data file from: {app_context.args['event_data_file']}")
 
-    histograms = EventDataHistograms(app_context.args["input_file"])
+    histograms = EventDataHistograms(app_context.args["event_data_file"])
     histograms.fill()
     plot_simtel_event_histograms.plot(
         histograms.histograms, output_path=app_context.io_handler.get_output_directory()

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -46,7 +46,7 @@ directions, level of night sky background, etc.).
 Command line arguments
 ----------------------
 event_data_file (str, required)
-    Path to reduced event data file.
+    Path or glob pattern for reduced event data files.
 telescope_ids (str, optional)
     Custom array layout file containing telescope IDs.
 loss_fraction (float, required)
@@ -106,7 +106,7 @@ def _add_arguments(parser):
         "--event_data_file",
         type=str,
         required=True,
-        help="Event data file containing reduced event data.",
+        help="Event data file or glob pattern containing reduced event data.",
     )
     parser.add_argument(
         "--loss_fraction",

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -101,13 +101,7 @@ from simtools.production_configuration.derive_corsika_limits import (
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
-    parser.initialize_application_arguments(["telescope_ids"])
-    parser.add_argument(
-        "--event_data_file",
-        type=str,
-        required=True,
-        help="Event data file or glob pattern containing reduced event data.",
-    )
+    parser.initialize_application_arguments(["telescope_ids", "event_data_file"])
     parser.add_argument(
         "--loss_fraction",
         type=float,

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -930,6 +930,11 @@ _APPLICATION_ARGS = {
         "help": "Data file name.",
         "type": str,
     },
+    "event_data_file": {
+        "help": "Event data file or glob pattern containing reduced event data.",
+        "type": str,
+        "required": True,
+    },
     "telescope_ids": {
         "help": "Path to a file containing telescope configurations.",
         "type": str,

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -58,7 +58,7 @@ def generate_corsika_limits_grid(args_dict):
             args_dict["loss_fraction"],
             args_dict["plot_histograms"],
         )
-        result["layout"] = array_name
+        result["array_name"] = array_name
         result["telescope_ids"] = telescope_ids
         results.append(result)
 
@@ -102,6 +102,12 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
         "upper_radius_limit": compute_upper_radius_limit(histograms, loss_fraction),
         "viewcone_radius": compute_viewcone(histograms, loss_fraction),
     }
+    limits.update(
+        {
+            key: histograms.file_info.get(key)
+            for key in ("primary_particle", "zenith", "azimuth", "nsb_level")
+        }
+    )
 
     if plot_histograms:
         plot_simtel_event_histograms.plot(

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -11,7 +11,6 @@ from simtools.data_model.metadata_collector import MetadataCollector
 from simtools.io import ascii_handler, io_handler
 from simtools.layout.array_layout_utils import get_array_elements_from_db_for_layouts
 from simtools.sim_events.histograms import EventDataHistograms
-from simtools.utils.general import resolve_file_patterns
 from simtools.utils.names import normalize_array_element_identifier_container
 from simtools.visualization import plot_simtel_event_histograms
 
@@ -89,9 +88,8 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
     dict
         Dictionary containing the computed limits and metadata.
     """
-    event_data_files = resolve_file_patterns(file_path)
     histograms = EventDataHistograms(
-        event_data_files,
+        file_path,
         array_name=array_name,
         telescope_list=telescope_ids,
     )

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -11,6 +11,7 @@ from simtools.data_model.metadata_collector import MetadataCollector
 from simtools.io import ascii_handler, io_handler
 from simtools.layout.array_layout_utils import get_array_elements_from_db_for_layouts
 from simtools.sim_events.histograms import EventDataHistograms
+from simtools.utils.general import resolve_file_patterns
 from simtools.utils.names import normalize_array_element_identifier_container
 from simtools.visualization import plot_simtel_event_histograms
 
@@ -72,8 +73,8 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
 
     Parameters
     ----------
-    file_path : str
-        Path to the event data file.
+    file_path : str or list
+        Path or glob pattern to the event data file, or a list of files.
     array_name : str
         Name of the telescope array configuration.
     telescope_ids : list[str]
@@ -88,7 +89,12 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
     dict
         Dictionary containing the computed limits and metadata.
     """
-    histograms = EventDataHistograms(file_path, array_name=array_name, telescope_list=telescope_ids)
+    event_data_files = resolve_file_patterns(file_path)
+    histograms = EventDataHistograms(
+        event_data_files,
+        array_name=array_name,
+        telescope_list=telescope_ids,
+    )
     histograms.fill()
 
     limits = {

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -77,6 +77,10 @@ class EventDataHistograms:
                 )
                 _file_info_table = reader.get_reduced_simulation_file_info(_file_info_table)
                 self.file_info = {
+                    "primary_particle": _file_info_table["primary_particle"],
+                    "zenith": _file_info_table["zenith"].to("deg"),
+                    "azimuth": _file_info_table["azimuth"].to("deg"),
+                    "nsb_level": _file_info_table["nsb_level"],
                     "energy_min": _file_info_table["energy_min"].to("TeV"),
                     "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
                     "viewcone_max": _file_info_table["viewcone_max"].to("deg"),

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -52,7 +52,11 @@ class EventDataHistograms:
 
     def _iter_readers(self):
         """Yield one reader per input file to keep memory usage bounded."""
-        for event_data_file in self.event_data_files:
+        for index, event_data_file in enumerate(self.event_data_files):
+            if index == 0:
+                yield event_data_file, self.reader
+                continue
+
             self.reader = EventDataReader(event_data_file, telescope_list=self.telescope_list)
             self._contains_triggered_data = (
                 self._contains_triggered_data or self._reader_has_triggered_data(self.reader)

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import numpy as np
 
 from simtools.sim_events.reader import EventDataReader
+from simtools.utils.general import resolve_file_patterns
 
 
 class EventDataHistograms:
@@ -42,10 +43,8 @@ class EventDataHistograms:
         self.telescope_list = telescope_list
 
     def _normalize_event_data_files(self, event_data_file):
-        """Return event-data files as a list of strings."""
-        if isinstance(event_data_file, list):
-            return [str(file_name) for file_name in event_data_file]
-        return [str(event_data_file)]
+        """Return event-data files as a list of resolved file names."""
+        return [str(file_name) for file_name in resolve_file_patterns(event_data_file)]
 
     def _reader_has_triggered_data(self, reader):
         """Check if a reader exposes triggered event tables."""

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -71,6 +71,49 @@ class EventDataHistograms:
             )
             yield event_data_file, self.reader
 
+    def _read_data_set(self, reader, event_data_file, data_set):
+        """Read one dataset and return reduced file information with event tables."""
+        self._logger.info(f"Reading event data from {event_data_file} for {data_set}")
+        file_info_table, shower_data, event_data, triggered_data = reader.read_event_data(
+            event_data_file, table_name_map=data_set
+        )
+        file_info_table = reader.get_reduced_simulation_file_info(file_info_table)
+        return file_info_table, shower_data, event_data, triggered_data
+
+    def _get_file_info_value(self, file_info_table, key, unit=None):
+        """Return file-info value, converting to the requested unit when provided."""
+        value = file_info_table.get(key)
+        if value is None or unit is None:
+            return value
+        return _coerce_quantity(value, unit)
+
+    def _update_file_info(self, file_info_table):
+        """Store normalized metadata from the reduced file-info table."""
+        self.file_info = {
+            "primary_particle": self._get_file_info_value(file_info_table, "primary_particle"),
+            "zenith": self._get_file_info_value(file_info_table, "zenith", "deg"),
+            "azimuth": self._get_file_info_value(file_info_table, "azimuth", "deg"),
+            "nsb_level": self._get_file_info_value(file_info_table, "nsb_level"),
+            "energy_min": self._get_file_info_value(file_info_table, "energy_min", "TeV"),
+            "core_scatter_max": self._get_file_info_value(file_info_table, "core_scatter_max", "m"),
+            "viewcone_max": self._get_file_info_value(file_info_table, "viewcone_max", "deg"),
+            "solid_angle": self._get_file_info_value(file_info_table, "solid_angle", "sr"),
+            "scatter_area": self._get_file_info_value(file_info_table, "scatter_area", "cm2"),
+        }
+
+    def _merge_histograms(self, current_histograms):
+        """Carry over accumulated histogram counts before filling new data."""
+        for name, hist in current_histograms.items():
+            previous = self.histograms.get(name)
+            if previous is not None:
+                hist["histogram"] = previous["histogram"]
+        self.histograms = current_histograms
+
+    def _fill_current_histograms(self):
+        """Fill all currently defined histograms with their event data."""
+        for data in self.histograms.values():
+            self._fill_histogram_and_bin_edges(data)
+
     def fill(self):
         """
         Fill histograms with event data.
@@ -83,39 +126,15 @@ class EventDataHistograms:
         """
         for event_data_file, reader in self._iter_readers():
             for data_set in reader.data_sets:
-                self._logger.info(f"Reading event data from {event_data_file} for {data_set}")
-                _file_info_table, shower_data, event_data, triggered_data = reader.read_event_data(
-                    event_data_file, table_name_map=data_set
+                file_info_table, shower_data, event_data, triggered_data = self._read_data_set(
+                    reader, event_data_file, data_set
                 )
-                _file_info_table = reader.get_reduced_simulation_file_info(_file_info_table)
-                self.file_info = {
-                    "primary_particle": _file_info_table.get("primary_particle"),
-                    "zenith": _coerce_quantity(_file_info_table["zenith"], "deg")
-                    if "zenith" in _file_info_table
-                    else None,
-                    "azimuth": _coerce_quantity(_file_info_table["azimuth"], "deg")
-                    if "azimuth" in _file_info_table
-                    else None,
-                    "nsb_level": _file_info_table.get("nsb_level"),
-                    "energy_min": _coerce_quantity(_file_info_table["energy_min"], "TeV"),
-                    "core_scatter_max": _coerce_quantity(_file_info_table["core_scatter_max"], "m"),
-                    "viewcone_max": _coerce_quantity(_file_info_table["viewcone_max"], "deg"),
-                    "solid_angle": _coerce_quantity(_file_info_table["solid_angle"], "sr"),
-                    "scatter_area": _coerce_quantity(_file_info_table["scatter_area"], "cm2"),
-                }
-
+                self._update_file_info(file_info_table)
                 current_histograms = self._define_histograms(
                     event_data, triggered_data, shower_data
                 )
-                for name, hist in current_histograms.items():
-                    previous = self.histograms.get(name)
-                    if previous is not None:
-                        hist["histogram"] = previous["histogram"]
-
-                self.histograms = current_histograms
-
-                for data in self.histograms.values():
-                    self._fill_histogram_and_bin_edges(data)
+                self._merge_histograms(current_histograms)
+                self._fill_current_histograms()
 
         self.print_summary()
         self.calculate_efficiency_data()

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -10,6 +10,14 @@ from simtools.sim_events.reader import EventDataReader
 from simtools.utils.general import resolve_file_patterns
 
 
+def _coerce_quantity(value, unit):
+    """Return a quantity converted to the requested unit."""
+    unit = u.Unit(unit)
+    if hasattr(value, "to"):
+        return value.to(unit)
+    return u.Quantity(value, unit)
+
+
 class EventDataHistograms:
     """
     Generate and fill histograms for shower and (if available) triggered events.
@@ -82,18 +90,18 @@ class EventDataHistograms:
                 _file_info_table = reader.get_reduced_simulation_file_info(_file_info_table)
                 self.file_info = {
                     "primary_particle": _file_info_table.get("primary_particle"),
-                    "zenith": _file_info_table["zenith"].to("deg")
+                    "zenith": _coerce_quantity(_file_info_table["zenith"], "deg")
                     if "zenith" in _file_info_table
                     else None,
-                    "azimuth": _file_info_table["azimuth"].to("deg")
+                    "azimuth": _coerce_quantity(_file_info_table["azimuth"], "deg")
                     if "azimuth" in _file_info_table
                     else None,
                     "nsb_level": _file_info_table.get("nsb_level"),
-                    "energy_min": _file_info_table["energy_min"].to("TeV"),
-                    "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
-                    "viewcone_max": _file_info_table["viewcone_max"].to("deg"),
-                    "solid_angle": _file_info_table["solid_angle"].to("sr"),
-                    "scatter_area": _file_info_table["scatter_area"].to("cm2"),
+                    "energy_min": _coerce_quantity(_file_info_table["energy_min"], "TeV"),
+                    "core_scatter_max": _coerce_quantity(_file_info_table["core_scatter_max"], "m"),
+                    "viewcone_max": _coerce_quantity(_file_info_table["viewcone_max"], "deg"),
+                    "solid_angle": _coerce_quantity(_file_info_table["solid_angle"], "sr"),
+                    "scatter_area": _coerce_quantity(_file_info_table["scatter_area"], "cm2"),
                 }
 
                 current_histograms = self._define_histograms(

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -18,8 +18,8 @@ class EventDataHistograms:
 
     Parameters
     ----------
-    event_data_file : str
-        Path to the event-data file.
+    event_data_file : str or list[pathlib.Path | str]
+        Path to the event-data file or a list of event-data files.
     array_name : str, optional
         Name of the telescope array configuration (default is None).
     telescope_list : list, optional
@@ -30,12 +30,35 @@ class EventDataHistograms:
         """Initialize."""
         self._logger = logging.getLogger(__name__)
         self.event_data_file = event_data_file
+        self.event_data_files = self._normalize_event_data_files(event_data_file)
         self.array_name = array_name
 
         self.histograms = {}
         self.file_info = {}
+        self._contains_triggered_data = False
 
-        self.reader = EventDataReader(event_data_file, telescope_list=telescope_list)
+        self.reader = EventDataReader(self.event_data_files[0], telescope_list=telescope_list)
+        self._contains_triggered_data = self._reader_has_triggered_data(self.reader)
+        self.telescope_list = telescope_list
+
+    def _normalize_event_data_files(self, event_data_file):
+        """Return event-data files as a list of strings."""
+        if isinstance(event_data_file, list):
+            return [str(file_name) for file_name in event_data_file]
+        return [str(event_data_file)]
+
+    def _reader_has_triggered_data(self, reader):
+        """Check if a reader exposes triggered event tables."""
+        return any(isinstance(ds, dict) and "TRIGGERS" in ds for ds in reader.data_sets)
+
+    def _iter_readers(self):
+        """Yield one reader per input file to keep memory usage bounded."""
+        for event_data_file in self.event_data_files:
+            self.reader = EventDataReader(event_data_file, telescope_list=self.telescope_list)
+            self._contains_triggered_data = (
+                self._contains_triggered_data or self._reader_has_triggered_data(self.reader)
+            )
+            yield event_data_file, self.reader
 
     def fill(self):
         """
@@ -47,30 +70,33 @@ class EventDataHistograms:
         Assume that all event data files are generated with similar configurations
         (self.file_info contains the file info of the last file).
         """
-        for data_set in self.reader.data_sets:
-            self._logger.info(f"Reading event data from {self.event_data_file} for {data_set}")
-            _file_info_table, shower_data, event_data, triggered_data = self.reader.read_event_data(
-                self.event_data_file, table_name_map=data_set
-            )
-            _file_info_table = self.reader.get_reduced_simulation_file_info(_file_info_table)
-            self.file_info = {
-                "energy_min": _file_info_table["energy_min"].to("TeV"),
-                "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
-                "viewcone_max": _file_info_table["viewcone_max"].to("deg"),
-                "solid_angle": _file_info_table["solid_angle"].to("sr"),
-                "scatter_area": _file_info_table["scatter_area"].to("cm2"),
-            }
+        for event_data_file, reader in self._iter_readers():
+            for data_set in reader.data_sets:
+                self._logger.info(f"Reading event data from {event_data_file} for {data_set}")
+                _file_info_table, shower_data, event_data, triggered_data = reader.read_event_data(
+                    event_data_file, table_name_map=data_set
+                )
+                _file_info_table = reader.get_reduced_simulation_file_info(_file_info_table)
+                self.file_info = {
+                    "energy_min": _file_info_table["energy_min"].to("TeV"),
+                    "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
+                    "viewcone_max": _file_info_table["viewcone_max"].to("deg"),
+                    "solid_angle": _file_info_table["solid_angle"].to("sr"),
+                    "scatter_area": _file_info_table["scatter_area"].to("cm2"),
+                }
 
-            current_histograms = self._define_histograms(event_data, triggered_data, shower_data)
-            for name, hist in current_histograms.items():
-                previous = self.histograms.get(name)
-                if previous is not None:
-                    hist["histogram"] = previous["histogram"]
+                current_histograms = self._define_histograms(
+                    event_data, triggered_data, shower_data
+                )
+                for name, hist in current_histograms.items():
+                    previous = self.histograms.get(name)
+                    if previous is not None:
+                        hist["histogram"] = previous["histogram"]
 
-            self.histograms = current_histograms
+                self.histograms = current_histograms
 
-            for data in self.histograms.values():
-                self._fill_histogram_and_bin_edges(data)
+                for data in self.histograms.values():
+                    self._fill_histogram_and_bin_edges(data)
 
         self.print_summary()
         self.calculate_efficiency_data()
@@ -234,7 +260,7 @@ class EventDataHistograms:
         dict
             Dictionary containing the efficiency histograms.
         """
-        if not any(isinstance(ds, dict) and "TRIGGERS" in ds for ds in self.reader.data_sets):
+        if not self._contains_triggered_data and not self._reader_has_triggered_data(self.reader):
             return None
 
         def calculate_efficiency(trig_hist, mc_hist):
@@ -323,7 +349,7 @@ class EventDataHistograms:
         dict
             Dictionary containing the cumulative histograms.
         """
-        if not any(isinstance(ds, dict) and "TRIGGERS" in ds for ds in self.reader.data_sets):
+        if not self._contains_triggered_data and not self._reader_has_triggered_data(self.reader):
             return None
 
         cumulative_data = {}

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -77,10 +77,14 @@ class EventDataHistograms:
                 )
                 _file_info_table = reader.get_reduced_simulation_file_info(_file_info_table)
                 self.file_info = {
-                    "primary_particle": _file_info_table["primary_particle"],
-                    "zenith": _file_info_table["zenith"].to("deg"),
-                    "azimuth": _file_info_table["azimuth"].to("deg"),
-                    "nsb_level": _file_info_table["nsb_level"],
+                    "primary_particle": _file_info_table.get("primary_particle"),
+                    "zenith": _file_info_table["zenith"].to("deg")
+                    if "zenith" in _file_info_table
+                    else None,
+                    "azimuth": _file_info_table["azimuth"].to("deg")
+                    if "azimuth" in _file_info_table
+                    else None,
+                    "nsb_level": _file_info_table.get("nsb_level"),
                     "energy_min": _file_info_table["energy_min"].to("TeV"),
                     "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
                     "viewcone_max": _file_info_table["viewcone_max"].to("deg"),

--- a/tests/integration_tests/config/plot_simulated_event_distributions.yml
+++ b/tests/integration_tests/config/plot_simulated_event_distributions.yml
@@ -2,7 +2,7 @@
 applications:
 - application: simtools-plot-simulated-event-distributions
   configuration:
-    input_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
     output_path: simtools-output
   integration_tests:
   - output_file: core_vs_energy.png

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
@@ -10,7 +10,7 @@ applications:
         ">=7.0.0":
         - LSTN-01
         - CTAO-North-Alpha
-    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_*.hdf5
     loss_fraction: 0.001
     model_version: 6.0.2
     output_file: corsika_simulation_limits.ecsv

--- a/tests/unit_tests/applications/test_plot_simulated_event_distributions.py
+++ b/tests/unit_tests/applications/test_plot_simulated_event_distributions.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import simtools.applications.plot_simulated_event_distributions as app
+
+
+def test_main_loads_histograms_and_plots(tmp_test_directory):
+    """Test plotting application builds histograms from the configured event-data file."""
+    output_dir = Path(tmp_test_directory) / "plots"
+    app_context = SimpleNamespace(
+        args={"event_data_file": "test_events.h5"},
+        io_handler=MagicMock(),
+        logger=MagicMock(),
+    )
+    app_context.io_handler.get_output_directory.return_value = output_dir
+
+    with (
+        patch(
+            "simtools.applications.plot_simulated_event_distributions.build_application",
+            return_value=app_context,
+        ),
+        patch(
+            "simtools.applications.plot_simulated_event_distributions.EventDataHistograms"
+        ) as mock_histogram_class,
+        patch(
+            "simtools.applications.plot_simulated_event_distributions.plot_simtel_event_histograms.plot"
+        ) as mock_plot,
+    ):
+        histogram_instance = MagicMock()
+        mock_histogram_class.return_value = histogram_instance
+
+        app.main()
+
+    mock_histogram_class.assert_called_once_with("test_events.h5")
+    histogram_instance.fill.assert_called_once()
+    mock_plot.assert_called_once_with(
+        histogram_instance.histograms,
+        output_path=output_dir,
+    )

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -278,6 +278,7 @@ def test_initialize_application_arguments():
             "off_axis_angles",
             "all_model_versions",
             "data",
+            "event_data_file",
             "telescope_ids",
         ]
     )
@@ -296,6 +297,8 @@ def test_initialize_application_arguments():
             "--all_model_versions",
             "--data",
             "psf_data.ecsv",
+            "--event_data_file",
+            "events.h5",
             "--telescope_ids",
             "layout_ids.txt",
         ]
@@ -309,6 +312,7 @@ def test_initialize_application_arguments():
     assert_quantity_allclose(args.off_axis_angles[1], 1 * u.deg)
     assert args.all_model_versions is True
     assert args.data == "psf_data.ecsv"
+    assert args.event_data_file == "events.h5"
     assert args.telescope_ids == "layout_ids.txt"
 
     job_groups = app_parser._action_groups

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -108,6 +108,10 @@ def test_process_file(mocker):
     mock_histograms = mocker.MagicMock()
     mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH)
     mock_histogram_class.return_value = mock_histograms
+    mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
+        return_value=["test.fits"],
+    )
 
     # Mock the individual limit computation functions
     mock_energy_limit = 1.0 * u.TeV
@@ -138,9 +142,29 @@ def test_process_file(mocker):
     }
     assert result == expected_result
     mock_histogram_class.assert_called_once_with(
-        "test.fits", array_name="array_name", telescope_list=[1, 2]
+        ["test.fits"], array_name="array_name", telescope_list=[1, 2]
     )
     mock_histograms.fill.assert_called_once()
+
+
+def test_process_file_resolves_event_data_patterns(mocker):
+    """Test _process_file resolves glob patterns before filling histograms."""
+    mock_histograms = mocker.MagicMock()
+    mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH, return_value=mock_histograms)
+    mock_resolve = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
+        return_value=["file_a.h5", "file_b.h5"],
+    )
+    mocker.patch(COMPUTE_LOWER_ENERGY_LIMIT_PATH, return_value=1.0 * u.TeV)
+    mocker.patch(COMPUTE_UPPER_RADIUS_LIMIT_PATH, return_value=100.0 * u.m)
+    mocker.patch(COMPUTE_VIEWCONE_PATH, return_value=2.0 * u.deg)
+
+    derive_corsika_limits._process_file("input/*.h5", "array_name", [1, 2], 0.2, False)
+
+    mock_resolve.assert_called_once_with("input/*.h5")
+    mock_histogram_class.assert_called_once_with(
+        ["file_a.h5", "file_b.h5"], array_name="array_name", telescope_list=[1, 2]
+    )
 
 
 def test_write_results(mocker, mock_args_dict, mock_results, tmp_test_directory):
@@ -385,6 +409,10 @@ def test_process_file_with_mocked_histograms(mocker):
     """Test _process_file with mocked EventDataHistograms."""
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
+    mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
+        return_value=[MOCK_FILE_PATH],
+    )
 
     mock_histogram_class = mocker.patch(
         SIM_EVENTS_HISTOGRAMS_PATH,
@@ -419,7 +447,7 @@ def test_process_file_with_mocked_histograms(mocker):
     }
 
     mock_histogram_class.assert_called_once_with(
-        MOCK_FILE_PATH, array_name="MockArray", telescope_list=[1, 2]
+        [MOCK_FILE_PATH], array_name="MockArray", telescope_list=[1, 2]
     )
     mock_histograms.fill.assert_called_once()
     mock_compute_lower_energy_limit.assert_called_once_with(mock_histograms, 0.2)
@@ -431,6 +459,10 @@ def test_process_file_with_plot_histograms(mocker, tmp_test_directory):
     """Test _process_file with plot_histograms=True using plotting module function."""
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
+    mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
+        return_value=[MOCK_FILE_PATH],
+    )
 
     mocker.patch(
         SIM_EVENTS_HISTOGRAMS_PATH,

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -106,6 +106,7 @@ def test_process_file(mocker):
     """Test _process_file function."""
     # Mock the EventDataHistograms class
     mock_histograms = mocker.MagicMock()
+    mock_histograms.file_info = {}
     mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH)
     mock_histogram_class.return_value = mock_histograms
     mocker.patch(
@@ -136,6 +137,10 @@ def test_process_file(mocker):
     result = derive_corsika_limits._process_file("test.fits", "array_name", [1, 2], 0.2, False)
 
     expected_result = {
+        "primary_particle": None,
+        "zenith": None,
+        "azimuth": None,
+        "nsb_level": None,
         "lower_energy_limit": mock_energy_limit,
         "upper_radius_limit": mock_radius_limit,
         "viewcone_radius": mock_viewcone_limit,
@@ -409,6 +414,7 @@ def test_process_file_with_mocked_histograms(mocker):
     """Test _process_file with mocked EventDataHistograms."""
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
+    mock_histograms.file_info = {}
     mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
         return_value=[MOCK_FILE_PATH],
@@ -441,6 +447,10 @@ def test_process_file_with_mocked_histograms(mocker):
     )
 
     assert result == {
+        "primary_particle": None,
+        "zenith": None,
+        "azimuth": None,
+        "nsb_level": None,
         "lower_energy_limit": 1.0 * u.TeV,
         "upper_radius_limit": 100.0 * u.m,
         "viewcone_radius": 2.0 * u.deg,
@@ -459,6 +469,7 @@ def test_process_file_with_plot_histograms(mocker, tmp_test_directory):
     """Test _process_file with plot_histograms=True using plotting module function."""
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
+    mock_histograms.file_info = {}
     mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
         return_value=[MOCK_FILE_PATH],
@@ -505,6 +516,10 @@ def test_process_file_with_plot_histograms(mocker, tmp_test_directory):
     assert args[0] is mock_histograms.histograms
     assert kwargs["output_path"] == tmp_test_directory
     assert kwargs["limits"] == {
+        "primary_particle": None,
+        "zenith": None,
+        "azimuth": None,
+        "nsb_level": None,
         "lower_energy_limit": 1.0 * u.TeV,
         "upper_radius_limit": 100.0 * u.m,
         "viewcone_radius": 2.0 * u.deg,

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -109,10 +109,6 @@ def test_process_file(mocker):
     mock_histograms.file_info = {}
     mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH)
     mock_histogram_class.return_value = mock_histograms
-    mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
-        return_value=["test.fits"],
-    )
 
     # Mock the individual limit computation functions
     mock_energy_limit = 1.0 * u.TeV
@@ -147,28 +143,23 @@ def test_process_file(mocker):
     }
     assert result == expected_result
     mock_histogram_class.assert_called_once_with(
-        ["test.fits"], array_name="array_name", telescope_list=[1, 2]
+        "test.fits", array_name="array_name", telescope_list=[1, 2]
     )
     mock_histograms.fill.assert_called_once()
 
 
-def test_process_file_resolves_event_data_patterns(mocker):
-    """Test _process_file resolves glob patterns before filling histograms."""
+def test_process_file_passes_event_data_patterns_through(mocker):
+    """Test _process_file passes glob patterns through to histogram resolution."""
     mock_histograms = mocker.MagicMock()
     mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH, return_value=mock_histograms)
-    mock_resolve = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
-        return_value=["file_a.h5", "file_b.h5"],
-    )
     mocker.patch(COMPUTE_LOWER_ENERGY_LIMIT_PATH, return_value=1.0 * u.TeV)
     mocker.patch(COMPUTE_UPPER_RADIUS_LIMIT_PATH, return_value=100.0 * u.m)
     mocker.patch(COMPUTE_VIEWCONE_PATH, return_value=2.0 * u.deg)
 
     derive_corsika_limits._process_file("input/*.h5", "array_name", [1, 2], 0.2, False)
 
-    mock_resolve.assert_called_once_with("input/*.h5")
     mock_histogram_class.assert_called_once_with(
-        ["file_a.h5", "file_b.h5"], array_name="array_name", telescope_list=[1, 2]
+        "input/*.h5", array_name="array_name", telescope_list=[1, 2]
     )
 
 
@@ -415,10 +406,6 @@ def test_process_file_with_mocked_histograms(mocker):
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
     mock_histograms.file_info = {}
-    mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
-        return_value=[MOCK_FILE_PATH],
-    )
 
     mock_histogram_class = mocker.patch(
         SIM_EVENTS_HISTOGRAMS_PATH,
@@ -457,7 +444,7 @@ def test_process_file_with_mocked_histograms(mocker):
     }
 
     mock_histogram_class.assert_called_once_with(
-        [MOCK_FILE_PATH], array_name="MockArray", telescope_list=[1, 2]
+        MOCK_FILE_PATH, array_name="MockArray", telescope_list=[1, 2]
     )
     mock_histograms.fill.assert_called_once()
     mock_compute_lower_energy_limit.assert_called_once_with(mock_histograms, 0.2)
@@ -470,10 +457,6 @@ def test_process_file_with_plot_histograms(mocker, tmp_test_directory):
     mock_histograms = mocker.MagicMock()
     mock_histograms.fill.return_value = None
     mock_histograms.file_info = {}
-    mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits.resolve_file_patterns",
-        return_value=[MOCK_FILE_PATH],
-    )
 
     mocker.patch(
         SIM_EVENTS_HISTOGRAMS_PATH,

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -9,6 +9,10 @@ from simtools.sim_events.histograms import EventDataHistograms
 
 @pytest.fixture
 def mock_reader(mocker):
+    mocker.patch(
+        "simtools.sim_events.histograms.resolve_file_patterns",
+        side_effect=lambda file_names: file_names if isinstance(file_names, list) else [file_names],
+    )
     mock = mocker.patch("simtools.sim_events.histograms.EventDataReader")
     mock.return_value.triggered_shower_data.simulated_energy = np.array([1, 10, 100])
     mock.return_value.shower_data.simulated_energy = np.array([1, 10, 100])
@@ -37,6 +41,21 @@ def test_init_default_telescope_list(mock_reader, hdf5_file_name):
 
     assert histograms.event_data_file == hdf5_file_name
     mock_reader.assert_called_once_with(hdf5_file_name, telescope_list=None)
+
+
+def test_init_resolves_event_data_glob_patterns(mocker):
+    """Test initialization resolves glob patterns before opening the first file."""
+    mock_resolve = mocker.patch(
+        "simtools.sim_events.histograms.resolve_file_patterns",
+        return_value=["test_file_1.h5", "test_file_2.h5"],
+    )
+    mock_reader = mocker.patch("simtools.sim_events.histograms.EventDataReader")
+
+    histograms = EventDataHistograms("test_file_*.h5")
+
+    mock_resolve.assert_called_once_with("test_file_*.h5")
+    assert histograms.event_data_files == ["test_file_1.h5", "test_file_2.h5"]
+    mock_reader.assert_called_once_with("test_file_1.h5", telescope_list=None)
 
 
 def test_energy_bins(mock_reader, hdf5_file_name):
@@ -441,6 +460,10 @@ def test_normalized_cumulative_histogram(mock_reader, hdf5_file_name):
 @pytest.fixture
 def mock_histograms(mocker):
     """Create a mocked EventDataHistograms that doesn't require a file."""
+    mocker.patch(
+        "simtools.sim_events.histograms.resolve_file_patterns",
+        side_effect=lambda file_names: file_names if isinstance(file_names, list) else [file_names],
+    )
     mocker.patch("simtools.sim_events.histograms.EventDataReader")
     return EventDataHistograms("dummy_file.h5", "test_array")
 

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -256,15 +256,13 @@ def test_fill_reads_multiple_files_sequentially(mock_reader, mocker):
 
     histograms.fill()
 
-    assert mock_reader.call_args_list == [
-        mocker.call("test_file_1.h5", telescope_list=None),
-        mocker.call("test_file_1.h5", telescope_list=None),
-        mocker.call("test_file_2.h5", telescope_list=None),
-    ]
-    assert mock_reader.return_value.read_event_data.call_args_list == [
-        mocker.call(mocker.ANY, table_name_map="test_dataset"),
-        mocker.call(mocker.ANY, table_name_map="test_dataset"),
-    ]
+    opened_files = [call.args[0] for call in mock_reader.call_args_list]
+    assert set(opened_files) >= {"test_file_1.h5", "test_file_2.h5"}
+    assert all(call.kwargs == {"telescope_list": None} for call in mock_reader.call_args_list)
+
+    read_calls = mock_reader.return_value.read_event_data.call_args_list
+    assert len(read_calls) == 2
+    assert all(call.kwargs.get("table_name_map") == "test_dataset" for call in read_calls)
 
 
 def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_name, mocker):

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -3,6 +3,7 @@ import logging
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.tests.helper import assert_quantity_allclose
 
 from simtools.sim_events.histograms import EventDataHistograms
 
@@ -350,13 +351,13 @@ def test_fill_coerces_unitless_file_info_values(mock_reader, hdf5_file_name, moc
 
     histograms.fill()
 
-    assert histograms.file_info["zenith"] == 20.0 * u.deg
-    assert histograms.file_info["azimuth"] == 180.0 * u.deg
-    assert histograms.file_info["energy_min"] == 0.1 * u.TeV
-    assert histograms.file_info["core_scatter_max"] == 100.0 * u.m
-    assert histograms.file_info["viewcone_max"] == 2.0 * u.deg
-    assert histograms.file_info["solid_angle"] == 1.0 * u.sr
-    assert histograms.file_info["scatter_area"] == 1.0 * (u.cm**2)
+    assert_quantity_allclose(histograms.file_info["zenith"], 20.0 * u.deg)
+    assert_quantity_allclose(histograms.file_info["azimuth"], 180.0 * u.deg)
+    assert_quantity_allclose(histograms.file_info["energy_min"], 0.1 * u.TeV)
+    assert_quantity_allclose(histograms.file_info["core_scatter_max"], 100.0 * u.m)
+    assert_quantity_allclose(histograms.file_info["viewcone_max"], 2.0 * u.deg)
+    assert_quantity_allclose(histograms.file_info["solid_angle"], 1.0 * u.sr)
+    assert_quantity_allclose(histograms.file_info["scatter_area"], 1.0 * (u.cm**2))
 
 
 def test_calculate_cumulative_histogram(mock_reader, hdf5_file_name):

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -206,6 +206,48 @@ def test_fill(mock_reader, hdf5_file_name, mocker):
     )
 
 
+def test_fill_reads_multiple_files_sequentially(mock_reader, mocker):
+    """Test fill iterates over multiple files without keeping a shared reader state."""
+    histograms = EventDataHistograms(["test_file_1.h5", "test_file_2.h5"])
+
+    mock_file_info = mocker.Mock()
+    mock_event_data = mocker.Mock()
+    mock_triggered_data = mocker.Mock()
+    mock_shower_data = mocker.Mock()
+
+    mock_reader.return_value.read_event_data.return_value = (
+        mock_file_info,
+        mock_shower_data,
+        mock_event_data,
+        mock_triggered_data,
+    )
+    mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
+        "energy_min": 1.0 * u.TeV,
+        "core_scatter_max": 100.0 * u.m,
+        "viewcone_max": 5.0 * u.deg,
+        "solid_angle": 1.0 * u.sr,
+        "scatter_area": 1.0 * u.cm**2,
+    }
+    mock_reader.return_value.data_sets = ["test_dataset"]
+
+    mocker.patch.object(histograms, "_define_histograms", return_value={})
+    mocker.patch.object(histograms, "print_summary")
+    mocker.patch.object(histograms, "calculate_efficiency_data")
+    mocker.patch.object(histograms, "calculate_cumulative_data")
+
+    histograms.fill()
+
+    assert mock_reader.call_args_list == [
+        mocker.call("test_file_1.h5", telescope_list=None),
+        mocker.call("test_file_1.h5", telescope_list=None),
+        mocker.call("test_file_2.h5", telescope_list=None),
+    ]
+    assert mock_reader.return_value.read_event_data.call_args_list == [
+        mocker.call(mocker.ANY, table_name_map="test_dataset"),
+        mocker.call(mocker.ANY, table_name_map="test_dataset"),
+    ]
+
+
 def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_name, mocker):
     """Test fill accumulates histogram counts across all indexed datasets."""
     histograms = EventDataHistograms(hdf5_file_name)

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -320,6 +320,45 @@ def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_nam
     assert mock_reader.return_value.read_event_data.call_count == 2
 
 
+def test_fill_coerces_unitless_file_info_values(mock_reader, hdf5_file_name, mocker):
+    """Test fill converts unitless FILE_INFO values to expected quantities."""
+    histograms = EventDataHistograms(hdf5_file_name)
+
+    mock_reader.return_value.data_sets = ["dataset_0"]
+    mock_reader.return_value.read_event_data.return_value = (
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+    mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
+        "primary_particle": "gamma",
+        "zenith": 20.0,
+        "azimuth": 180.0,
+        "nsb_level": 1.0,
+        "energy_min": 0.1,
+        "core_scatter_max": 100.0,
+        "viewcone_max": 2.0,
+        "solid_angle": 1.0,
+        "scatter_area": 1.0,
+    }
+
+    mocker.patch.object(histograms, "_define_histograms", return_value={})
+    mocker.patch.object(histograms, "print_summary")
+    mocker.patch.object(histograms, "calculate_efficiency_data")
+    mocker.patch.object(histograms, "calculate_cumulative_data")
+
+    histograms.fill()
+
+    assert histograms.file_info["zenith"] == 20.0 * u.deg
+    assert histograms.file_info["azimuth"] == 180.0 * u.deg
+    assert histograms.file_info["energy_min"] == 0.1 * u.TeV
+    assert histograms.file_info["core_scatter_max"] == 100.0 * u.m
+    assert histograms.file_info["viewcone_max"] == 2.0 * u.deg
+    assert histograms.file_info["solid_angle"] == 1.0 * u.sr
+    assert histograms.file_info["scatter_area"] == 1.0 * (u.cm**2)
+
+
 def test_calculate_cumulative_histogram(mock_reader, hdf5_file_name):
     """Test calculation of cumulative histogram."""
     histograms = EventDataHistograms(hdf5_file_name)


### PR DESCRIPTION
Add functionality to production_derive_corsika_limits and plot_simulated_event_distributions to read in several event data file using globular patterns.

Also ensure that metadata (e.g., primary particle, zenith angle of simulations) is read in correctly

