### PR TITLE
Simplify ensure_iterable / ensure_list

### DIFF
--- a/docs/changes/2191.api.md
+++ b/docs/changes/2191.api.md
@@ -1,0 +1,1 @@
+Rename `general.ensure_iterable` to `general.ensure_list` to clarify function intent (API change).

--- a/docs/changes/2191.maintenance.md
+++ b/docs/changes/2191.maintenance.md
@@ -1,0 +1,1 @@
+Rename `general.ensure_iterable` to `general.ensure_list` to clarify function intend.

--- a/docs/changes/2191.maintenance.md
+++ b/docs/changes/2191.maintenance.md
@@ -1,1 +1,0 @@
-Rename `general.ensure_iterable` to `general.ensure_list` to clarify function intent.

--- a/docs/changes/2191.maintenance.md
+++ b/docs/changes/2191.maintenance.md
@@ -1,1 +1,1 @@
-Rename `general.ensure_iterable` to `general.ensure_list` to clarify function intend.
+Rename `general.ensure_iterable` to `general.ensure_list` to clarify function intent.

--- a/src/simtools/applications/plot_simtel_events.py
+++ b/src/simtools/applications/plot_simtel_events.py
@@ -167,7 +167,7 @@ def main():
         },
     )
 
-    plots = list(gen.ensure_iterable(app_context.args.get("plots")))
+    plots = list(gen.ensure_list(app_context.args.get("plots")))
     generate_and_save_plots(plots=plots, args=app_context.args, ioh=app_context.io_handler)
 
 

--- a/src/simtools/applications/plot_simtel_events.py
+++ b/src/simtools/applications/plot_simtel_events.py
@@ -167,7 +167,7 @@ def main():
         },
     )
 
-    plots = list(gen.ensure_list(app_context.args.get("plots")))
+    plots = gen.ensure_list(app_context.args.get("plots"))
     generate_and_save_plots(plots=plots, args=app_context.args, ioh=app_context.io_handler)
 
 

--- a/src/simtools/applications/simulate_flasher.py
+++ b/src/simtools/applications/simulate_flasher.py
@@ -168,7 +168,7 @@ def main():
         telescopes = (
             get_array_elements_for_layout(app_context.args["array_layout_name"])
             if app_context.args.get("array_layout_name") is not None
-            else general.ensure_iterable(app_context.args["telescopes"])
+            else general.ensure_list(app_context.args["telescopes"])
         )
         for telescope in telescopes:
             light_source = SimulatorLightEmission(

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -586,7 +586,7 @@ class CommandLineParser(argparse.ArgumentParser):
         str or list of str
             Validated telescope name(s)
         """
-        values = general.ensure_iterable(value)
+        values = general.ensure_list(value)
         for v in values:
             names.validate_array_element_name(str(v))
         return values if len(values) > 1 else values[0]

--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -143,7 +143,7 @@ class CorsikaConfig:
             config["USER_INPUT"] = self._corsika_configuration_from_user_input(args)
 
         config.update(
-            self._fill_corsika_configuration_from_db(gen.ensure_iterable(args.get("model_version")))
+            self._fill_corsika_configuration_from_db(gen.ensure_list(args.get("model_version")))
         )
         return config
 

--- a/src/simtools/corsika/corsika_output_validator.py
+++ b/src/simtools/corsika/corsika_output_validator.py
@@ -24,8 +24,8 @@ def validate_corsika_output(data_files, log_files, expected_shower_events=None, 
     curved_atmo: bool, optional
         Whether the CORSIKA simulation was run with the curved atmosphere option.
     """
-    data_files = general.ensure_iterable(data_files) if data_files is not None else []
-    log_files = general.ensure_iterable(log_files)
+    data_files = general.ensure_list(data_files) if data_files is not None else []
+    log_files = general.ensure_list(log_files)
 
     validate_event_numbers(data_files, expected_shower_events)
     validate_log_files(

--- a/src/simtools/corsika/corsika_output_validator.py
+++ b/src/simtools/corsika/corsika_output_validator.py
@@ -24,7 +24,7 @@ def validate_corsika_output(data_files, log_files, expected_shower_events=None, 
     curved_atmo: bool, optional
         Whether the CORSIKA simulation was run with the curved atmosphere option.
     """
-    data_files = general.ensure_list(data_files) if data_files is not None else []
+    data_files = general.ensure_list(data_files)
     log_files = general.ensure_list(log_files)
 
     validate_event_numbers(data_files, expected_shower_events)

--- a/src/simtools/io/ascii_handler.py
+++ b/src/simtools/io/ascii_handler.py
@@ -10,7 +10,7 @@ import astropy.units as u
 import numpy as np
 import yaml
 
-from simtools.utils.general import ensure_iterable, is_url
+from simtools.utils.general import ensure_list, is_url
 
 _logger = logging.getLogger(__name__)
 
@@ -288,7 +288,7 @@ def _write_to_text_file(data, output_file, unique_lines):
     """
 
     def iter_lines(data):
-        for entry in ensure_iterable(data):
+        for entry in ensure_list(data):
             yield from entry.splitlines()
 
     lines_to_write = (

--- a/src/simtools/layout/array_layout_utils.py
+++ b/src/simtools/layout/array_layout_utils.py
@@ -339,7 +339,7 @@ def get_array_layouts_from_db(
     """
     layout_names = []
     if layout_name:
-        layout_names = gen.ensure_iterable(layout_name)
+        layout_names = gen.ensure_list(layout_name)
     else:
         site_model = SiteModel(
             site=site,

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -36,7 +36,7 @@ class CorsikaSimtelRunner:
         curved_atmosphere_min_zenith_angle=None,
     ):
         self._logger = logging.getLogger(__name__)
-        self.corsika_config = gen.ensure_iterable(corsika_config)
+        self.corsika_config = gen.ensure_list(corsika_config)
         # the base corsika config is the one used to define the CORSIKA specific parameters.
         # The others are used for the array configurations.
         self.base_corsika_config = self.corsika_config[0]

--- a/src/simtools/sim_events/output_validator.py
+++ b/src/simtools/sim_events/output_validator.py
@@ -19,7 +19,7 @@ def validate_sim_events(data_files, expected_mc_events):
     expected_mc_events: int
         Expected number of simulated MC events.
     """
-    data_files = general.ensure_iterable(data_files)
+    data_files = general.ensure_list(data_files)
     validate_event_numbers(data_files, expected_mc_events)
 
 

--- a/src/simtools/simtel/simtel_event_reader.py
+++ b/src/simtools/simtel/simtel_event_reader.py
@@ -47,7 +47,7 @@ def read_events(file_name, telescope, event_ids, max_events=1, verbose=False):
         _logger.warning(f"Telescope type '{telescope}' not found in file '{file_name}'.")
         return None, None, None
 
-    event_ids = gen.ensure_list(event_ids) if event_ids is not None else []
+    event_ids = gen.ensure_list(event_ids)
     ids_with_data, events = [], []
 
     with SimTelFile(file_name, skip_calibration=False) as f:

--- a/src/simtools/simtel/simtel_event_reader.py
+++ b/src/simtools/simtel/simtel_event_reader.py
@@ -47,7 +47,7 @@ def read_events(file_name, telescope, event_ids, max_events=1, verbose=False):
         _logger.warning(f"Telescope type '{telescope}' not found in file '{file_name}'.")
         return None, None, None
 
-    event_ids = gen.ensure_iterable(event_ids) if event_ids is not None else []
+    event_ids = gen.ensure_list(event_ids) if event_ids is not None else []
     ids_with_data, events = [], []
 
     with SimTelFile(file_name, skip_calibration=False) as f:

--- a/src/simtools/simtel/simtel_output_validator.py
+++ b/src/simtools/simtel/simtel_output_validator.py
@@ -55,8 +55,8 @@ def validate_sim_telarray(
     ValueError
         If the sim_telarray output files or metadata are not consistent with the array models.
     """
-    data_files = general.ensure_iterable(data_files)
-    log_files = general.ensure_iterable(log_files)
+    data_files = general.ensure_list(data_files)
+    log_files = general.ensure_list(log_files)
 
     if array_models:
         validate_metadata(data_files, array_models, allow_for_changes)
@@ -425,7 +425,7 @@ def validate_event_numbers(data_files, expected_mc_events, expected_shower_event
         If the number of simulated events does not match the expected number.
     """
     event_errors = []
-    for file in general.ensure_iterable(data_files):
+    for file in general.ensure_list(data_files):
         shower_events, mc_events = file_info.get_simulated_events(file)
 
         if (shower_events, mc_events) != (expected_shower_events, expected_mc_events):

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -108,7 +108,7 @@ class Simulator:
         list, list
             List of ArrayModel and CorsikaConfig objects.
         """
-        versions = general.ensure_iterable(self.model_version)
+        versions = general.ensure_list(self.model_version)
 
         array_model = []
         corsika_configurations = []
@@ -118,7 +118,7 @@ class Simulator:
                 label=self.label,
                 site=self.site,
                 layout_name=settings.config.args.get("array_layout_name"),
-                array_elements=general.ensure_iterable(settings.config.args.get("telescopes", [])),
+                array_elements=general.ensure_list(settings.config.args.get("telescopes", [])),
                 model_version=version,
                 calibration_device_types=self._get_calibration_device_types(self.run_mode),
                 overwrite_model_parameters=settings.config.args.get("overwrite_model_parameters"),
@@ -458,7 +458,7 @@ class Simulator:
                 model_logs
                 + [f for f in histogram_files if model_version in str(f)]
                 + [str(self.get_files(file_type="corsika_log"))]
-                + list(general.ensure_iterable(model.pack_model_files()))
+                + list(general.ensure_list(model.pack_model_files()))
             )
             # simtools log file duplicated for each model version
             if simtools_log_file and Path(simtools_log_file).exists():
@@ -498,7 +498,7 @@ class Simulator:
         if self.run_mode != "direct_injection" or flasher_photons is None:
             return
 
-        for array_model in general.ensure_iterable(self.array_models):
+        for array_model in general.ensure_list(self.array_models):
             for calibration_models in array_model.calibration_models.values():
                 for calibration_model in calibration_models.values():
                     calibration_model.overwrite_model_parameter(

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -458,7 +458,7 @@ class Simulator:
                 model_logs
                 + [f for f in histogram_files if model_version in str(f)]
                 + [str(self.get_files(file_type="corsika_log"))]
-                + list(general.ensure_list(model.pack_model_files()))
+                + general.ensure_list(model.pack_model_files())
             )
             # simtools log file duplicated for each model version
             if simtools_log_file and Path(simtools_log_file).exists():

--- a/src/simtools/testing/log_inspector.py
+++ b/src/simtools/testing/log_inspector.py
@@ -127,7 +127,7 @@ def check_plain_logs(log_files, file_test):
     if wanted is None and forbidden is None:
         return True
 
-    log_files = gen.ensure_iterable(log_files)
+    log_files = gen.ensure_list(log_files)
 
     def file_open(file):
         if file.suffix == ".gz":

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -198,27 +198,27 @@ def get_log_level_from_user(log_level):
     return possible_levels[log_level_lower]
 
 
-def ensure_iterable(value):
+def ensure_list(value):
     """
-    Return input value as iterable.
-
-    - Single values will return as a list with a single element.
-    - None values will return as empty list.
-    - Values of list or tuple type are not changed.
+    Return input value as list.
 
     Parameters
     ----------
     value: any
-        Input value to be converted to a iterable.
+        Input value to be converted to a list.
 
     Returns
     -------
-    list or tuple
-        Converted value as list or tuple.
+    list
+        Converted value as list.
     """
     if value is None:
         return []
-    return value if isinstance(value, list | tuple) else [value]
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
 
 
 def parse_typed_sequence(value, cast=float):

--- a/src/simtools/visualization/plot_simtel_events.py
+++ b/src/simtools/visualization/plot_simtel_events.py
@@ -59,7 +59,7 @@ def generate_and_save_plots(plots, args, ioh):
     plotter = PlotSimtelEvent(
         file_name=args.get("simtel_file", None),
         telescope=args.get("telescope", None),
-        event_ids=gen.ensure_iterable(args.get("event_id", None)),
+        event_ids=gen.ensure_list(args.get("event_id", None)),
         max_events=args.get("max_events", None),
     )
     output_file = plotter.make_output_paths(ioh, args.get("output_file"))
@@ -244,7 +244,7 @@ class PlotSimtelEvent:
         """Generate list of plots to run based on user input."""
         if "all" in plots:
             return list(self._plot_definitions.keys())
-        return gen.ensure_iterable(plots)
+        return gen.ensure_list(plots)
 
     @property
     def _plot_definitions(self):

--- a/src/simtools/visualization/visualize.py
+++ b/src/simtools/visualization/visualize.py
@@ -640,7 +640,7 @@ def save_figure(fig, output_file, figure_format=None, log_title="", dpi="figure"
 
     figure_format = figure_format or configured_formats or ["png"]
 
-    for fmt in gen.ensure_iterable(figure_format):
+    for fmt in gen.ensure_list(figure_format):
         _file = Path(output_file).with_suffix(f".{fmt}")
         fig.savefig(_file, format=fmt, bbox_inches="tight", dpi=dpi)
         logging.info(f"Saved plot {log_title} to {_file}")

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -830,16 +830,16 @@ def test_find_differences_in_json_objects():
     ]
 
 
-def test_ensure_iterable():
-    assert gen.ensure_iterable(None) == []
-    assert gen.ensure_iterable([1, 2, 3]) == [1, 2, 3]
-    assert gen.ensure_iterable(5) == [5]
-    assert gen.ensure_iterable((1, 2, 3)) == (1, 2, 3)
+def test_ensure_list():
+    assert gen.ensure_list(None) == []
+    assert gen.ensure_list([1, 2, 3]) == [1, 2, 3]
+    assert gen.ensure_list(5) == [5]
     # Test falsy values are correctly wrapped (not treated as None)
-    assert gen.ensure_iterable(0) == [0]
-    assert gen.ensure_iterable(0.0) == [0.0]
-    assert gen.ensure_iterable("") == [""]
-    assert gen.ensure_iterable(False) == [False]
+    assert gen.ensure_list(0) == [0]
+    assert gen.ensure_list(0.0) == [0.0]
+    assert gen.ensure_list("") == [""]
+    assert gen.ensure_list(False) == [False]
+    assert gen.ensure_list("abc") == ["abc"]
 
 
 def test_parse_typed_sequence():


### PR DESCRIPTION
Rename the `general.ensure_iterable` to `general_ensure_list` as this is the way it is used (iterables are I think as well broader including strings, dicts, etc).

I have checked the usage of the function and I cannot find anywhere that it is used for tuples.

**Note: this is an API change - both function name and behavior (with respect to tuples) changed)**

