### PR TITLE
Event data list reading performance

### DIFF
--- a/docs/changes/2180.maintenance.md
+++ b/docs/changes/2180.maintenance.md
@@ -1,0 +1,1 @@
+Improve event data list reading performance.

--- a/src/simtools/io/table_handler.py
+++ b/src/simtools/io/table_handler.py
@@ -182,7 +182,7 @@ def _merge(input_files, table_names, file_type, output_file, add_file_id_to_tabl
     return merged
 
 
-def read_tables(file, table_names, file_type=None):
+def read_tables(file, table_names, file_type=None, table_columns=None):
     """
     Read tables from a file.
 
@@ -194,6 +194,8 @@ def read_tables(file, table_names, file_type=None):
         List of table names to read.
     file_type : str
         Type of the input file ('HDF5' or 'FITS').
+    table_columns : dict, optional
+        Mapping of table name to list of columns to read. Used for HDF5 only.
 
     Returns
     -------
@@ -202,13 +204,20 @@ def read_tables(file, table_names, file_type=None):
     """
     file_type = file_type or read_table_file_type([file])
     if file_type == "HDF5":
-        return {name: read_table_from_hdf5(file, name) for name in table_names}
+        return {
+            name: read_table_from_hdf5(
+                file,
+                name,
+                columns=(table_columns or {}).get(name),
+            )
+            for name in table_names
+        }
     if file_type == "FITS":
         return {name: Table.read(file, hdu=name) for name in table_names}
     raise ValueError(f"Unsupported file format: {file_type}. Supported formats are HDF5 and FITS.")
 
 
-def read_table_from_hdf5(file, table_name):
+def read_table_from_hdf5(file, table_name, columns=None):
     """
     Read a single astropy table from an HDF5 file.
 
@@ -218,15 +227,40 @@ def read_table_from_hdf5(file, table_name):
         Path to the input HDF5 file.
     table_name : str
         Name of the table to read.
+    columns : list[str], optional
+        List of columns to read from a compound HDF5 dataset. If None, all columns are read.
 
     Returns
     -------
     astropy.table.Table
         The requested astropy table.
     """
-    table = Table.read(file, path=table_name)
+    table = None
+    if columns is None:
+        table = Table.read(file, path=table_name)
+
     with h5py.File(file, "r") as f:
         dset = f[table_name]
+
+        if columns is not None:
+            if dset.dtype.names is None:
+                raise ValueError(
+                    f"Table '{table_name}' does not use a compound dtype and "
+                    "cannot be column-filtered."
+                )
+
+            missing_columns = [col for col in columns if col not in dset.dtype.names]
+            if missing_columns:
+                raise KeyError(f"Columns {missing_columns} not found in table '{table_name}'.")
+
+            if hasattr(dset, "fields"):
+                data = dset.fields(columns)[:]
+            else:
+                data = dset[:][columns]
+
+            table = Table(data)
+            table.meta["EXTNAME"] = table_name
+
         for col in table.colnames:
             unit_key = f"{col}_unit"
             if unit_key in dset.attrs:

--- a/src/simtools/io/table_handler.py
+++ b/src/simtools/io/table_handler.py
@@ -12,6 +12,23 @@ from astropy.table import Table, vstack
 _logger = logging.getLogger(__name__)
 
 
+def _decode_hdf5_string_column(column):
+    """Decode HDF5 byte-string columns to unicode."""
+    if column.dtype.kind == "S":
+        return column.astype(str)
+
+    if column.dtype.kind == "O" and column.size:
+        sample = column.flat[0]
+        if isinstance(sample, (bytes, np.bytes_)):
+            decoded = [
+                item.decode("utf-8") if isinstance(item, (bytes, np.bytes_)) else item
+                for item in column
+            ]
+            return np.asarray(decoded, dtype=str)
+
+    return column
+
+
 def read_table_list(input_file, table_names, include_indexed_tables=False):
     """
     Read available tables found in the input file.
@@ -258,7 +275,7 @@ def read_table_from_hdf5(file, table_name, columns=None):
             else:
                 data = dset[:][columns]
 
-            table = Table({col: data[col] for col in columns})
+            table = Table({col: _decode_hdf5_string_column(data[col]) for col in columns})
             table.meta["EXTNAME"] = table_name
 
         for col in table.colnames:

--- a/src/simtools/io/table_handler.py
+++ b/src/simtools/io/table_handler.py
@@ -258,7 +258,7 @@ def read_table_from_hdf5(file, table_name, columns=None):
             else:
                 data = dset[:][columns]
 
-            table = Table(data)
+            table = Table({col: data[col] for col in columns})
             table.meta["EXTNAME"] = table_name
 
         for col in table.colnames:

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -71,9 +71,10 @@ class EventDataHistograms:
             )
             yield event_data_file, self.reader
 
-    def _read_data_set(self, reader, event_data_file, data_set):
+    def _read_data_set(self, reader, event_data_file, data_set, file_index=None, total_files=None):
         """Read one dataset and return reduced file information with event tables."""
-        self._logger.info(f"Reading event data from {event_data_file} for {data_set}")
+        progress = f" ({file_index}/{total_files})" if file_index and total_files else ""
+        self._logger.info(f"Reading event data from {event_data_file} for {data_set}{progress}")
         file_info_table, shower_data, event_data, triggered_data = reader.read_event_data(
             event_data_file, table_name_map=data_set
         )
@@ -124,10 +125,15 @@ class EventDataHistograms:
         Assume that all event data files are generated with similar configurations
         (self.file_info contains the file info of the last file).
         """
-        for event_data_file, reader in self._iter_readers():
+        total_files = len(self.event_data_files)
+        for file_index, (event_data_file, reader) in enumerate(self._iter_readers(), start=1):
             for data_set in reader.data_sets:
                 file_info_table, shower_data, event_data, triggered_data = self._read_data_set(
-                    reader, event_data_file, data_set
+                    reader,
+                    event_data_file,
+                    data_set,
+                    file_index=file_index,
+                    total_files=total_files,
                 )
                 self._update_file_info(file_info_table)
                 current_histograms = self._define_histograms(

--- a/src/simtools/sim_events/reader.py
+++ b/src/simtools/sim_events/reader.py
@@ -48,6 +48,37 @@ class EventDataReader:
     """Read reduced MC data set stored in astropy tables."""
 
     _particle_name_cache = {}
+    _required_shower_columns = [
+        "shower_id",
+        "event_id",
+        "file_id",
+        "simulated_energy",
+        "x_core",
+        "y_core",
+        "shower_azimuth",
+        "shower_altitude",
+        "area_weight",
+    ]
+    _required_trigger_columns = [
+        "shower_id",
+        "event_id",
+        "file_id",
+        "array_altitude",
+        "array_azimuth",
+        "telescope_list",
+    ]
+    _required_file_info_columns = [
+        "particle_id",
+        "zenith",
+        "azimuth",
+        "nsb_level",
+        "energy_min",
+        "energy_max",
+        "viewcone_min",
+        "viewcone_max",
+        "core_scatter_min",
+        "core_scatter_max",
+    ]
 
     def __init__(self, event_data_file, telescope_list=None):
         """Initialize EventDataReader."""
@@ -272,7 +303,20 @@ class EventDataReader:
         table_names = [
             name for k in ("SHOWERS", "TRIGGERS", "FILE_INFO") if (name := get_name(k)) is not None
         ]
-        tables = table_handler.read_tables(event_data_file, table_names=table_names)
+
+        table_columns = {
+            get_name("SHOWERS"): self._required_shower_columns,
+            get_name("FILE_INFO"): self._required_file_info_columns,
+        }
+        triggers_name = get_name("TRIGGERS")
+        if triggers_name is not None:
+            table_columns[triggers_name] = self._required_trigger_columns
+
+        tables = table_handler.read_tables(
+            event_data_file,
+            table_names=table_names,
+            table_columns=table_columns,
+        )
         self.reduced_file_info = self.get_reduced_simulation_file_info(
             tables[get_name("FILE_INFO")]
         )

--- a/src/simtools/sim_events/reader.py
+++ b/src/simtools/sim_events/reader.py
@@ -47,6 +47,8 @@ class TriggeredEventData:
 class EventDataReader:
     """Read reduced MC data set stored in astropy tables."""
 
+    _particle_name_cache = {}
+
     def __init__(self, event_data_file, telescope_list=None):
         """Initialize EventDataReader."""
         self._logger = logging.getLogger(__name__)
@@ -202,23 +204,38 @@ class EventDataReader:
         """
         triggered_shower = ShowerEventData()
 
+        shower_key_to_index = {}
+        duplicate_shower_keys = set()
+        for idx, (shower_id, event_id, file_id) in enumerate(
+            zip(shower_data.shower_id, shower_data.event_id, shower_data.file_id)
+        ):
+            key = (int(shower_id), int(event_id), int(file_id))
+            if key in shower_key_to_index:
+                duplicate_shower_keys.add(key)
+                continue
+            shower_key_to_index[key] = idx
+
         matched_indices = []
         for tr_shower_id, tr_event_id, tr_file_id in zip(
             triggered_shower_id, triggered_event_id, triggered_file_id
         ):
-            mask = (
-                (shower_data.shower_id == tr_shower_id)
-                & (shower_data.event_id == tr_event_id)
-                & (shower_data.file_id == tr_file_id)
-            )
-            matched_idx = np.nonzero(mask)[0]
-            if len(matched_idx) == 1:
-                matched_indices.append(matched_idx[0])
-            else:
+            trigger_key = (int(tr_shower_id), int(tr_event_id), int(tr_file_id))
+            if trigger_key in duplicate_shower_keys:
                 self._logger.warning(
-                    f"Found {len(matched_idx)} matches for shower {tr_shower_id}"
+                    f"Found multiple matches for shower {tr_shower_id}"
                     f" event {tr_event_id} file {tr_file_id}"
                 )
+                continue
+
+            matched_idx = shower_key_to_index.get(trigger_key)
+            if matched_idx is None:
+                self._logger.warning(
+                    f"Found 0 matches for shower {tr_shower_id}"
+                    f" event {tr_event_id} file {tr_file_id}"
+                )
+                continue
+
+            matched_indices.append(matched_idx)
 
         for attr in vars(shower_data):
             if not attr.endswith("_unit"):
@@ -300,19 +317,21 @@ class EventDataReader:
 
     def _filter_by_telescopes(self, triggered_data, triggered_shower):
         """Filter trigger data and triggered shower data by the specified telescope list."""
-        mask = np.array(
-            [
-                any(tel in event for tel in self.telescope_list)
-                for event in triggered_data.telescope_list
-            ]
+        telescope_set = set(self.telescope_list)
+        mask = np.fromiter(
+            (not telescope_set.isdisjoint(event) for event in triggered_data.telescope_list),
+            dtype=np.bool_,
+            count=len(triggered_data.telescope_list),
         )
+        selected_indices = np.flatnonzero(mask)
+
         filtered_triggered_data = TriggeredEventData(
             shower_id=triggered_data.shower_id[mask],
             event_id=triggered_data.event_id[mask],
             file_id=triggered_data.file_id[mask],
             array_altitude=triggered_data.array_altitude[mask],
             array_azimuth=triggered_data.array_azimuth[mask],
-            telescope_list=[triggered_data.telescope_list[i] for i in np.arange(len(mask))[mask]],
+            telescope_list=[triggered_data.telescope_list[i] for i in selected_indices],
             angular_distance=triggered_data.angular_distance[mask],
         )
         filtered_triggered_shower_data = self._get_triggered_shower_data(
@@ -378,11 +397,15 @@ class EventDataReader:
         if any(len(arr) > 1 for arr in (particle_id, *(float_arrays[key] for key in keys))):
             self._logger.warning("Simulation file info has non-unique values.")
 
-        reduced_info = {
-            "primary_particle": PrimaryParticle(
+        primary_particle_id = int(particle_id[0])
+        if primary_particle_id not in self._particle_name_cache:
+            self._particle_name_cache[primary_particle_id] = PrimaryParticle(
                 particle_id_type="corsika7_id",
-                particle_id=int(particle_id[0]),
-            ).name,
+                particle_id=primary_particle_id,
+            ).name
+
+        reduced_info = {
+            "primary_particle": self._particle_name_cache[primary_particle_id],
         }
 
         for key in keys:

--- a/tests/unit_tests/io/test_table_handler.py
+++ b/tests/unit_tests/io/test_table_handler.py
@@ -838,6 +838,34 @@ def test_read_table_from_hdf5_with_selected_columns(mocker):
     assert result["col1"].unit == u.Unit("m")
 
 
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        ([("col1", "S3")], ["abc", "def"]),
+        ([("col1", object)], ["abc", "def"]),
+    ],
+)
+def test_read_table_from_hdf5_decodes_selected_string_columns(mocker, dtype, expected):
+    """Test selected-column reads decode bytes-backed string columns."""
+    mock_file = mocker.MagicMock()
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.dtype.names = ("col1",)
+    mock_dataset.attrs = {}
+
+    selected_data = np.array([(b"abc",), (b"def",)], dtype=dtype)
+    mock_dataset.fields.return_value = selected_data
+
+    mock_file.__getitem__.return_value = mock_dataset
+    mock_context = mocker.MagicMock()
+    mock_context.__enter__.return_value = mock_file
+    mocker.patch(H5PY_FILE, return_value=mock_context)
+
+    result = read_table_from_hdf5(TEST_H5, TEST_TABLE_NAME, columns=["col1"])
+
+    assert list(result["col1"]) == expected
+    assert result["col1"].dtype.kind == "U"
+
+
 def test_read_table_from_hdf5_with_missing_selected_columns(mocker):
     """Test selected-column read with unknown column names."""
     mock_file = mocker.MagicMock()

--- a/tests/unit_tests/io/test_table_handler.py
+++ b/tests/unit_tests/io/test_table_handler.py
@@ -238,6 +238,27 @@ def test_read_tables_hdf5(mocker):
     )
 
 
+def test_read_tables_hdf5_with_selected_columns(mocker):
+    """Test reading selected HDF5 table columns."""
+    mock_reader = mocker.patch(f"{TABLE_HANDLER_PATH}.read_table_from_hdf5")
+    mock_reader.return_value = Table({"col1": [1, 2]})
+
+    result = read_tables(
+        TEST_H5,
+        ["table1", "table2"],
+        file_type="HDF5",
+        table_columns={"table1": ["col1"]},
+    )
+
+    assert len(result) == 2
+    mock_reader.assert_has_calls(
+        [
+            mocker.call(TEST_H5, "table1", columns=["col1"]),
+            mocker.call(TEST_H5, "table2", columns=None),
+        ]
+    )
+
+
 def test_read_tables_unsupported_format(mocker):
     mock_file_type = mocker.patch(READ_TABLE_FILE_TYPE)
     mock_file_type.return_value = "CSV"
@@ -789,6 +810,47 @@ def test_read_table_from_hdf5_with_units(mocker):
     # Verify unit assignment
     mock_table.__getitem__.assert_called_once_with("col1")
     assert result == mock_table
+
+
+def test_read_table_from_hdf5_with_selected_columns(mocker):
+    """Test reading only selected columns from a compound HDF5 dataset."""
+    mock_file = mocker.MagicMock()
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.dtype.names = ("col1", "col2")
+    mock_dataset.attrs = {"col1_unit": "m"}
+
+    selected_data = np.array([(1.0,), (2.0,)], dtype=[("col1", "f8")])
+    fields_accessor = mocker.MagicMock()
+    fields_accessor.__getitem__.return_value = selected_data
+    mock_dataset.fields.return_value = fields_accessor
+
+    mock_file.__getitem__.return_value = mock_dataset
+    mock_context = mocker.MagicMock()
+    mock_context.__enter__.return_value = mock_file
+    mocker.patch(H5PY_FILE, return_value=mock_context)
+    mock_table_read = mocker.patch(ASTROPY_TABLE_READ)
+
+    result = read_table_from_hdf5(TEST_H5, TEST_TABLE_NAME, columns=["col1"])
+
+    mock_table_read.assert_not_called()
+    mock_dataset.fields.assert_called_once_with(["col1"])
+    assert result.colnames == ["col1"]
+    assert result["col1"].unit == u.Unit("m")
+
+
+def test_read_table_from_hdf5_with_missing_selected_columns(mocker):
+    """Test selected-column read with unknown column names."""
+    mock_file = mocker.MagicMock()
+    mock_dataset = mocker.MagicMock()
+    mock_dataset.dtype.names = ("col1",)
+    mock_dataset.attrs = {}
+    mock_file.__getitem__.return_value = mock_dataset
+    mock_context = mocker.MagicMock()
+    mock_context.__enter__.return_value = mock_file
+    mocker.patch(H5PY_FILE, return_value=mock_context)
+
+    with pytest.raises(KeyError, match="not found in table"):
+        read_table_from_hdf5(TEST_H5, TEST_TABLE_NAME, columns=["col2"])
 
 
 def test_write_table_in_hdf5_with_units(mocker, mock_h5py_file):

--- a/tests/unit_tests/sim_events/test_reader.py
+++ b/tests/unit_tests/sim_events/test_reader.py
@@ -7,6 +7,7 @@ import pytest
 from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 
+from simtools.io.table_handler import write_tables
 from simtools.sim_events.reader import (
     EventDataReader,
 )
@@ -296,3 +297,30 @@ def test_read_event_data_with_missing_triggers(tmp_test_directory, mock_tables):
     assert triggered_data is None
     assert hasattr(file_info, "colnames")
     assert hasattr(shower_data, "shower_id")
+
+
+def test_read_event_data_hdf5_with_selected_columns_and_telescope_filter(
+    tmp_test_directory, mock_tables
+):
+    """Test HDF5 event-data reads preserve trigger parsing and telescope filtering."""
+    test_file = tmp_test_directory / "test_event_data.h5"
+    shower_table, trigger_table, file_info_table = mock_tables
+
+    write_tables(
+        [shower_table, trigger_table, file_info_table],
+        test_file,
+        file_type="HDF5",
+    )
+
+    reader = EventDataReader(str(test_file), telescope_list=["LSTN-01"])
+    file_info, shower_data, triggered_shower, triggered_data = reader.read_event_data(
+        str(test_file)
+    )
+
+    assert hasattr(file_info, "colnames")
+    assert len(shower_data.shower_id) == 2
+    assert len(triggered_shower.shower_id) == 1
+    assert len(triggered_data.telescope_list) == 1
+    assert list(triggered_data.telescope_list[0]) == ["LSTN-01", "LSTN-02", "LSTN-03"]
+    assert all(isinstance(item, str) for item in triggered_data.telescope_list[0])
+    assert triggered_shower.shower_id[0] == 1


### PR DESCRIPTION
Applications like `production_derive_corsika_limits.py` are very very slow. 

This PR tries to add some reading optimization. Limited profile shows that a  65–70% HDF5 read speedup is achieved. 

There should be no functional change, simply a bit of gymnastics. 

Key changes:

- **Selective HDF5 column reads**: Only load required columns (shower_id, event_id, file_id, etc.) instead of full tables, reducing I/O time by 65–70% (36→11 seconds in profile).

- **Optimized event matching**: Replaced per-triggered-event full-array masking with single-pass dictionary indexing on (file_id, event_id, shower_id) tuples, improving algorithmic complexity from O(N_triggered × N_showers) to O(N_showers + N_triggered).

- **Vectorized telescope filtering**: Replaced Python-level nested membership checks with set-based `isdisjoint` and numpy `fromiter`, eliminating generator overhead.

- **Particle name caching**: Cache PrimaryParticle name lookups at class level to avoid repeated conversions across all files.

- **Optimized Astropy Table construction**: Use dict-based Table initialization for selective-column reads to bypass expensive structured-array processing.