### PR TITLE
Bug fix ground-to-shower coordinate transformation

### DIFF
--- a/docs/changes/2194.bugfix.md
+++ b/docs/changes/2194.bugfix.md
@@ -1,1 +1,1 @@
-Fixed bug in ground-to-shower coordinate transformation of passing angles in degrees where radians are expected. Fixed coordinated system orientation for transformation.
+Fixed bug in ground-to-shower coordinate transformation of passing angles in degrees where radians are expected. Fixed coordinate system orientation for transformation.

--- a/docs/changes/2194.bugfix.md
+++ b/docs/changes/2194.bugfix.md
@@ -1,0 +1,1 @@
+Fixed bug in ground-to-shower coordinate transformation of passing angles in degrees where radians are expected. Fixed coordinated system orientation for transformation.

--- a/docs/source/components/coordinate_systems.md
+++ b/docs/source/components/coordinate_systems.md
@@ -57,7 +57,7 @@ CORSIKA uses the ARRANGE card to specify geomagnetic field rotation, aligning th
 
 Local frame aligned with shower propagation direction. Used for ray-tracing and event reconstruction. Transforms ground coordinates based on shower azimuth and zenith angle.
 
-**Implementation:** `simtools.utils.geometry.transform_ground_to_shower_coordinates()`
+**Implementation:** `simtools.utils.geometry.project_ground_to_corsika_shower_coordinates()`
 
 ## Camera Coordinate Systems
 

--- a/src/simtools/sim_events/reader.py
+++ b/src/simtools/sim_events/reader.py
@@ -9,7 +9,7 @@ from astropy.coordinates import angular_separation
 
 from simtools.corsika.primary_particle import PrimaryParticle
 from simtools.io import table_handler
-from simtools.utils.geometry import solid_angle, transform_ground_to_shower_coordinates
+from simtools.utils.geometry import project_ground_to_corsika_shower_coordinates, solid_angle
 
 
 @dataclass
@@ -153,12 +153,12 @@ class EventDataReader:
                 setattr(shower_data, f"{col}_unit", table[col].unit)
 
         shower_data.x_core_shower, shower_data.y_core_shower, _ = (
-            transform_ground_to_shower_coordinates(
+            project_ground_to_corsika_shower_coordinates(
                 shower_data.x_core,
                 shower_data.y_core,
                 0.0,
-                shower_data.shower_azimuth,
-                shower_data.shower_altitude,
+                np.deg2rad(shower_data.shower_azimuth),
+                np.deg2rad(shower_data.shower_altitude),
             )
         )
         shower_data.core_distance_shower = np.hypot(

--- a/src/simtools/utils/geometry.py
+++ b/src/simtools/utils/geometry.py
@@ -141,8 +141,8 @@ def project_ground_to_corsika_shower_coordinates(
     - 0 rad   = North
     - pi/2    = East
 
-    Internally, the azimuth is converted to the CORSIKA `phi` convention used
-    in `iact.c`:
+    Internally, the azimuth is converted to the CORSIKA 'phi' convention used
+    in 'iact.c':
 
     - phi = 0       : shower propagates toward North
     - phi = pi/2    : shower propagates toward West

--- a/src/simtools/utils/geometry.py
+++ b/src/simtools/utils/geometry.py
@@ -121,11 +121,34 @@ def solid_angle(angle_max, angle_min=0 * u.rad):
     return 2 * np.pi * (np.cos(angle_min.to("rad")) - np.cos(angle_max.to("rad"))) * u.sr
 
 
-def transform_ground_to_shower_coordinates(x_ground, y_ground, z_ground, azimuth, altitude):
+def project_ground_to_corsika_shower_coordinates(
+    x_ground, y_ground, z_ground, azimuth_from_north_east, altitude
+):
     """
-    Transform ground to shower coordinates.
+    Transform ground to shower coordinates following the CORSIKA/sim_telarray convention.
 
-    Assume ground to be of type 'North-West-Up' (NWU) coordinates.
+    This function applies the same horizontal coordinate transformation used
+    internally by sim_telarray for shower-oriented coordinates.
+
+    Input ground coordinates follow the CORSIKA/sim_telarray ground system:
+
+    - x_ground : points North
+    - y_ground : points West
+    - z_ground : points Up
+
+    The input azimuth is assumed to follow the standard astronomical convention:
+
+    - 0 rad   = North
+    - pi/2    = East
+
+    Internally, the azimuth is converted to the CORSIKA `phi` convention used
+    in `iact.c`:
+
+    - phi = 0       : shower propagates toward North
+    - phi = pi/2    : shower propagates toward West
+
+    The transformation corresponds to the inverse of the projection applied
+    in sim_telarray when converting shower coordinates into ground coordinates.
 
     Parameters
     ----------
@@ -145,14 +168,20 @@ def transform_ground_to_shower_coordinates(x_ground, y_ground, z_ground, azimuth
     tuple
         Transformed shower coordinates (x', y', z').
     """
-    x, y, z, az, alt = np.broadcast_arrays(x_ground, y_ground, z_ground, azimuth, altitude)
+    x, y, z, az, alt = np.broadcast_arrays(
+        x_ground, y_ground, z_ground, azimuth_from_north_east, altitude
+    )
 
-    ca, sa = np.cos(az), np.sin(az)
-    cz, sz = np.sin(alt), np.cos(alt)
+    # Convert to CORSIKA phi convention used in iact.c:
+    # 0 = moves North, 90 deg = moves West
+    phi = np.mod(np.pi - az, 2.0 * np.pi)
 
-    x_s = ca * cz * x - sa * y + ca * sz * z
-    y_s = sa * cz * x + ca * y + sa * sz * z
-    z_s = -sz * x + cz * z
+    ca, sa = np.cos(phi), np.sin(phi)
+    cos_zenith = np.sin(alt)  # pi/2 - altitude
+
+    x_s = (ca * ca * cos_zenith + sa * sa) * x + ca * sa * (cos_zenith - 1.0) * y
+    y_s = ca * sa * (cos_zenith - 1.0) * x + (sa * sa * cos_zenith + ca * ca) * y
+    z_s = z
 
     return x_s, y_s, z_s
 

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -106,72 +106,53 @@ def test_solid_angle():
     )
 
 
-def test_transform_ground_to_shower_coordinates():
+def test_project_ground_to_corsika_shower_coordinates():
     """
     Test ground to shower coordinates.
 
-    Values below crosschecked with Eventdisplay and ctapipe results.
-
-    For ctapipe, do:
-
-        from ctapipe.coordinates import GroundFrame, TiltedGroundFrame
-
-        ground = GroundFrame(x=x_core * u.m, y=y_core * u.m, z=np.zeros_like(x_core) * u.m)
-        shower_frame = ground.transform_to(
-            TiltedGroundFrame(
-                pointing_direction=AltAz(
-                    az=shower_azimuth * u.rad, alt=shower_altitude * u.rad
-                )
-            )
-        )
-        return shower_frame.x.value, shower_frame.y.value
+    The implementation applies the documented horizontal CORSIKA/sim_telarray
+    projection and keeps ``z`` unchanged. In particular, zenith-pointing cases
+    are identical to ground coordinates for any azimuth.
     """
     x_ground = np.array([488.83758545] * 4)
     y_ground = np.array([-901.18658447] * 4)
     z_ground = np.array([0.0] * 4)
 
     # Following cases are tested:
-    # 1. both systems are identical for zenith pointing and zero azimuth
-    # 2. zenith pointing with azimuth rotation by 90 deg
-    # 3. random values
+    # 1. zenith pointing and zero azimuth
+    # 2. zenith pointing and azimuth rotated by 90 deg
+    # 3. generic values
     # 4. pointing towards horizon
     shower_azimuth = np.array([0.0, np.pi / 2.0, 0.21440187, 0.0])
     shower_altitude = np.array([np.pi / 2.0, np.pi / 2.0, 1.29735112, 0.0])
 
-    # The following expected values were crosschecked with Eventdisplay and ctapipe.
-    # For reference, see the docstring above for the ctapipe code used.
-    # The third and fourth columns are the results of transforming the ground coordinates
-    # (x_ground, y_ground, z_ground) to the shower frame for the given azimuth and altitude.
-    # These values are hardcoded here for regression testing.
     expected_x = np.array(
         [
-            x_ground[0],  # Case 1: zenith pointing, zero azimuth
-            -1.0 * y_ground[0],  # Case 2: zenith pointing, azimuth 90 deg
-            651.6379522993169,  # Case 3: expected result from Eventdisplay/ctapipe
-            0.0,  # Case 4: pointing towards horizon
+            x_ground[0],  # Case 1
+            x_ground[0],  # Case 2: zenith pointing preserves horizontal coordinates
+            464.53686987894685,  # Case 3: regression value for the documented projection
+            0.0,  # Case 4
         ]
     )
     expected_y = np.array(
         [
             y_ground[0],  # Case 1
-            x_ground[0],  # Case 2
-            -780.4105314700417,  # Case 3 expected result from Eventdisplay/ctapipe
+            y_ground[0],  # Case 2
+            -895.8951366687575,  # Case 3
             y_ground[0],  # Case 4
         ]
     )
-    # The following values were obtained by running the Eventdisplay code.
-    # Cross-checked with the ctapipe code in the docstring.
     expected_z = np.array(
         [
             0.0,  # Case 1
             0.0,  # Case 2
-            -132.01070589573638,  # Case 3: expected result from Eventdisplay/ctapipe
-            -1.0 * x_ground[0],  # Case 4: for horizon, z = -x_ground
+            0.0,  # Case 3
+            0.0,  # Case 4
         ]
     )
     expected = np.array([expected_x, expected_y, expected_z])
 
-    result = transf.transform_ground_to_shower_coordinates(
+    result = transf.project_ground_to_corsika_shower_coordinates(
         x_ground, y_ground, z_ground, shower_azimuth, shower_altitude
     )
 

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -116,7 +116,7 @@ def test_project_ground_to_corsika_shower_coordinates():
     """
     x_ground = np.array([488.83758545] * 4)
     y_ground = np.array([-901.18658447] * 4)
-    z_ground = np.array([0.0] * 4)
+    z_ground = np.array([0.0, 0.0, 123.4, 0.0])
 
     # Following cases are tested:
     # 1. zenith pointing and zero azimuth
@@ -146,7 +146,7 @@ def test_project_ground_to_corsika_shower_coordinates():
         [
             0.0,  # Case 1
             0.0,  # Case 2
-            0.0,  # Case 3
+            z_ground[2],  # Case 3: projection keeps the ground z coordinate unchanged
             0.0,  # Case 4
         ]
     )


### PR DESCRIPTION
Two important fixes:

- Fixed bug in ground-to-shower coordinate transformation of passing angles in degrees where radians are expected. 
- Fixed coordinated system orientation for transformation.

For the latter, I've spend quite some time in understanding the iact module transformation and fix the values accordingly. We finally have e.g., max core distances which are below the max CSCATTER value.

The good thing is that the coordinate transformation is applied in the reader, meaning we do not have to rep-process any data.