### PR TITLE
Add feature to allow for user-defined cosmic-ray spectra on the trigger rate application.

### DIFF
--- a/docs/changes/2177.feature.md
+++ b/docs/changes/2177.feature.md
@@ -1,0 +1,1 @@
+Add feature to allow for user-defined cosmic-ray spectra on the trigger rate application.

--- a/src/simtools/applications/derive_trigger_rates.py
+++ b/src/simtools/applications/derive_trigger_rates.py
@@ -19,6 +19,10 @@ model_version (str, optional)
     Version of the simulation model to use.
 site (str, optional)
     Name of the site where the simulation is being run.
+cr_spectrum (str, optional)
+    Path to a YAML file defining a user-provided cosmic-ray spectrum.
+    Supported spectrum types: PowerLaw, LogParabola, PowerLawWithExponentialGaussian.
+    If not given, the spectrum is selected from the CTAO spectrum library.
 
 
 Example
@@ -34,6 +38,17 @@ Derive trigger rates for the South Alpha layout:
         --event_data_file /path/to/event_data_file.h5 \\
         --array_layout_name alpha\\
         --plot_histograms
+
+Derive trigger rates with a user-defined spectrum:
+
+.. code-block:: console
+
+    simtools-derive-trigger-rates \\
+        --site South \\
+        --model_version 6.0.0 \\
+        --event_data_file /path/to/event_data_file.h5 \\
+        --array_layout_name alpha \\
+        --cr_spectrum /path/to/spectrum.yml
 
 """
 
@@ -55,6 +70,16 @@ def _add_arguments(parser):
         help="Plot histograms of the event data.",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--cr_spectrum",
+        type=str,
+        default=None,
+        help=(
+            "Path to a YAML file defining the cosmic-ray spectrum. "
+            "Supported types: PowerLaw, LogParabola, PowerLawWithExponentialGaussian. "
+            "If not given, the spectrum is selected from the CTAO spectrum library."
+        ),
     )
 
 

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -54,6 +54,7 @@ class EventDataHistograms:
             )
             _file_info_table = self.reader.get_reduced_simulation_file_info(_file_info_table)
             self.file_info = {
+                "primary_particle": _file_info_table["primary_particle"],
                 "energy_min": _file_info_table["energy_min"].to("TeV"),
                 "core_scatter_max": _file_info_table["core_scatter_max"].to("m"),
                 "viewcone_max": _file_info_table["viewcone_max"].to("deg"),

--- a/src/simtools/telescope_trigger_rates.py
+++ b/src/simtools/telescope_trigger_rates.py
@@ -1,10 +1,14 @@
 """Trigger rate calculation for telescopes and arrays of telescopes."""
 
 import logging
+from pathlib import Path
 
 import numpy as np
+import yaml
 from astropy import units as u
-from ctao_cr_spectra.definitions import IRFDOC_PROTON_SPECTRUM
+from ctao_cr_spectra.definitions import IRFDOC_ELECTRON_SPECTRUM, IRFDOC_PROTON_SPECTRUM
+from ctao_cr_spectra.spectral import LogParabola, PowerLaw, PowerLawWithExponentialGaussian
+from scipy import integrate
 
 from simtools.io import ascii_handler, io_handler
 from simtools.layout.array_layout_utils import get_array_elements_from_db_for_layouts
@@ -13,6 +17,19 @@ from simtools.visualization import plot_simtel_event_histograms
 
 _logger = logging.getLogger(__name__)
 
+#: Mapping from primary particle common name to default cosmic-ray spectrum.
+PARTICLE_SPECTRUM_MAP = {
+    "proton": IRFDOC_PROTON_SPECTRUM,
+    "electron": IRFDOC_ELECTRON_SPECTRUM,
+}
+
+#: Supported spectrum type names in YAML spectrum files.
+_SPECTRUM_TYPES = {
+    "PowerLaw": PowerLaw,
+    "LogParabola": LogParabola,
+    "PowerLawWithExponentialGaussian": PowerLawWithExponentialGaussian,
+}
+
 
 def telescope_trigger_rates(args_dict):
     """
@@ -20,7 +37,10 @@ def telescope_trigger_rates(args_dict):
 
     Main function to read event data, fill histograms, and derive trigger rates.
 
-
+    Parameters
+    ----------
+    args_dict : dict
+        Dictionary of command line arguments.
     """
     if args_dict.get("array_layout_name"):
         telescope_configs = get_array_elements_from_db_for_layouts(
@@ -42,7 +62,7 @@ def telescope_trigger_rates(args_dict):
         )
         histograms.fill()
 
-        _calculate_trigger_rates(histograms, array_name)
+        _calculate_trigger_rates(histograms, array_name, args_dict.get("cr_spectrum"))
 
         if args_dict["plot_histograms"]:
             plot_simtel_event_histograms.plot(
@@ -52,26 +72,34 @@ def telescope_trigger_rates(args_dict):
             )
 
 
-def _calculate_trigger_rates(histograms, array_name):
+def _calculate_trigger_rates(histograms, array_name, cr_spectrum_file=None):
     """
     Calculate trigger rates from the filled histograms.
 
-    Missing
-
-    - custom definition of energy spectra
-
+    Parameters
+    ----------
+    histograms : EventDataHistograms
+        Filled histogram object containing event data and file info.
+    array_name : str
+        Name of the telescope array configuration.
+    cr_spectrum_file : str or Path, optional
+        Path to a YAML file describing the cosmic-ray spectrum. If None, the spectrum
+        is selected automatically based on the primary particle in the simulation data.
     """
     efficiency = histograms.histograms.get("energy_eff", {}).get("histogram")
     energy_axis = histograms.histograms.get("energy_eff", {}).get("bin_edges")
 
-    cr_spectrum = get_cosmic_ray_spectrum()
+    primary_particle = histograms.file_info.get("primary_particle")
+    cr_spectrum = get_cosmic_ray_spectrum(primary_particle, cr_spectrum_file)
     _logger.info(f"Cosmic ray spectrum: {cr_spectrum}")
     e_min = energy_axis[:-1] * u.TeV
     e_max = energy_axis[1:] * u.TeV
     cr_rates = (
         np.array(
             [
-                cr_spectrum.integrate_energy(e1, e2).decompose(bases=[u.s, u.cm, u.sr]).value
+                _integrate_energy_spectrum(cr_spectrum, e1, e2)
+                .decompose(bases=[u.s, u.cm, u.sr])
+                .value
                 for e1, e2 in zip(e_min, e_max)
             ]
         )
@@ -104,15 +132,130 @@ def _calculate_trigger_rates(histograms, array_name):
     return cr_rates, trigger_rates, trigger_rate
 
 
-def get_cosmic_ray_spectrum():
+def get_cosmic_ray_spectrum(primary_particle=None, cr_spectrum_file=None):
     """
-    Return the cosmic ray spectrum.
+    Return the cosmic-ray spectrum to use for trigger rate calculations.
 
-    To be extended in future to read a larger variety of spectra.
+    If a YAML spectrum file is provided, the spectrum is loaded from that file.
+    Otherwise, the spectrum is selected based on the primary particle name. If the
+    particle is not found in the default map, a warning is logged and the proton
+    spectrum is used as a fallback.
+
+    Parameters
+    ----------
+    primary_particle : str, optional
+        Common name of the simulated primary particle (e.g. 'proton', 'electron').
+    cr_spectrum_file : str or Path, optional
+        Path to a YAML file describing the cosmic-ray spectrum.
+
+    Returns
+    -------
+    spectrum
+        A callable spectrum object from ctao_cr_spectra.
+    """
+    if cr_spectrum_file is not None:
+        return _load_spectrum_from_file(cr_spectrum_file)
+
+    if primary_particle is not None:
+        spectrum = PARTICLE_SPECTRUM_MAP.get(primary_particle)
+        if spectrum is None:
+            _logger.warning(
+                f"No default spectrum for primary particle '{primary_particle}'. "
+                "Falling back to IRFDOC_PROTON_SPECTRUM."
+            )
+            return IRFDOC_PROTON_SPECTRUM
+        return spectrum
+
+    return IRFDOC_PROTON_SPECTRUM
+
+
+def _load_spectrum_from_file(yaml_path):
+    """
+    Load a cosmic-ray spectrum from a YAML configuration file.
+
+    The YAML file must contain a 'type' key with one of the supported spectrum class
+    names ('PowerLaw', 'LogParabola', 'PowerLawWithExponentialGaussian'), a
+    'normalization' key with a numeric value, and a 'normalization_unit' key with
+    an astropy-parseable unit string. Additional keys are passed as keyword arguments
+    to the spectrum class constructor.
+
+    Parameters
+    ----------
+    yaml_path : str or Path
+        Path to the YAML spectrum definition file.
+
+    Returns
+    -------
+    spectrum
+        A spectrum object from ctao_cr_spectra.
+
+    Raises
+    ------
+    ValueError
+        If the spectrum type is not supported or required keys are missing.
+
+    Examples
+    --------
+    Example YAML file content for a power-law spectrum:
+
+    .. code-block:: yaml
+
+        type: PowerLaw
+        normalization: 9.8e-6
+        normalization_unit: 1 / (cm2 s TeV sr)
+        index: -2.62
+        e_ref: 1.0
+        e_ref_unit: TeV
+    """
+    with Path(yaml_path).open(encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    spectrum_type = config.get("type")
+    if spectrum_type not in _SPECTRUM_TYPES:
+        raise ValueError(
+            f"Unsupported spectrum type '{spectrum_type}'. Supported types: {list(_SPECTRUM_TYPES)}"
+        )
+
+    normalization = config["normalization"] * u.Unit(config["normalization_unit"])
+
+    kwargs = {"normalization": normalization}
+    for key in ("index", "a", "b", "f", "mu", "sigma"):
+        if key in config:
+            kwargs[key] = config[key]
+    if "e_ref" in config:
+        kwargs["e_ref"] = config["e_ref"] * u.Unit(config.get("e_ref_unit", "TeV"))
+
+    return _SPECTRUM_TYPES[spectrum_type](**kwargs)
+
+
+def _integrate_energy_spectrum(spectrum, energy_min, energy_max):
+    """
+    Integrate a spectrum over an energy range.
+
+    Uses the analytical integration method for PowerLaw spectra and
+    numerical integration (scipy.integrate.quad) for all other types.
+
+    Parameters
+    ----------
+    spectrum : callable
+        A spectrum object from ctao_cr_spectra.
+    energy_min : astropy.units.Quantity
+        Lower bound of the energy integration interval.
+    energy_max : astropy.units.Quantity
+        Upper bound of the energy integration interval.
 
     Returns
     -------
     astropy.units.Quantity
-        Cosmic ray spectrum.
+        Integrated spectrum value over the energy range.
     """
-    return IRFDOC_PROTON_SPECTRUM
+    if type(spectrum) is PowerLaw:  # pylint: disable=unidiomatic-typecheck
+        return spectrum.integrate_energy(energy_min, energy_max)
+
+    flux_unit = spectrum(energy_min).unit * u.TeV
+
+    def integrand(e_tev):
+        return spectrum(e_tev * u.TeV).to_value(spectrum(energy_min).unit)
+
+    result, _ = integrate.quad(integrand, energy_min.to_value("TeV"), energy_max.to_value("TeV"))
+    return result * flux_unit

--- a/src/simtools/telescope_trigger_rates.py
+++ b/src/simtools/telescope_trigger_rates.py
@@ -189,11 +189,6 @@ def _load_spectrum_from_file(yaml_path):
     spectrum
         A spectrum object from ctao_cr_spectra.
 
-    Raises
-    ------
-    ValueError
-        If the spectrum type is not supported or required keys are missing.
-
     Examples
     --------
     Example YAML file content for a power-law spectrum:
@@ -232,8 +227,9 @@ def _integrate_energy_spectrum(spectrum, energy_min, energy_max):
     """
     Integrate a spectrum over an energy range.
 
-    Uses the analytical integration method for PowerLaw spectra and
-    numerical integration (scipy.integrate.quad) for all other types.
+    Uses the analytical integration method when the spectrum provides
+    integrate_energy, and falls back to numerical integration
+    (scipy.integrate.quad) otherwise.
 
     Parameters
     ----------
@@ -249,13 +245,14 @@ def _integrate_energy_spectrum(spectrum, energy_min, energy_max):
     astropy.units.Quantity
         Integrated spectrum value over the energy range.
     """
-    if type(spectrum) is PowerLaw:  # pylint: disable=unidiomatic-typecheck
+    if callable(getattr(spectrum, "integrate_energy", None)):
         return spectrum.integrate_energy(energy_min, energy_max)
 
-    flux_unit = spectrum(energy_min).unit * u.TeV
+    spectrum_unit = spectrum(energy_min).unit
+    flux_unit = spectrum_unit * u.TeV
 
     def integrand(e_tev):
-        return spectrum(e_tev * u.TeV).to_value(spectrum(energy_min).unit)
+        return spectrum(e_tev * u.TeV).to_value(spectrum_unit)
 
     result, _ = integrate.quad(integrand, energy_min.to_value("TeV"), energy_max.to_value("TeV"))
     return result * flux_unit

--- a/tests/integration_tests/config/derive_trigger_rates_user_spectrum.yml
+++ b/tests/integration_tests/config/derive_trigger_rates_user_spectrum.yml
@@ -1,0 +1,13 @@
+---
+applications:
+- application: simtools-derive-trigger-rates
+  configuration:
+    cr_spectrum: tests/resources/trigger_rates_user_spectrum_powerlaw.yml
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+    model_version: 6.0.2
+    output_path: simtools-output
+    plot_histograms: true
+    telescope_ids: tests/resources/production_layouts_telescope_ids.yml
+  test_name: user_defined_spectrum
+schema_name: application_workflow.metaschema
+schema_version: 0.4.0

--- a/tests/resources/trigger_rates_user_spectrum_powerlaw.yml
+++ b/tests/resources/trigger_rates_user_spectrum_powerlaw.yml
@@ -1,0 +1,7 @@
+---
+type: PowerLaw
+normalization: 8.0e-6
+normalization_unit: 1 / (cm2 s TeV sr)
+index: -2.75
+e_ref: 1.0
+e_ref_unit: TeV

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -206,6 +206,35 @@ def test_fill(mock_reader, hdf5_file_name, mocker):
     )
 
 
+def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker):
+    """Test that fill() stores primary_particle in file_info."""
+    histograms = EventDataHistograms(hdf5_file_name)
+
+    mock_reader.return_value.data_sets = ["test_dataset"]
+    mock_reader.return_value.read_event_data.return_value = (
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+    mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
+        "primary_particle": "proton",
+        "energy_min": 0.1 * u.TeV,
+        "core_scatter_max": 100.0 * u.m,
+        "viewcone_max": 2.0 * u.deg,
+        "solid_angle": 1.0 * u.sr,
+        "scatter_area": 1.0 * u.cm**2,
+    }
+    mocker.patch.object(histograms, "_define_histograms", return_value={})
+    mocker.patch.object(histograms, "print_summary")
+    mocker.patch.object(histograms, "calculate_efficiency_data")
+    mocker.patch.object(histograms, "calculate_cumulative_data")
+
+    histograms.fill()
+
+    assert histograms.file_info["primary_particle"] == "proton"
+
+
 def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_name, mocker):
     """Test fill accumulates histogram counts across all indexed datasets."""
     histograms = EventDataHistograms(hdf5_file_name)

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -22,6 +22,22 @@ def hdf5_file_name():
     return "test_file.h5"
 
 
+@pytest.fixture
+def reduced_file_info():
+    """Common reduced file info mock for fill() tests."""
+    return {
+        "primary_particle": "proton",
+        "zenith": 20.0 * u.deg,
+        "azimuth": 0.0 * u.deg,
+        "nsb_level": 1.0,
+        "energy_min": 0.1 * u.TeV,
+        "core_scatter_max": 100.0 * u.m,
+        "viewcone_max": 2.0 * u.deg,
+        "solid_angle": 1.0 * u.sr,
+        "scatter_area": 1.0 * u.cm**2,
+    }
+
+
 def test_init(mock_reader, hdf5_file_name):
     """Test initialization with telescope list."""
     test_telescope_list = [1, 2]
@@ -206,7 +222,7 @@ def test_fill(mock_reader, hdf5_file_name, mocker):
     )
 
 
-def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker):
+def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker, reduced_file_info):
     """Test that fill() stores primary_particle in file_info."""
     histograms = EventDataHistograms(hdf5_file_name)
 
@@ -217,17 +233,7 @@ def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker):
         mocker.Mock(),
         mocker.Mock(),
     )
-    mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
-        "primary_particle": "proton",
-        "zenith": 20.0 * u.deg,
-        "azimuth": 0.0 * u.deg,
-        "nsb_level": 1.0,
-        "energy_min": 0.1 * u.TeV,
-        "core_scatter_max": 100.0 * u.m,
-        "viewcone_max": 2.0 * u.deg,
-        "solid_angle": 1.0 * u.sr,
-        "scatter_area": 1.0 * u.cm**2,
-    }
+    mock_reader.return_value.get_reduced_simulation_file_info.return_value = reduced_file_info
     mocker.patch.object(histograms, "_define_histograms", return_value={})
     mocker.patch.object(histograms, "print_summary")
     mocker.patch.object(histograms, "calculate_efficiency_data")
@@ -238,7 +244,9 @@ def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker):
     assert histograms.file_info["primary_particle"] == "proton"
 
 
-def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_name, mocker):
+def test_fill_accumulates_histograms_across_data_sets(
+    mock_reader, hdf5_file_name, mocker, reduced_file_info
+):
     """Test fill accumulates histogram counts across all indexed datasets."""
     histograms = EventDataHistograms(hdf5_file_name)
 
@@ -249,17 +257,7 @@ def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_nam
         mocker.Mock(),
         mocker.Mock(),
     )
-    mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
-        "primary_particle": "proton",
-        "zenith": 20.0 * u.deg,
-        "azimuth": 0.0 * u.deg,
-        "nsb_level": 1.0,
-        "energy_min": 0.1 * u.TeV,
-        "core_scatter_max": 100.0 * u.m,
-        "viewcone_max": 2.0 * u.deg,
-        "solid_angle": 1.0 * u.sr,
-        "scatter_area": 1.0 * u.cm**2,
-    }
+    mock_reader.return_value.get_reduced_simulation_file_info.return_value = reduced_file_info
 
     dataset_0 = mocker.Mock()
     dataset_0.simulated_energy = np.array([0.2, 0.4])

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -219,6 +219,9 @@ def test_fill_populates_primary_particle(mock_reader, hdf5_file_name, mocker):
     )
     mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
         "primary_particle": "proton",
+        "zenith": 20.0 * u.deg,
+        "azimuth": 0.0 * u.deg,
+        "nsb_level": 1.0,
         "energy_min": 0.1 * u.TeV,
         "core_scatter_max": 100.0 * u.m,
         "viewcone_max": 2.0 * u.deg,
@@ -247,6 +250,10 @@ def test_fill_accumulates_histograms_across_data_sets(mock_reader, hdf5_file_nam
         mocker.Mock(),
     )
     mock_reader.return_value.get_reduced_simulation_file_info.return_value = {
+        "primary_particle": "proton",
+        "zenith": 20.0 * u.deg,
+        "azimuth": 0.0 * u.deg,
+        "nsb_level": 1.0,
         "energy_min": 0.1 * u.TeV,
         "core_scatter_max": 100.0 * u.m,
         "viewcone_max": 2.0 * u.deg,

--- a/tests/unit_tests/test_telescope_trigger_rates.py
+++ b/tests/unit_tests/test_telescope_trigger_rates.py
@@ -129,7 +129,7 @@ def test_load_spectrum_from_file_power_law(tmp_test_directory):
     spectrum = _load_spectrum_from_file(spectrum_file)
     assert isinstance(spectrum, PowerLaw)
     assert spectrum.index == pytest.approx(-2.62)
-    assert spectrum.e_ref == 1.0 * u.TeV
+    assert spectrum.e_ref.value == pytest.approx(1.0)
 
 
 def test_load_spectrum_from_file_log_parabola(tmp_test_directory):

--- a/tests/unit_tests/test_telescope_trigger_rates.py
+++ b/tests/unit_tests/test_telescope_trigger_rates.py
@@ -1,7 +1,18 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from simtools.telescope_trigger_rates import telescope_trigger_rates
+import astropy.units as u
+import pytest
+import yaml
+from ctao_cr_spectra.definitions import IRFDOC_ELECTRON_SPECTRUM, IRFDOC_PROTON_SPECTRUM
+from ctao_cr_spectra.spectral import LogParabola, PowerLaw
+
+from simtools.telescope_trigger_rates import (
+    _integrate_energy_spectrum,
+    _load_spectrum_from_file,
+    get_cosmic_ray_spectrum,
+    telescope_trigger_rates,
+)
 
 FILE_SIMTEL = "test_file.simtel"
 
@@ -67,3 +78,110 @@ def test_telescope_trigger_rates_without_array_layout_name():
         mock_plot.assert_called_once_with(
             mock_histograms_instance.histograms, output_path=Path("output_dir"), array_name="array1"
         )
+
+
+def test_get_cosmic_ray_spectrum_default():
+    """No arguments: should return the proton spectrum."""
+    assert get_cosmic_ray_spectrum() is IRFDOC_PROTON_SPECTRUM
+
+
+def test_get_cosmic_ray_spectrum_known_particle():
+    assert get_cosmic_ray_spectrum(primary_particle="proton") is IRFDOC_PROTON_SPECTRUM
+    assert get_cosmic_ray_spectrum(primary_particle="electron") is IRFDOC_ELECTRON_SPECTRUM
+
+
+def test_get_cosmic_ray_spectrum_unknown_particle_falls_back(caplog):
+    """Unknown primary particle should log a warning and return the proton spectrum."""
+    with caplog.at_level("WARNING"):
+        result = get_cosmic_ray_spectrum(primary_particle="gamma")
+    assert result is IRFDOC_PROTON_SPECTRUM
+    assert "gamma" in caplog.text
+
+
+def test_get_cosmic_ray_spectrum_from_file(tmp_test_directory):
+    """Spectrum loaded from YAML file takes priority over primary_particle."""
+    spectrum_file = tmp_test_directory / "spectrum.yml"
+    config = {
+        "type": "PowerLaw",
+        "normalization": 9.8e-6,
+        "normalization_unit": "1 / (cm2 s TeV sr)",
+        "index": -2.7,
+    }
+    spectrum_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    result = get_cosmic_ray_spectrum(primary_particle="proton", cr_spectrum_file=spectrum_file)
+    assert isinstance(result, PowerLaw)
+    assert result.index == pytest.approx(-2.7)
+
+
+def test_load_spectrum_from_file_power_law(tmp_test_directory):
+    spectrum_file = tmp_test_directory / "pl.yml"
+    config = {
+        "type": "PowerLaw",
+        "normalization": 9.8e-6,
+        "normalization_unit": "1 / (cm2 s TeV sr)",
+        "index": -2.62,
+        "e_ref": 1.0,
+        "e_ref_unit": "TeV",
+    }
+    spectrum_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    spectrum = _load_spectrum_from_file(spectrum_file)
+    assert isinstance(spectrum, PowerLaw)
+    assert spectrum.index == pytest.approx(-2.62)
+    assert spectrum.e_ref == 1.0 * u.TeV
+
+
+def test_load_spectrum_from_file_log_parabola(tmp_test_directory):
+    spectrum_file = tmp_test_directory / "lp.yml"
+    config = {
+        "type": "LogParabola",
+        "normalization": 3.23e-11,
+        "normalization_unit": "1 / (cm2 s TeV sr)",
+        "a": -2.47,
+        "b": -0.24,
+    }
+    spectrum_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    spectrum = _load_spectrum_from_file(spectrum_file)
+    assert isinstance(spectrum, LogParabola)
+    assert spectrum.a == pytest.approx(-2.47)
+    assert spectrum.b == pytest.approx(-0.24)
+
+
+def test_load_spectrum_from_file_unknown_type_raises(tmp_test_directory):
+    spectrum_file = tmp_test_directory / "bad.yml"
+    config = {
+        "type": "BrokenPowerLaw",
+        "normalization": 1.0,
+        "normalization_unit": "1 / (cm2 s TeV sr)",
+    }
+    spectrum_file.write_text(yaml.dump(config), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported spectrum type"):
+        _load_spectrum_from_file(spectrum_file)
+
+
+def test_integrate_energy_spectrum_power_law():
+    """PowerLaw uses analytical integration."""
+    spectrum = PowerLaw(
+        normalization=9.8e-6 / (u.cm**2 * u.s * u.TeV * u.sr),
+        index=-2.62,
+        e_ref=1.0 * u.TeV,
+    )
+    result = _integrate_energy_spectrum(spectrum, 1.0 * u.TeV, 2.0 * u.TeV)
+    expected = spectrum.integrate_energy(1.0 * u.TeV, 2.0 * u.TeV)
+    assert result.decompose().value == pytest.approx(expected.decompose().value, rel=1e-6)
+
+
+def test_integrate_energy_spectrum_log_parabola():
+    """LogParabola uses numerical integration; result is physically reasonable."""
+    spectrum = LogParabola(
+        normalization=3.23e-11 / (u.cm**2 * u.s * u.TeV * u.sr),
+        a=-2.47,
+        b=-0.24,
+    )
+    result = _integrate_energy_spectrum(spectrum, 1.0 * u.TeV, 2.0 * u.TeV)
+    assert result.value > 0
+    # Cross-check that units reduce to flux * energy (per cm2 s sr)
+    assert result.unit.is_equivalent(u.cm**-2 * u.s**-1 * u.sr**-1)


### PR DESCRIPTION
Closes #931 

See the new integration test on how to use it.
