### PR TITLE
xfail integration tests on network errors

### DIFF
--- a/docs/changes/2199.maintenance.md
+++ b/docs/changes/2199.maintenance.md
@@ -1,0 +1,1 @@
+Allow integration tests configured with `xfail_network_error: true` to xfail on network errors.

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -86,6 +86,9 @@ definitions:
         test_use_case:
           type: string
           description: "Use case ID of the test."
+        xfail_network_error:
+          type: boolean
+          description: "Mark test as xfail if application exits with a network error."
       required:
         - application
         - configuration

--- a/tests/integration_tests/config/derive_ctao_array_layouts.yml
+++ b/tests/integration_tests/config/derive_ctao_array_layouts.yml
@@ -11,5 +11,6 @@ applications:
   - output_file: array_layouts/array_layouts-1.0.99.json
   - output_file: array_layouts/array_layouts-1.0.99.meta.yml
   test_name: run
+  xfail_network_error: true
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -81,6 +81,17 @@ def test_applications_from_config(tmp_test_directory, config, request):
         env=env,
     )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    if result.returncode != 0 and config.get("xfail_network_error"):
+        combined_output = result.stdout + result.stderr
+        network_error_patterns = (
+            "URLError",
+            "Network is unreachable",
+            "ConnectionError",
+            "TimeoutError",
+            "gaierror",
+        )
+        if any(pattern in combined_output for pattern in network_error_patterns):
+            pytest.xfail(f"Network error: {msg}")
     assert result.returncode == 0, msg
 
     assert log_inspector.inspect([result.stdout, result.stderr])


### PR DESCRIPTION
Regularily integration tests fail due to a network errors (mostly connections to the CTAO gitlab) - this is a bit annoying, requires additional actions, and delays work. Adding here an xfail mechanism for clearly labeled integration tests.

solves e.g. [this one](https://github.com/gammasim/simtools/actions/runs/26276353561/job/77344586942)