### PR TITLE
Allow to run derivation of corsika limits in parallel

### DIFF
--- a/docs/changes/2182.feature.md
+++ b/docs/changes/2182.feature.md
@@ -1,1 +1,1 @@
-Add the possibility to run the derivation of corsika limits in parallel - e.g. for several zenith angles..
+Add the possibility to run the derivation of CORSIKA limits in parallel - e.g. for several zenith angles.

--- a/docs/changes/2182.feature.md
+++ b/docs/changes/2182.feature.md
@@ -1,0 +1,1 @@
+Add the possibility to run the derivation of corsika limits in parallel - e.g. for several zenith angles..

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -64,8 +64,7 @@ plot_histograms (bool, optional)
 output_file (str, optional)
     Path to the output file for the derived limits.
 n_workers (int, optional)
-    Number of parallel worker processes to use for multi-production execution. Default is 1
-    (on parallel workers). Used only when multiple event_data_file patterns are provided.
+    Number of worker processes to use for execution. Default is 1.
 
 Example
 -------
@@ -143,7 +142,7 @@ def _add_arguments(parser):
     )
     parser.add_argument(
         "--n_workers",
-        help="Number of parallel worker processes to use for multi-production execution.",
+        help="Number of worker processes to use for execution.",
         type=int,
         required=False,
         default=1,

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -143,7 +143,10 @@ def _add_arguments(parser):
     )
     parser.add_argument(
         "--n_workers",
-        help="Number of worker processes to use for execution.",
+        help=(
+            "Number of worker processes to use for execution "
+            "(default: 1; set to 0 for auto-detection of available cores)."
+        ),
         type=int,
         required=False,
         default=1,

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -43,10 +43,18 @@ The input event data files are generated using the application simtools-generate
 and are required for each point in the observational parameter space (e.g., array pointing
 directions, level of night sky background, etc.).
 
+Multi-production support
+------------------------
+To process multiple independent production datasets in parallel, provide multiple glob patterns
+via ``--event_data_file``. Each pattern is processed as a separate production, with results
+merged into a single output ECSV file. Plot files are organized into per-production subdirectories.
+
 Command line arguments
 ----------------------
-event_data_file (str, required)
-    Path or glob pattern for reduced event data files.
+event_data_file (str or list of str, required)
+    Path or glob pattern for reduced event data files. Can be a single pattern or
+    multiple patterns (one per ``--event_data_file`` argument) to enable parallel
+    multi-production processing.
 telescope_ids (str, optional)
     Custom array layout file containing telescope IDs.
 loss_fraction (float, required)
@@ -55,11 +63,14 @@ plot_histograms (bool, optional)
     Plot histograms of the event data.
 output_file (str, optional)
     Path to the output file for the derived limits.
+n_workers (int, optional)
+    Number of parallel worker processes to use for multi-production execution. Default is 1
+    (on parallel workers). Used only when multiple event_data_file patterns are provided.
 
 Example
 -------
 
-Derive limits for a list of array layouts (use 'all' to derive limits for all layouts):
+Derive limits for a single production with a list of array layouts:
 
 .. code-block:: console
 
@@ -70,7 +81,7 @@ Derive limits for a list of array layouts (use 'all' to derive limits for all la
         --plot_histograms \\
         --output_file corsika_simulation_limits.ecsv
 
-Derive limits for a given file for custom defined array layouts:
+Derive limits for a single production with a given file for custom defined array layouts:
 
 .. code-block:: console
 
@@ -81,16 +92,22 @@ Derive limits for a given file for custom defined array layouts:
         --plot_histograms \\
         --output_file corsika_simulation_limits.ecsv
 
-Derive limits for an inline list of array elements:
+Derive limits for multiple independent productions in parallel:
 
 .. code-block:: console
 
     simtools-production-derive-corsika-limits \\
-        --event_data_file event_dat_file.hdf5 \\
-        --array_element_list LSTN-01 LSTN-02 MSTN-03 \\
+        --event_data_file pattern_1_*.hdf5 \\
+        --event_data_file pattern_2_*.hdf5 \\
+        --array_layout_name alpha \\
         --loss_fraction 1e-6 \\
         --plot_histograms \\
+        --n_workers 4 \\
         --output_file corsika_simulation_limits.ecsv
+
+When multiple ``--event_data_file`` patterns are provided, results are merged into a single output
+ECSV with a ``production_index`` column, and plot files are organized into per-production
+subdirectories derived from the input pattern names (for example ``production_production_a/``).
 """
 
 from simtools.application_control import build_application
@@ -101,7 +118,17 @@ from simtools.production_configuration.derive_corsika_limits import (
 
 def _add_arguments(parser):
     """Register application-specific command line arguments."""
-    parser.initialize_application_arguments(["telescope_ids", "event_data_file"])
+    parser.initialize_application_arguments(["telescope_ids"])
+    # Override event_data_file to allow multiple patterns for multi-production support
+    parser.add_argument(
+        "--event_data_file",
+        help=(
+            "Event data file or glob pattern (one or more patterns for "
+            "multi-production processing)."
+        ),
+        nargs="+",
+        required=True,
+    )
     parser.add_argument(
         "--loss_fraction",
         type=float,
@@ -113,6 +140,13 @@ def _add_arguments(parser):
         help="Plot histograms of the event data.",
         action="store_true",
         default=False,
+    )
+    parser.add_argument(
+        "--n_workers",
+        help="Number of parallel worker processes to use for multi-production execution.",
+        type=int,
+        required=False,
+        default=1,
     )
 
 

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -126,6 +126,7 @@ def _add_arguments(parser):
             "multi-production processing)."
         ),
         nargs="+",
+        action="extend",
         required=True,
     )
     parser.add_argument(

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -2,6 +2,8 @@
 
 import datetime
 import logging
+import re
+from pathlib import Path
 
 import astropy.units as u
 import numpy as np
@@ -9,23 +11,160 @@ from astropy.table import Column, Table
 
 from simtools.data_model.metadata_collector import MetadataCollector
 from simtools.io import ascii_handler, io_handler
+from simtools.job_execution.process_pool import process_pool_map_ordered
 from simtools.layout.array_layout_utils import get_array_elements_from_db_for_layouts
 from simtools.sim_events.histograms import EventDataHistograms
+from simtools.utils.general import get_uuid
 from simtools.utils.names import normalize_array_element_identifier_container
 from simtools.visualization import plot_simtel_event_histograms
 
 _logger = logging.getLogger(__name__)
 
 
+def _normalize_event_data_file(event_data_file):
+    """
+    Normalize event_data_file to an ordered list of production patterns.
+
+    Parameters
+    ----------
+    event_data_file : str or list
+        A single pattern string or list of pattern strings.
+
+    Returns
+    -------
+    list
+        Ordered list of event data file patterns.
+    """
+    if isinstance(event_data_file, str):
+        return [event_data_file]
+    if isinstance(event_data_file, list):
+        return list(event_data_file)
+    raise TypeError(f"event_data_file must be str or list, got {type(event_data_file)}")
+
+
+def _get_production_directory_name(production_pattern, existing_names=None):
+    """
+    Generate a readable, filesystem-safe production directory name.
+
+    The name is derived from the glob pattern and kept human-readable.
+    If a collision is detected with an existing directory name, append
+    a UUID7 suffix.
+
+    Parameters
+    ----------
+    production_pattern : str
+        The glob pattern for this production.
+    existing_names : set[str] or None
+        Existing directory names used in this run.
+
+    Returns
+    -------
+    str
+        Safe directory name (e.g., "production_prod_a_events").
+    """
+    pattern_path = Path(production_pattern)
+    parts = []
+
+    if pattern_path.parent.name and pattern_path.parent.name != ".":
+        parts.append(pattern_path.parent.name)
+    if pattern_path.stem:
+        parts.append(pattern_path.stem)
+
+    readable_name = "_".join(parts) if parts else "production"
+    readable_name = re.sub(r"[^A-Za-z0-9]+", "_", readable_name)
+    readable_name = readable_name.strip("_")
+    readable_name = re.sub(r"_+", "_", readable_name)
+
+    if not readable_name:
+        readable_name = "production"
+
+    base_name = f"production_{readable_name}"
+
+    if existing_names is None or base_name not in existing_names:
+        return base_name
+
+    return f"{base_name}_{get_uuid()}"
+
+
+def _execute_production_job(job_spec):
+    """
+    Execute a single production job (top-level picklable worker).
+
+    This function is called by process_pool_map_ordered and must be
+    picklable (top-level defined).
+
+    Parameters
+    ----------
+    job_spec : dict
+        Dictionary containing:
+        - production_index (int)
+        - production_pattern (str)
+        - array_name (str)
+        - telescope_ids (list)
+        - loss_fraction (float)
+        - plot_histograms (bool)
+        - output_subdir (Path or None)
+
+    Returns
+    -------
+    dict
+        Result dictionary with limits and production metadata.
+    """
+    production_index = job_spec["production_index"]
+    production_pattern = job_spec["production_pattern"]
+    array_name = job_spec["array_name"]
+    telescope_ids = job_spec["telescope_ids"]
+    loss_fraction = job_spec["loss_fraction"]
+    plot_histograms = job_spec["plot_histograms"]
+    output_subdir = job_spec.get("output_subdir")
+
+    _logger.info(
+        f"Processing production {production_index}: pattern={production_pattern}, "
+        f"array={array_name}"
+    )
+
+    result = _process_file(
+        production_pattern,
+        array_name,
+        telescope_ids,
+        loss_fraction,
+        plot_histograms,
+        output_subdir=output_subdir,
+    )
+
+    result["production_index"] = production_index
+    result["event_data_file"] = production_pattern
+    result["array_name"] = array_name
+    result["telescope_ids"] = telescope_ids
+
+    return result
+
+
 def generate_corsika_limits_grid(args_dict):
     """
-    Generate CORSIKA limits.
+    Generate CORSIKA limits, supporting single or multi-production execution.
+
+    Handles both single event_data_file (string) and multiple patterns (list),
+    dispatching jobs in parallel if multiple patterns are provided.
 
     Parameters
     ----------
     args_dict : dict
-        Dictionary containing command line arguments.
+        Dictionary containing command line arguments, including:
+        - event_data_file: str or list of patterns
+        - loss_fraction: float
+        - plot_histograms: bool
+        - n_workers: int (default 1 for single use)
+        - array_layout_name, array_element_list, or telescope_ids for telescope config
     """
+    # Normalize event_data_file to list
+    production_patterns = _normalize_event_data_file(args_dict["event_data_file"])
+    n_productions = len(production_patterns)
+    is_multi_production = n_productions > 1
+
+    _logger.info(f"Processing {n_productions} production(s)")
+
+    # Resolve telescope configurations (same logic as before)
     if args_dict.get("array_layout_name"):
         telescope_configs = get_array_elements_from_db_for_layouts(
             args_dict["array_layout_name"],
@@ -44,27 +183,66 @@ def generate_corsika_limits_grid(args_dict):
             "--array_element_list, or --telescope_ids."
         )
 
-    results = []
-    for array_name, telescope_ids in telescope_configs.items():
-        telescope_ids = normalize_array_element_identifier_container(telescope_ids)
-        _logger.info(
-            f"Processing file: {args_dict['event_data_file']} with telescope config: {array_name}"
-        )
-        result = _process_file(
-            args_dict["event_data_file"],
-            array_name,
-            telescope_ids,
-            args_dict["loss_fraction"],
-            args_dict["plot_histograms"],
-        )
-        result["array_name"] = array_name
-        result["telescope_ids"] = telescope_ids
-        results.append(result)
+    # Build deterministic job specs: Cartesian product of productions and telescope configs
+    job_specs = []
+    output_dir = io_handler.IOHandler().get_output_directory()
 
+    production_subdirs = {}
+    used_subdir_names = set()
+
+    for production_pattern in production_patterns:
+        subdir_name = _get_production_directory_name(production_pattern, used_subdir_names)
+        used_subdir_names.add(subdir_name)
+        production_subdirs[production_pattern] = subdir_name
+
+    for prod_idx, production_pattern in enumerate(production_patterns):
+        for array_name, telescope_ids_raw in telescope_configs.items():
+            telescope_ids = normalize_array_element_identifier_container(telescope_ids_raw)
+
+            # Create subdirectory for plots if multi-production
+            output_subdir = None
+            if is_multi_production:
+                subdir_name = production_subdirs[production_pattern]
+                output_subdir = output_dir / subdir_name
+                # Ensure directory exists (compatible with both pathlib.Path and py.path.local)
+                Path(output_subdir).mkdir(parents=True, exist_ok=True)
+
+            job_spec = {
+                "production_index": prod_idx,
+                "production_pattern": production_pattern,
+                "array_name": array_name,
+                "telescope_ids": telescope_ids,
+                "loss_fraction": args_dict["loss_fraction"],
+                "plot_histograms": args_dict["plot_histograms"],
+                "output_subdir": output_subdir,
+            }
+            job_specs.append(job_spec)
+
+    # Execute jobs (parallel if multi-production, otherwise direct)
+    if is_multi_production:
+        n_workers = int(args_dict.get("n_workers", 1))
+        _logger.info(f"Executing {len(job_specs)} jobs with {n_workers or 'auto'} workers")
+        results = process_pool_map_ordered(
+            _execute_production_job,
+            job_specs,
+            max_workers=n_workers,
+        )
+    else:
+        # Single production: execute directly without process pool overhead
+        results = [_execute_production_job(job_spec) for job_spec in job_specs]
+
+    # Write merged results
     write_results(results, args_dict)
 
 
-def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_histograms):
+def _process_file(
+    file_path,
+    array_name,
+    telescope_ids,
+    loss_fraction,
+    plot_histograms,
+    output_subdir=None,
+):
     """
     Compute limits for a given event data file and telescope configuration.
 
@@ -82,6 +260,8 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
         Fraction of events to be lost.
     plot_histograms : bool
         Whether to plot histograms.
+    output_subdir : Path or None, optional
+        Output subdirectory for plots. If None, uses default output directory.
 
     Returns
     -------
@@ -108,9 +288,11 @@ def _process_file(file_path, array_name, telescope_ids, loss_fraction, plot_hist
     )
 
     if plot_histograms:
+        # Use provided subdirectory or default output directory
+        plot_output_path = output_subdir or io_handler.IOHandler().get_output_directory()
         plot_simtel_event_histograms.plot(
             histograms.histograms,
-            output_path=io_handler.IOHandler().get_output_directory(),
+            output_path=plot_output_path,
             limits=limits,
             array_name=array_name,
         )
@@ -145,6 +327,7 @@ def _create_results_table(results, loss_fraction):
     Convert list of simulation results to an astropy Table with metadata.
 
     Round values to appropriate precision and add metadata.
+    For multi-production execution, includes production-origin columns.
 
     Parameters
     ----------
@@ -156,19 +339,29 @@ def _create_results_table(results, loss_fraction):
     Returns
     -------
     astropy.table.Table
-        Table with computed limits.
+        Table with computed limits and optional production-origin columns.
     """
-    cols = [
-        "primary_particle",
-        "array_name",
-        "telescope_ids",
-        "zenith",
-        "azimuth",
-        "nsb_level",
-        "lower_energy_limit",
-        "upper_radius_limit",
-        "viewcone_radius",
-    ]
+    # Check if this is multi-production (results have production_index field)
+    is_multi_production = any("production_index" in res for res in results)
+
+    # Build column list: production-origin first (if multi-production), then standard columns
+    cols = []
+    if is_multi_production:
+        cols.extend(["production_index", "event_data_file"])
+
+    cols.extend(
+        [
+            "primary_particle",
+            "array_name",
+            "telescope_ids",
+            "zenith",
+            "azimuth",
+            "nsb_level",
+            "lower_energy_limit",
+            "upper_radius_limit",
+            "viewcone_radius",
+        ]
+    )
 
     columns = {name: [] for name in cols}
     units = {}

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -212,11 +212,13 @@ def generate_corsika_limits_grid(args_dict):
     job_specs = []
     output_dir = io_handler.IOHandler().get_output_directory()
 
-    production_subdirs = _build_production_subdirectories(
-        production_patterns,
-        output_dir,
-        is_multi_production,
-    )
+    production_subdirs = {}
+    if is_multi_production and args_dict["plot_histograms"]:
+        production_subdirs = _build_production_subdirectories(
+            production_patterns,
+            output_dir,
+            is_multi_production,
+        )
 
     for prod_idx, production_pattern in enumerate(production_patterns):
         for array_name, telescope_ids_raw in telescope_configs.items():

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -96,14 +96,7 @@ def _execute_production_job(job_spec):
     Parameters
     ----------
     job_spec : dict
-        Dictionary containing:
-        - production_index (int)
-        - production_pattern (str)
-        - array_name (str)
-        - telescope_ids (list)
-        - loss_fraction (float)
-        - plot_histograms (bool)
-        - output_subdir (Path or None)
+        Dictionary containing with job specifications
 
     Returns
     -------
@@ -142,29 +135,22 @@ def _execute_production_job(job_spec):
 
 def generate_corsika_limits_grid(args_dict):
     """
-    Generate CORSIKA limits, supporting single or multi-production execution.
+    Generate CORSIKA limits for one or more production patterns.
 
-    Handles both single event_data_file (string) and multiple patterns (list),
-    dispatching jobs in parallel if multiple patterns are provided.
+    Single- and multi-production runs share the same dispatch path using
+    process_pool_map_ordered.
 
     Parameters
     ----------
     args_dict : dict
-        Dictionary containing command line arguments, including:
-        - event_data_file: str or list of patterns
-        - loss_fraction: float
-        - plot_histograms: bool
-        - n_workers: int (default 1 for single use)
-        - array_layout_name, array_element_list, or telescope_ids for telescope config
+        Dictionary containing command line arguments.
     """
-    # Normalize event_data_file to list
     production_patterns = _normalize_event_data_file(args_dict["event_data_file"])
     n_productions = len(production_patterns)
     is_multi_production = n_productions > 1
 
     _logger.info(f"Processing {n_productions} production(s)")
 
-    # Resolve telescope configurations (same logic as before)
     if args_dict.get("array_layout_name"):
         telescope_configs = get_array_elements_from_db_for_layouts(
             args_dict["array_layout_name"],
@@ -199,12 +185,10 @@ def generate_corsika_limits_grid(args_dict):
         for array_name, telescope_ids_raw in telescope_configs.items():
             telescope_ids = normalize_array_element_identifier_container(telescope_ids_raw)
 
-            # Create subdirectory for plots if multi-production
             output_subdir = None
             if is_multi_production:
                 subdir_name = production_subdirs[production_pattern]
                 output_subdir = output_dir / subdir_name
-                # Ensure directory exists (compatible with both pathlib.Path and py.path.local)
                 Path(output_subdir).mkdir(parents=True, exist_ok=True)
 
             job_spec = {
@@ -218,20 +202,14 @@ def generate_corsika_limits_grid(args_dict):
             }
             job_specs.append(job_spec)
 
-    # Execute jobs (parallel if multi-production, otherwise direct)
-    if is_multi_production:
-        n_workers = int(args_dict.get("n_workers", 1))
-        _logger.info(f"Executing {len(job_specs)} jobs with {n_workers or 'auto'} workers")
-        results = process_pool_map_ordered(
-            _execute_production_job,
-            job_specs,
-            max_workers=n_workers,
-        )
-    else:
-        # Single production: execute directly without process pool overhead
-        results = [_execute_production_job(job_spec) for job_spec in job_specs]
+    n_workers = int(args_dict.get("n_workers", 1))
+    _logger.info(f"Executing {len(job_specs)} jobs with {n_workers or 'auto'} workers")
+    results = process_pool_map_ordered(
+        _execute_production_job,
+        job_specs,
+        max_workers=n_workers,
+    )
 
-    # Write merged results
     write_results(results, args_dict)
 
 
@@ -288,7 +266,6 @@ def _process_file(
     )
 
     if plot_histograms:
-        # Use provided subdirectory or default output directory
         plot_output_path = output_subdir or io_handler.IOHandler().get_output_directory()
         plot_simtel_event_histograms.plot(
             histograms.histograms,
@@ -341,27 +318,19 @@ def _create_results_table(results, loss_fraction):
     astropy.table.Table
         Table with computed limits and optional production-origin columns.
     """
-    # Check if this is multi-production (results have production_index field)
-    is_multi_production = any("production_index" in res for res in results)
-
-    # Build column list: production-origin first (if multi-production), then standard columns
-    cols = []
-    if is_multi_production:
-        cols.extend(["production_index", "event_data_file"])
-
-    cols.extend(
-        [
-            "primary_particle",
-            "array_name",
-            "telescope_ids",
-            "zenith",
-            "azimuth",
-            "nsb_level",
-            "lower_energy_limit",
-            "upper_radius_limit",
-            "viewcone_radius",
-        ]
-    )
+    cols = [
+        "production_index",
+        "event_data_file",
+        "primary_particle",
+        "array_name",
+        "telescope_ids",
+        "zenith",
+        "azimuth",
+        "nsb_level",
+        "lower_energy_limit",
+        "upper_radius_limit",
+        "viewcone_radius",
+    ]
 
     columns = {name: [] for name in cols}
     units = {}

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -20,6 +20,21 @@ from simtools.visualization import plot_simtel_event_histograms
 
 _logger = logging.getLogger(__name__)
 
+FILE_INFO_KEYS = ("primary_particle", "zenith", "azimuth", "nsb_level")
+RESULT_COLUMNS = [
+    "production_index",
+    "event_data_file",
+    "primary_particle",
+    "array_name",
+    "telescope_ids",
+    "zenith",
+    "azimuth",
+    "nsb_level",
+    "lower_energy_limit",
+    "upper_radius_limit",
+    "viewcone_radius",
+]
+
 
 def _normalize_event_data_file(event_data_file):
     """
@@ -125,12 +140,52 @@ def _execute_production_job(job_spec):
         output_subdir=output_subdir,
     )
 
-    result["production_index"] = production_index
-    result["event_data_file"] = production_pattern
-    result["array_name"] = array_name
-    result["telescope_ids"] = telescope_ids
+    result.update(
+        {
+            "production_index": production_index,
+            "event_data_file": production_pattern,
+            "array_name": array_name,
+            "telescope_ids": telescope_ids,
+        }
+    )
 
     return result
+
+
+def _resolve_telescope_configs(args_dict):
+    """Resolve telescope configurations from one of the supported input options."""
+    if args_dict.get("array_layout_name"):
+        return get_array_elements_from_db_for_layouts(
+            args_dict["array_layout_name"],
+            args_dict.get("site"),
+            args_dict.get("model_version"),
+        )
+    if args_dict.get("array_element_list"):
+        return {"array_element_list": args_dict["array_element_list"]}
+    if args_dict.get("telescope_ids"):
+        return ascii_handler.collect_data_from_file(args_dict["telescope_ids"])["telescope_configs"]
+
+    raise ValueError(
+        "No telescope configuration provided. Use one of --array_layout_name, "
+        "--array_element_list, or --telescope_ids."
+    )
+
+
+def _build_production_subdirectories(production_patterns, output_dir, is_multi_production):
+    """Build and create per-production output subdirectories when needed."""
+    if not is_multi_production:
+        return {}
+
+    production_subdirs = {}
+    used_subdir_names = set()
+    for production_pattern in production_patterns:
+        subdir_name = _get_production_directory_name(production_pattern, used_subdir_names)
+        used_subdir_names.add(subdir_name)
+        output_subdir = output_dir / subdir_name
+        Path(output_subdir).mkdir(parents=True, exist_ok=True)
+        production_subdirs[production_pattern] = output_subdir
+
+    return production_subdirs
 
 
 def generate_corsika_limits_grid(args_dict):
@@ -151,45 +206,23 @@ def generate_corsika_limits_grid(args_dict):
 
     _logger.info(f"Processing {n_productions} production(s)")
 
-    if args_dict.get("array_layout_name"):
-        telescope_configs = get_array_elements_from_db_for_layouts(
-            args_dict["array_layout_name"],
-            args_dict.get("site"),
-            args_dict.get("model_version"),
-        )
-    elif args_dict.get("array_element_list"):
-        telescope_configs = {"array_element_list": args_dict["array_element_list"]}
-    elif args_dict.get("telescope_ids"):
-        telescope_configs = ascii_handler.collect_data_from_file(args_dict["telescope_ids"])[
-            "telescope_configs"
-        ]
-    else:
-        raise ValueError(
-            "No telescope configuration provided. Use one of --array_layout_name, "
-            "--array_element_list, or --telescope_ids."
-        )
+    telescope_configs = _resolve_telescope_configs(args_dict)
 
     # Build deterministic job specs: Cartesian product of productions and telescope configs
     job_specs = []
     output_dir = io_handler.IOHandler().get_output_directory()
 
-    production_subdirs = {}
-    used_subdir_names = set()
-
-    for production_pattern in production_patterns:
-        subdir_name = _get_production_directory_name(production_pattern, used_subdir_names)
-        used_subdir_names.add(subdir_name)
-        production_subdirs[production_pattern] = subdir_name
+    production_subdirs = _build_production_subdirectories(
+        production_patterns,
+        output_dir,
+        is_multi_production,
+    )
 
     for prod_idx, production_pattern in enumerate(production_patterns):
         for array_name, telescope_ids_raw in telescope_configs.items():
             telescope_ids = normalize_array_element_identifier_container(telescope_ids_raw)
 
-            output_subdir = None
-            if is_multi_production:
-                subdir_name = production_subdirs[production_pattern]
-                output_subdir = output_dir / subdir_name
-                Path(output_subdir).mkdir(parents=True, exist_ok=True)
+            output_subdir = production_subdirs.get(production_pattern)
 
             job_spec = {
                 "production_index": prod_idx,
@@ -258,12 +291,7 @@ def _process_file(
         "upper_radius_limit": compute_upper_radius_limit(histograms, loss_fraction),
         "viewcone_radius": compute_viewcone(histograms, loss_fraction),
     }
-    limits.update(
-        {
-            key: histograms.file_info.get(key)
-            for key in ("primary_particle", "zenith", "azimuth", "nsb_level")
-        }
-    )
+    limits.update({key: histograms.file_info.get(key) for key in FILE_INFO_KEYS})
 
     if plot_histograms:
         plot_output_path = output_subdir or io_handler.IOHandler().get_output_directory()
@@ -304,7 +332,6 @@ def _create_results_table(results, loss_fraction):
     Convert list of simulation results to an astropy Table with metadata.
 
     Round values to appropriate precision and add metadata.
-    For multi-production execution, includes production-origin columns.
 
     Parameters
     ----------
@@ -316,21 +343,9 @@ def _create_results_table(results, loss_fraction):
     Returns
     -------
     astropy.table.Table
-        Table with computed limits and optional production-origin columns.
+        Table with computed limits and production-origin columns.
     """
-    cols = [
-        "production_index",
-        "event_data_file",
-        "primary_particle",
-        "array_name",
-        "telescope_ids",
-        "zenith",
-        "azimuth",
-        "nsb_level",
-        "lower_energy_limit",
-        "upper_radius_limit",
-        "viewcone_radius",
-    ]
+    cols = list(RESULT_COLUMNS)
 
     columns = {name: [] for name in cols}
     units = {}

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -58,26 +60,36 @@ def hdf5_file_name(tmp_test_directory):
 
 
 def test_generate_corsika_limits_grid(mocker, mock_args_dict):
-    """Test generate_corsika_limits_grid function."""
+    """Test generate_corsika_limits_grid function with single production (no parallelization)."""
     # Mock dependencies
     mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
     mock_collect.side_effect = [
         {"telescope_configs": {"LST": [1, 2], "MST": [3, 4]}},
     ]
 
-    mock_process = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._process_file"
+    mock_execute_job = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
     )
+    mock_execute_job.side_effect = [
+        {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
+        {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+    ]
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
     )
 
-    # Run function
+    # Run function (single production mode)
     derive_corsika_limits.generate_corsika_limits_grid(mock_args_dict)
 
     # Verify calls
     assert mock_collect.call_count == 1
-    assert mock_process.call_count == 2  # 2 configs
+    assert mock_execute_job.call_count == 2  # 2 telescope configs
     assert mock_write.call_count == 1
 
 
@@ -232,9 +244,19 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     )
     mock_read_layouts.return_value = {"LST": [1, 2], "MST": [3, 4]}
 
-    mock_process = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._process_file"
+    mock_execute_job = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
     )
+    mock_execute_job.side_effect = [
+        {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
+        {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+    ]
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
     )
@@ -244,7 +266,7 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     mock_read_layouts.assert_called_once_with(
         args["array_layout_name"], args["site"], args["model_version"]
     )
-    assert mock_process.call_count == 2  # 2 layouts
+    assert mock_execute_job.call_count == 2  # 2 layouts
     assert mock_write.call_count == 1
 
 
@@ -254,21 +276,28 @@ def test_generate_corsika_limits_grid_with_array_element_list(mocker, mock_args_
     args["array_element_list"] = ["LSTN-01", "LSTN-02", "MSTN-03"]
     args["telescope_ids"] = None
 
-    mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
-    mock_process = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._process_file"
+    mock_execute_job = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
     )
+    mock_execute_job.side_effect = [
+        {"primary_particle": "gamma", "array_name": "array_element_list"},
+    ]
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
     )
 
     derive_corsika_limits.generate_corsika_limits_grid(args)
 
-    mock_collect.assert_not_called()
-    mock_process.assert_called_once()
-    call_args = mock_process.call_args[0]
-    assert call_args[1] == "array_element_list"
-    assert call_args[2] == ["LSTN-01", "LSTN-02", "MSTN-03"]
+    assert mock_execute_job.call_count == 1
+    job_spec = mock_execute_job.call_args[0][0]
+    assert job_spec["array_name"] == "array_element_list"
+    assert job_spec["telescope_ids"] == ["LSTN-01", "LSTN-02", "MSTN-03"]
     assert mock_write.call_count == 1
 
 
@@ -508,3 +537,298 @@ def test_process_file_with_plot_histograms(mocker, tmp_test_directory):
         "viewcone_radius": 2.0 * u.deg,
     }
     assert kwargs["array_name"] == "MockArray"
+
+
+# Tests for multi-production and parallel execution support
+
+
+def test_normalize_event_data_file_single_string():
+    """Test _normalize_event_data_file with single string input."""
+    result = derive_corsika_limits._normalize_event_data_file("pattern_*.hdf5")
+    assert result == ["pattern_*.hdf5"]
+    assert isinstance(result, list)
+
+
+def test_normalize_event_data_file_list():
+    """Test _normalize_event_data_file with list input."""
+    patterns = ["pattern_1_*.hdf5", "pattern_2_*.hdf5"]
+    result = derive_corsika_limits._normalize_event_data_file(patterns)
+    assert result == patterns
+    # Should preserve order
+    assert result[0] == "pattern_1_*.hdf5"
+    assert result[1] == "pattern_2_*.hdf5"
+
+
+def test_normalize_event_data_file_invalid_type():
+    """Test _normalize_event_data_file raises on invalid type."""
+    with pytest.raises(TypeError):
+        derive_corsika_limits._normalize_event_data_file(123)
+
+
+def test_get_production_directory_name_readable_and_deterministic():
+    """Test _get_production_directory_name generates readable deterministic names."""
+    # Same inputs should produce same output when no collision exists
+    name1 = derive_corsika_limits._get_production_directory_name("pattern_1_*.hdf5")
+    name2 = derive_corsika_limits._get_production_directory_name("pattern_1_*.hdf5")
+    assert name1 == name2
+
+    # Different patterns should produce different readable names
+    name3 = derive_corsika_limits._get_production_directory_name("pattern_2_*.hdf5")
+    assert name1 != name3
+
+    # Names should be filesystem-safe (no special chars)
+    assert all(c.isalnum() or c == "_" for c in name1)
+    assert name1 == "production_pattern_1"
+
+
+def test_get_production_directory_name_appends_uuid_on_collision(mocker):
+    """Test _get_production_directory_name appends UUID when names collide."""
+    mock_uuid = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.get_uuid",
+        return_value="019d776b-e24c-741d-bc05-e3f6f7ec77c7",
+    )
+
+    name = derive_corsika_limits._get_production_directory_name(
+        "pattern_1_*.hdf5",
+        existing_names={"production_pattern_1"},
+    )
+
+    assert name == "production_pattern_1_019d776b-e24c-741d-bc05-e3f6f7ec77c7"
+    mock_uuid.assert_called_once()
+
+
+def test_execute_production_job_single_job(mocker):
+    """Test _execute_production_job executes one job correctly."""
+    mock_histograms = mocker.MagicMock()
+    mock_histograms.fill.return_value = None
+    mock_histograms.file_info = {}
+
+    mocker.patch(
+        SIM_EVENTS_HISTOGRAMS_PATH,
+        return_value=mock_histograms,
+    )
+
+    mocker.patch(
+        COMPUTE_LOWER_ENERGY_LIMIT_PATH,
+        return_value=1.0 * u.TeV,
+    )
+    mocker.patch(
+        COMPUTE_UPPER_RADIUS_LIMIT_PATH,
+        return_value=100.0 * u.m,
+    )
+    mocker.patch(
+        COMPUTE_VIEWCONE_PATH,
+        return_value=2.0 * u.deg,
+    )
+
+    job_spec = {
+        "production_index": 0,
+        "production_pattern": "pattern_*.hdf5",
+        "array_name": "LST",
+        "telescope_ids": ["LSTN-01"],
+        "loss_fraction": 0.2,
+        "plot_histograms": False,
+        "output_subdir": None,
+    }
+
+    result = derive_corsika_limits._execute_production_job(job_spec)
+
+    # Result should include production metadata
+    assert result["production_index"] == 0
+    assert result["event_data_file"] == "pattern_*.hdf5"
+    assert result["array_name"] == "LST"
+    assert "lower_energy_limit" in result
+    assert "upper_radius_limit" in result
+    assert "viewcone_radius" in result
+
+
+def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_directory):
+    """Test generate_corsika_limits_grid with multiple event_data_file patterns."""
+    # Mock dependencies
+    mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
+    mock_collect.return_value = {"telescope_configs": {"LST": ["LSTN-01"]}}
+
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
+    )
+    # Mock process_pool_map_ordered to return results directly
+    mock_pool.return_value = [
+        {
+            "production_index": 0,
+            "event_data_file": "pattern_1_*.hdf5",
+            "array_name": "LST",
+            "telescope_ids": ["LSTN-01"],
+            "lower_energy_limit": 0.5 * u.TeV,
+            "upper_radius_limit": 400.0 * u.m,
+            "viewcone_radius": 5.0 * u.deg,
+            "primary_particle": "gamma",
+            "zenith": 20.0 * u.deg,
+            "azimuth": 180.0 * u.deg,
+            "nsb_level": 1.0,
+        },
+        {
+            "production_index": 1,
+            "event_data_file": "pattern_2_*.hdf5",
+            "array_name": "LST",
+            "telescope_ids": ["LSTN-01"],
+            "lower_energy_limit": 0.6 * u.TeV,
+            "upper_radius_limit": 450.0 * u.m,
+            "viewcone_radius": 5.5 * u.deg,
+            "primary_particle": "gamma",
+            "zenith": 20.0 * u.deg,
+            "azimuth": 180.0 * u.deg,
+            "nsb_level": 1.0,
+        },
+    ]
+
+    mock_write = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.write_results"
+    )
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    # Use actual tmp_test_directory to allow directory creation
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
+
+    # Multi-production args
+    args_dict = {
+        "event_data_file": ["pattern_1_*.hdf5", "pattern_2_*.hdf5"],
+        "telescope_ids": "telescope_ids.yml",
+        "loss_fraction": 0.2,
+        "plot_histograms": False,
+        "output_file": "test_output.ecsv",
+        "n_workers": 2,
+    }
+
+    derive_corsika_limits.generate_corsika_limits_grid(args_dict)
+
+    # Verify process_pool_map_ordered was called with correct n_workers
+    mock_pool.assert_called_once()
+    call_kwargs = mock_pool.call_args[1]
+    assert call_kwargs["max_workers"] == 2
+
+    # Verify write_results was called with merged results
+    mock_write.assert_called_once()
+    written_results = mock_write.call_args[0][0]
+    assert len(written_results) == 2  # Both productions merged
+
+
+def test_generate_corsika_limits_grid_single_production_no_pool(mocker, tmp_test_directory):
+    """Test generate_corsika_limits_grid with single production avoids process pool."""
+    mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
+    mock_collect.return_value = {"telescope_configs": {"LST": ["LSTN-01"]}}
+
+    # Process pool should NOT be called for single production
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
+    )
+
+    mock_execute_job = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
+    )
+    mock_execute_job.return_value = {
+        "primary_particle": "gamma",
+        "array_name": "LST",
+        "telescope_ids": ["LSTN-01"],
+    }
+
+    mocker.patch("simtools.production_configuration.derive_corsika_limits.write_results")
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
+
+    args_dict = {
+        "event_data_file": "pattern_*.hdf5",  # Single string, not list
+        "telescope_ids": "telescope_ids.yml",
+        "loss_fraction": 0.2,
+        "plot_histograms": False,
+        "output_file": "test_output.ecsv",
+        "n_workers": 0,
+    }
+
+    derive_corsika_limits.generate_corsika_limits_grid(args_dict)
+
+    # Process pool should NOT be called for single production
+    mock_pool.assert_not_called()
+    # Direct execution should be used
+    mock_execute_job.assert_called_once()
+
+
+def test_create_results_table_with_production_columns(mock_results):
+    """Test _create_results_table includes production-origin columns for multi-production."""
+    # Add production metadata to mock results
+    for i, res in enumerate(mock_results):
+        res["production_index"] = i
+        res["event_data_file"] = f"pattern_{i}_*.hdf5"
+
+    table = derive_corsika_limits._create_results_table(mock_results, loss_fraction=0.2)
+
+    # Should include production-origin columns
+    assert "production_index" in table.colnames
+    assert "event_data_file" in table.colnames
+
+    # Check values
+    assert table["production_index"][0] == 0
+    assert table["event_data_file"][0] == "pattern_0_*.hdf5"
+
+
+def test_create_results_table_without_production_columns(mock_results):
+    """Test _create_results_table without production columns for single-production."""
+    # Results without production metadata (old format)
+    table = derive_corsika_limits._create_results_table(mock_results, loss_fraction=0.2)
+
+    # Should NOT include production-origin columns
+    assert "production_index" not in table.colnames
+    assert "event_data_file" not in table.colnames
+
+    # Standard columns should be present
+    assert "primary_particle" in table.colnames
+    assert "array_name" in table.colnames
+
+
+def test_process_file_with_output_subdir(mocker, tmp_test_directory):
+    """Test _process_file routes plots to specified output subdirectory."""
+    mock_histograms = mocker.MagicMock()
+    mock_histograms.fill.return_value = None
+    mock_histograms.file_info = {}
+
+    mocker.patch(
+        SIM_EVENTS_HISTOGRAMS_PATH,
+        return_value=mock_histograms,
+    )
+
+    mocker.patch(
+        COMPUTE_LOWER_ENERGY_LIMIT_PATH,
+        return_value=1.0 * u.TeV,
+    )
+    mocker.patch(
+        COMPUTE_UPPER_RADIUS_LIMIT_PATH,
+        return_value=100.0 * u.m,
+    )
+    mocker.patch(
+        COMPUTE_VIEWCONE_PATH,
+        return_value=2.0 * u.deg,
+    )
+
+    mock_plot = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.plot_simtel_event_histograms.plot"
+    )
+
+    output_subdir = tmp_test_directory / "production_pattern_1"
+
+    derive_corsika_limits._process_file(
+        file_path=MOCK_FILE_PATH,
+        array_name="MockArray",
+        telescope_ids=["LSTN-01"],
+        loss_fraction=0.2,
+        plot_histograms=True,
+        output_subdir=output_subdir,
+    )
+
+    # Verify plot was called with the specified subdirectory
+    mock_plot.assert_called_once()
+    call_kwargs = mock_plot.call_args[1]
+    assert call_kwargs["output_path"] == output_subdir

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -20,6 +20,31 @@ COMPUTE_VIEWCONE_PATH = "simtools.production_configuration.derive_corsika_limits
 MOCK_FILE_PATH = "mock_file.fits"
 
 
+def _pool_result(
+    production_index=0,
+    event_data_file="pattern_*.hdf5",
+    array_name="LST",
+    telescope_ids=None,
+    lower_energy_limit=0.5 * u.TeV,
+    upper_radius_limit=400.0 * u.m,
+    viewcone_radius=5.0 * u.deg,
+):
+    """Build a standard mocked pool result row for grid execution tests."""
+    return {
+        "production_index": production_index,
+        "event_data_file": event_data_file,
+        "array_name": array_name,
+        "telescope_ids": telescope_ids or ["LSTN-01"],
+        "lower_energy_limit": lower_energy_limit,
+        "upper_radius_limit": upper_radius_limit,
+        "viewcone_radius": viewcone_radius,
+        "primary_particle": "gamma",
+        "zenith": 20.0 * u.deg,
+        "azimuth": 180.0 * u.deg,
+        "nsb_level": 1.0,
+    }
+
+
 @pytest.fixture
 def mock_args_dict():
     """Create mock arguments dictionary."""
@@ -49,12 +74,6 @@ def mock_results():
             "layout": "LST",
         }
     ]
-
-
-@pytest.fixture
-def hdf5_file_name(tmp_test_directory):
-    """Create temporary HDF5 file name."""
-    return str(tmp_test_directory / "test_file.h5")
 
 
 def test_generate_corsika_limits_grid(mocker, mock_args_dict, tmp_test_directory):
@@ -110,52 +129,6 @@ def test_generate_corsika_limits_grid_normalizes_telescope_ids(mocker, mock_args
     ]
     job_specs = mock_pool.call_args[0][1]
     assert job_specs[0]["telescope_ids"] == expected_telescopes
-
-
-def test_process_file(mocker):
-    """Test _process_file function."""
-    # Mock the EventDataHistograms class
-    mock_histograms = mocker.MagicMock()
-    mock_histograms.file_info = {}
-    mock_histogram_class = mocker.patch(SIM_EVENTS_HISTOGRAMS_PATH)
-    mock_histogram_class.return_value = mock_histograms
-
-    # Mock the individual limit computation functions
-    mock_energy_limit = 1.0 * u.TeV
-    mock_radius_limit = 100.0 * u.m
-    mock_viewcone_limit = 2.0 * u.deg
-
-    mocker.patch(
-        COMPUTE_LOWER_ENERGY_LIMIT_PATH,
-        return_value=mock_energy_limit,
-    )
-    mocker.patch(
-        COMPUTE_UPPER_RADIUS_LIMIT_PATH,
-        return_value=mock_radius_limit,
-    )
-    mocker.patch(
-        COMPUTE_VIEWCONE_PATH,
-        return_value=mock_viewcone_limit,
-    )
-
-    mocker.patch("simtools.io.io_handler.IOHandler")
-
-    result = derive_corsika_limits._process_file("test.fits", "array_name", [1, 2], 0.2, False)
-
-    expected_result = {
-        "primary_particle": None,
-        "zenith": None,
-        "azimuth": None,
-        "nsb_level": None,
-        "lower_energy_limit": mock_energy_limit,
-        "upper_radius_limit": mock_radius_limit,
-        "viewcone_radius": mock_viewcone_limit,
-    }
-    assert result == expected_result
-    mock_histogram_class.assert_called_once_with(
-        "test.fits", array_name="array_name", telescope_list=[1, 2]
-    )
-    mock_histograms.fill.assert_called_once()
 
 
 def test_process_file_passes_event_data_patterns_through(mocker):
@@ -348,7 +321,7 @@ def test_compute_limits_default_type():
     assert result == 2
 
 
-def test_compute_viewcone(hdf5_file_name, mocker):
+def test_compute_viewcone(mocker):
     """Test compute_viewcone function with mocked histograms."""
     mock_hist = np.array([10, 8, 6, 4, 2])
     mock_bins = np.linspace(0, 20.0, 6)
@@ -370,7 +343,7 @@ def test_compute_viewcone(hdf5_file_name, mocker):
     assert result.value == pytest.approx(expected.value)
 
 
-def test_compute_lower_energy_limit(hdf5_file_name, mocker):
+def test_compute_lower_energy_limit(mocker):
     """Test compute_lower_energy_limit function with mocked histograms."""
     mock_hist = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
     mock_bins = np.logspace(-3, 3, 6)
@@ -393,7 +366,7 @@ def test_compute_lower_energy_limit(hdf5_file_name, mocker):
     assert result == expected
 
 
-def test_compute_upper_radius_limit(hdf5_file_name, mocker):
+def test_compute_upper_radius_limit(mocker):
     """Test compute_upper_radius_limit function with mocked histograms."""
     mock_hist = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
     mock_bins = np.linspace(0, 500, 6)
@@ -655,32 +628,14 @@ def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_director
     )
     # Mock process_pool_map_ordered to return results directly
     mock_pool.return_value = [
-        {
-            "production_index": 0,
-            "event_data_file": "pattern_1_*.hdf5",
-            "array_name": "LST",
-            "telescope_ids": ["LSTN-01"],
-            "lower_energy_limit": 0.5 * u.TeV,
-            "upper_radius_limit": 400.0 * u.m,
-            "viewcone_radius": 5.0 * u.deg,
-            "primary_particle": "gamma",
-            "zenith": 20.0 * u.deg,
-            "azimuth": 180.0 * u.deg,
-            "nsb_level": 1.0,
-        },
-        {
-            "production_index": 1,
-            "event_data_file": "pattern_2_*.hdf5",
-            "array_name": "LST",
-            "telescope_ids": ["LSTN-01"],
-            "lower_energy_limit": 0.6 * u.TeV,
-            "upper_radius_limit": 450.0 * u.m,
-            "viewcone_radius": 5.5 * u.deg,
-            "primary_particle": "gamma",
-            "zenith": 20.0 * u.deg,
-            "azimuth": 180.0 * u.deg,
-            "nsb_level": 1.0,
-        },
+        _pool_result(production_index=0, event_data_file="pattern_1_*.hdf5"),
+        _pool_result(
+            production_index=1,
+            event_data_file="pattern_2_*.hdf5",
+            lower_energy_limit=0.6 * u.TeV,
+            upper_radius_limit=450.0 * u.m,
+            viewcone_radius=5.5 * u.deg,
+        ),
     ]
 
     mock_write = mocker.patch(
@@ -724,21 +679,7 @@ def test_generate_corsika_limits_grid_single_production_uses_pool(mocker, tmp_te
     mock_pool = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_pool.return_value = [
-        {
-            "production_index": 0,
-            "event_data_file": "pattern_*.hdf5",
-            "array_name": "LST",
-            "telescope_ids": ["LSTN-01"],
-            "lower_energy_limit": 0.5 * u.TeV,
-            "upper_radius_limit": 400.0 * u.m,
-            "viewcone_radius": 5.0 * u.deg,
-            "primary_particle": "gamma",
-            "zenith": 20.0 * u.deg,
-            "azimuth": 180.0 * u.deg,
-            "nsb_level": 1.0,
-        }
-    ]
+    mock_pool.return_value = [_pool_result()]
 
     mock_execute_job = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits._execute_production_job"

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import astropy.units as u
 import numpy as np
 import pytest
@@ -59,7 +57,7 @@ def hdf5_file_name(tmp_test_directory):
     return str(tmp_test_directory / "test_file.h5")
 
 
-def test_generate_corsika_limits_grid(mocker, mock_args_dict):
+def test_generate_corsika_limits_grid(mocker, mock_args_dict, tmp_test_directory):
     """Test generate_corsika_limits_grid function with single production."""
     # Mock dependencies
     mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
@@ -78,7 +76,7 @@ def test_generate_corsika_limits_grid(mocker, mock_args_dict):
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
     )
-    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
 
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
@@ -230,7 +228,7 @@ def test_round_value():
     assert derive_corsika_limits._round_value("unknown", "string_value") == "string_value"
 
 
-def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
+def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict, tmp_test_directory):
     """Test generate_corsika_limits_grid using get_array_elements_from_db_for_layouts."""
     # Prepare args_dict to use array_layout_name
     args = mock_args_dict.copy()
@@ -255,7 +253,7 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
     )
-    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
 
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
@@ -271,7 +269,9 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     assert mock_write.call_count == 1
 
 
-def test_generate_corsika_limits_grid_with_array_element_list(mocker, mock_args_dict):
+def test_generate_corsika_limits_grid_with_array_element_list(
+    mocker, mock_args_dict, tmp_test_directory
+):
     """Test generate_corsika_limits_grid using inline array_element_list."""
     args = mock_args_dict.copy()
     args["array_element_list"] = ["LSTN-01", "LSTN-02", "MSTN-03"]
@@ -287,7 +287,7 @@ def test_generate_corsika_limits_grid_with_array_element_list(mocker, mock_args_
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
     )
-    mock_io.return_value.get_output_directory.return_value = Path("/tmp/output")
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
 
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -60,17 +60,17 @@ def hdf5_file_name(tmp_test_directory):
 
 
 def test_generate_corsika_limits_grid(mocker, mock_args_dict):
-    """Test generate_corsika_limits_grid function with single production (no parallelization)."""
+    """Test generate_corsika_limits_grid function with single production."""
     # Mock dependencies
     mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
     mock_collect.side_effect = [
         {"telescope_configs": {"LST": [1, 2], "MST": [3, 4]}},
     ]
 
-    mock_execute_job = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_execute_job.side_effect = [
+    mock_pool.return_value = [
         {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
         {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
     ]
@@ -89,7 +89,7 @@ def test_generate_corsika_limits_grid(mocker, mock_args_dict):
 
     # Verify calls
     assert mock_collect.call_count == 1
-    assert mock_execute_job.call_count == 2  # 2 telescope configs
+    mock_pool.assert_called_once()
     assert mock_write.call_count == 1
 
 
@@ -98,10 +98,10 @@ def test_generate_corsika_limits_grid_normalizes_telescope_ids(mocker, mock_args
     mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
     mock_collect.return_value = {"telescope_configs": {"LST": [1, 2]}}
 
-    mock_process = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._process_file"
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_process.return_value = {}
+    mock_pool.return_value = [{}]
     mocker.patch("simtools.production_configuration.derive_corsika_limits.write_results")
 
     derive_corsika_limits.generate_corsika_limits_grid(mock_args_dict)
@@ -110,8 +110,8 @@ def test_generate_corsika_limits_grid_normalizes_telescope_ids(mocker, mock_args
         get_array_element_name_from_common_identifier(1),
         get_array_element_name_from_common_identifier(2),
     ]
-    call_args = mock_process.call_args[0]
-    assert call_args[2] == expected_telescopes
+    job_specs = mock_pool.call_args[0][1]
+    assert job_specs[0]["telescope_ids"] == expected_telescopes
 
 
 def test_process_file(mocker):
@@ -244,10 +244,10 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     )
     mock_read_layouts.return_value = {"LST": [1, 2], "MST": [3, 4]}
 
-    mock_execute_job = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_execute_job.side_effect = [
+    mock_pool.return_value = [
         {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
         {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
     ]
@@ -266,7 +266,8 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     mock_read_layouts.assert_called_once_with(
         args["array_layout_name"], args["site"], args["model_version"]
     )
-    assert mock_execute_job.call_count == 2  # 2 layouts
+    job_specs = mock_pool.call_args[0][1]
+    assert len(job_specs) == 2  # 2 layouts
     assert mock_write.call_count == 1
 
 
@@ -276,10 +277,10 @@ def test_generate_corsika_limits_grid_with_array_element_list(mocker, mock_args_
     args["array_element_list"] = ["LSTN-01", "LSTN-02", "MSTN-03"]
     args["telescope_ids"] = None
 
-    mock_execute_job = mocker.patch(
-        "simtools.production_configuration.derive_corsika_limits._execute_production_job"
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_execute_job.side_effect = [
+    mock_pool.return_value = [
         {"primary_particle": "gamma", "array_name": "array_element_list"},
     ]
 
@@ -294,8 +295,9 @@ def test_generate_corsika_limits_grid_with_array_element_list(mocker, mock_args_
 
     derive_corsika_limits.generate_corsika_limits_grid(args)
 
-    assert mock_execute_job.call_count == 1
-    job_spec = mock_execute_job.call_args[0][0]
+    job_specs = mock_pool.call_args[0][1]
+    assert len(job_specs) == 1
+    job_spec = job_specs[0]
     assert job_spec["array_name"] == "array_element_list"
     assert job_spec["telescope_ids"] == ["LSTN-01", "LSTN-02", "MSTN-03"]
     assert mock_write.call_count == 1
@@ -714,24 +716,34 @@ def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_director
     assert len(written_results) == 2  # Both productions merged
 
 
-def test_generate_corsika_limits_grid_single_production_no_pool(mocker, tmp_test_directory):
-    """Test generate_corsika_limits_grid with single production avoids process pool."""
+def test_generate_corsika_limits_grid_single_production_uses_pool(mocker, tmp_test_directory):
+    """Test generate_corsika_limits_grid with single production uses process pool."""
     mock_collect = mocker.patch("simtools.io.ascii_handler.collect_data_from_file")
     mock_collect.return_value = {"telescope_configs": {"LST": ["LSTN-01"]}}
 
-    # Process pool should NOT be called for single production
     mock_pool = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
+    mock_pool.return_value = [
+        {
+            "production_index": 0,
+            "event_data_file": "pattern_*.hdf5",
+            "array_name": "LST",
+            "telescope_ids": ["LSTN-01"],
+            "lower_energy_limit": 0.5 * u.TeV,
+            "upper_radius_limit": 400.0 * u.m,
+            "viewcone_radius": 5.0 * u.deg,
+            "primary_particle": "gamma",
+            "zenith": 20.0 * u.deg,
+            "azimuth": 180.0 * u.deg,
+            "nsb_level": 1.0,
+        }
+    ]
 
     mock_execute_job = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits._execute_production_job"
     )
-    mock_execute_job.return_value = {
-        "primary_particle": "gamma",
-        "array_name": "LST",
-        "telescope_ids": ["LSTN-01"],
-    }
+    mock_execute_job.return_value = {}
 
     mocker.patch("simtools.production_configuration.derive_corsika_limits.write_results")
 
@@ -751,10 +763,10 @@ def test_generate_corsika_limits_grid_single_production_no_pool(mocker, tmp_test
 
     derive_corsika_limits.generate_corsika_limits_grid(args_dict)
 
-    # Process pool should NOT be called for single production
-    mock_pool.assert_not_called()
-    # Direct execution should be used
-    mock_execute_job.assert_called_once()
+    mock_pool.assert_called_once()
+    call_kwargs = mock_pool.call_args[1]
+    assert call_kwargs["max_workers"] == 0
+    mock_execute_job.assert_not_called()
 
 
 def test_create_results_table_with_production_columns(mock_results):
@@ -776,13 +788,15 @@ def test_create_results_table_with_production_columns(mock_results):
 
 
 def test_create_results_table_without_production_columns(mock_results):
-    """Test _create_results_table without production columns for single-production."""
+    """Test _create_results_table with missing production metadata values."""
     # Results without production metadata (old format)
     table = derive_corsika_limits._create_results_table(mock_results, loss_fraction=0.2)
 
-    # Should NOT include production-origin columns
-    assert "production_index" not in table.colnames
-    assert "event_data_file" not in table.colnames
+    # Production-origin columns are included and filled with None if missing
+    assert "production_index" in table.colnames
+    assert "event_data_file" in table.colnames
+    assert table["production_index"][0] is None
+    assert table["event_data_file"][0] is None
 
     # Standard columns should be present
     assert "primary_particle" in table.colnames

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -641,6 +641,9 @@ def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_director
     mock_write = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.write_results"
     )
+    mock_build_subdirs = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._build_production_subdirectories"
+    )
 
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
@@ -664,6 +667,11 @@ def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_director
     mock_pool.assert_called_once()
     call_kwargs = mock_pool.call_args[1]
     assert call_kwargs["max_workers"] == 2
+
+    # For non-plotting runs, no production subdirectories should be built/passed
+    mock_build_subdirs.assert_not_called()
+    job_specs = mock_pool.call_args[0][1]
+    assert all(job_spec["output_subdir"] is None for job_spec in job_specs)
 
     # Verify write_results was called with merged results
     mock_write.assert_called_once()


### PR DESCRIPTION
Add the possibility to run the derivation of corsika limits in parallel - e.g. for several zenith angles.

Two updated / new command line parameters for `simtools-production-derive-corsika-limits`:

- `--event_data_file` accepts now a list of files / globular pattern
- `--n_workers` specifies the number of workers to use (default is 1)

This will generate a single ecsv file with the limits derived for all given parameter points.

If plotting is requested, the plots will be saved in subdirectories. 