### PR TITLE
Add collection step to simtools-run-application

### DIFF
--- a/docs/changes/2215.feature.md
+++ b/docs/changes/2215.feature.md
@@ -1,0 +1,1 @@
+Add a file collection step to simtools-run-application.

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -12,7 +12,10 @@ from astropy.table import Column, Table
 from simtools.data_model.metadata_collector import MetadataCollector
 from simtools.io import ascii_handler, io_handler
 from simtools.job_execution.process_pool import process_pool_map_ordered
-from simtools.layout.array_layout_utils import get_array_elements_from_db_for_layouts
+from simtools.layout.array_layout_utils import (
+    get_array_elements_from_db_for_layouts,
+    resolve_array_layout_name,
+)
 from simtools.sim_events.histograms import EventDataHistograms
 from simtools.utils.general import get_uuid
 from simtools.utils.names import normalize_array_element_identifier_container
@@ -175,8 +178,14 @@ def _execute_production_job(job_spec):
 def _resolve_telescope_configs(args_dict):
     """Resolve telescope configurations from one of the supported input options."""
     if args_dict.get("array_layout_name"):
-        return get_array_elements_from_db_for_layouts(
+        layouts = resolve_array_layout_name(
             args_dict["array_layout_name"],
+            args_dict.get("model_version"),
+        )
+        if not isinstance(layouts, list):
+            layouts = [layouts]
+        return get_array_elements_from_db_for_layouts(
+            layouts,
             args_dict.get("site"),
             args_dict.get("model_version"),
         )

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -34,6 +34,15 @@ def run_applications(args_dict):
         args_dict.get("steps"),
         args_dict.get("activity_id"),
     )
+
+    collection_config = None
+    try:
+        collection_config = ascii_handler.collect_data_from_file(args_dict["config_file"]).get(
+            "collection"
+        )
+    except (OSError, TypeError):
+        logger.debug("Could not read collection configuration from workflow file.")
+
     workflow_start = datetime.now(UTC)
     associated_activities = []
     runtime_environment_snapshot = deepcopy(runtime_environment)
@@ -74,6 +83,8 @@ def run_applications(args_dict):
                 file.write(
                     f"Application: {app}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}\n"
                 )
+
+            _copy_collection_files(configurations, collection_config)
         finally:
             _update_workflow_metadata_files(
                 args_dict=args_dict,
@@ -84,6 +95,66 @@ def run_applications(args_dict):
                 model_parameter_metadata_files=model_parameter_metadata_files,
                 associated_activities=associated_activities,
             )
+
+
+def _copy_collection_files(configurations, collection_config):
+    """Copy listed files from application output paths to collection output path."""
+    if not collection_config:
+        return
+
+    output_path = collection_config.get("output_path")
+    files = collection_config.get("files") or []
+    if output_path is None or not files:
+        return
+
+    source_directories = _collect_source_directories(configurations)
+    collection_output_path = Path(output_path)
+    collection_output_path.mkdir(parents=True, exist_ok=True)
+
+    for file_name in files:
+        source_file = _find_collection_file(file_name, source_directories)
+        shutil.copy2(source_file, collection_output_path / file_name)
+
+
+def _collect_source_directories(configurations):
+    """Return unique output directories from application configurations."""
+    source_directories = []
+    for config in configurations:
+        source_dir = config.get("configuration", {}).get("output_path")
+        if source_dir is not None:
+            source_directory = Path(source_dir)
+            if source_directory not in source_directories:
+                source_directories.append(source_directory)
+    return source_directories
+
+
+def _find_collection_file(file_name, source_directories):
+    """Find a named file in the list of source directories.
+
+    Parameters
+    ----------
+    file_name : str
+        File name to locate.
+    source_directories : list
+        Directories to search in order.
+
+    Returns
+    -------
+    Path
+        Path to the found file.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file is not found in any source directory.
+    """
+    for source_directory in source_directories:
+        candidate = source_directory / file_name
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"Could not find collection file '{file_name}' in {source_directories}."
+    )
 
 
 def _append_metadata_file(model_parameter_metadata_files, metadata_file):
@@ -329,9 +400,22 @@ def _set_input_output_directories(path):
     Returns
     -------
     tuple
-        The first part is the 'input' directory, the second part is the subdirectory name
+        The first part is the output directory, the second part is the subdirectory name.
     """
-    setting_workflow = gen.extract_subdirectories_from_path(path, anchor="input")
+    path = Path(path)
+    try:
+        setting_workflow = gen.extract_subdirectories_from_path(path, anchor="input")
+    except ValueError:
+        if path.parent != Path():
+            setting_workflow = str(path.parent)
+        else:
+            setting_workflow = path.stem
+
+        logger.info(
+            "Could not derive setting workflow from 'input' anchor; "
+            f"using fallback '{setting_workflow}'"
+        )
+
     output_path = Path("output") / Path(setting_workflow)
     output_path.mkdir(parents=True, exist_ok=True)
     return output_path, setting_workflow

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -15,6 +15,8 @@ definitions:
     properties:
       applications:
         "$ref": "#/definitions/applications"
+      collection:
+        "$ref": "#/definitions/collection"
       schema_version:
         $ref: 'common_definitions.schema.yml#/$defs/schema_version_field'
       schema_url:
@@ -31,6 +33,21 @@ definitions:
       - schema_version
       - schema_name
     title: ""
+  collection:
+    type: object
+    additionalProperties: false
+    properties:
+      output_path:
+        type: string
+        description: "Path to the collection output directory."
+      files:
+        type: array
+        items:
+          type: string
+        description: "List of files to copy from application output_path to collection output_path."
+    required:
+      - output_path
+      - files
   runtime_environment:
     additionalProperties: false
     type: array

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -186,6 +186,46 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict, tm
     assert mock_write.call_count == 1
 
 
+def test_generate_corsika_limits_grid_by_version_layout_resolved(
+    mocker, mock_args_dict, tmp_test_directory
+):
+    """Test that a by_version dict string for array_layout_name is resolved before DB lookup.
+
+    This covers the case where run_application serializes the by_version dict as a Python
+    dict string when passing it as a CLI argument to the subprocess.
+    """
+    args = mock_args_dict.copy()
+    args["array_layout_name"] = ["{'by_version': {'>=1.0.0': ['LST', 'MST']}}"]
+    args["site"] = "North"
+    args["model_version"] = "1.2.3"
+
+    mock_read_layouts = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits."
+        "get_array_elements_from_db_for_layouts"
+    )
+    mock_read_layouts.return_value = {"LST": [1, 2], "MST": [3, 4]}
+
+    mock_pool = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
+    )
+    mock_pool.return_value = [
+        {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
+        {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+    ]
+
+    mock_io = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
+    )
+    mock_io.return_value.get_output_directory.return_value = tmp_test_directory
+
+    mocker.patch("simtools.production_configuration.derive_corsika_limits.write_results")
+
+    derive_corsika_limits.generate_corsika_limits_grid(args)
+
+    # by_version must be resolved to the actual list before calling DB lookup
+    mock_read_layouts.assert_called_once_with(["LST", "MST"], "North", "1.2.3")
+
+
 def test_generate_corsika_limits_grid_with_array_element_list(
     mocker, mock_args_dict, tmp_test_directory
 ):

--- a/tests/unit_tests/runners/test_simtools_runner.py
+++ b/tests/unit_tests/runners/test_simtools_runner.py
@@ -56,9 +56,10 @@ def test_set_input_output_directories():
 
     assert setting_workflow == "LSTN-01/pm_photoelectron_spectrum/20250304T073000"
 
-    path = "output/LSTN-01/pm_photoelectron_spectrum/20250304T073000/config.yml"
-    with pytest.raises(ValueError, match=r"^Could not find subdirectory under"):
-        simtools_runner._set_input_output_directories(path)
+    path = "tests/resources_generation/application_config/config.yml"
+    output_path, setting_workflow = simtools_runner._set_input_output_directories(path)
+    assert str(output_path) == "output/tests/resources_generation/application_config"
+    assert setting_workflow == "tests/resources_generation/application_config"
 
 
 def test_replace_placeholders_in_configuration_replaces_string():
@@ -291,6 +292,72 @@ def test_run_applications_runs_and_logs(monkeypatch, tmp_test_directory):
     version_string_mock.assert_called_once_with([], include_software_versions=False)
     workflow_build_mock.assert_not_called()
     workflow_update_mock.assert_not_called()
+
+
+def test_run_applications_copies_collection_files(monkeypatch, tmp_test_directory):
+    """Copy collection files from application output_path to collection output_path."""
+    tmp_path = Path(str(tmp_test_directory))
+    source_output = tmp_path / "app_output"
+    source_output.mkdir(parents=True, exist_ok=True)
+    source_file = source_output / "result.dat"
+    source_file.write_text("test-data", encoding="utf-8")
+
+    collection_output = tmp_path / "collection"
+
+    mock_args_dict = {
+        "config_file": "dummy_config.yml",
+        "steps": None,
+        "ignore_runtime_environment": False,
+    }
+    mock_configurations = [
+        {
+            "application": "app1",
+            "run_application": True,
+            "configuration": {
+                "activity_id": "cfg-id-1",
+                "output_path": str(source_output),
+            },
+        }
+    ]
+    log_file_path = tmp_path / "simtools.log"
+
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner._read_application_configuration",
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+    )
+    monkeypatch.setattr(
+        "simtools.io.ascii_handler.collect_data_from_file",
+        mock.Mock(
+            return_value={
+                "collection": {
+                    "output_path": str(collection_output),
+                    "files": ["result.dat"],
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "simtools.dependencies.get_version_string",
+        mock.Mock(return_value="simtools version: 1.2.3\n"),
+    )
+    monkeypatch.setattr(
+        "simtools.job_execution.job_manager.submit",
+        mock.Mock(return_value=mock.Mock(stdout="ok", stderr="")),
+    )
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner.workflow_metadata.build_workflow_activity_metadata",
+        mock.Mock(return_value={"id": "wf-activity-id"}),
+    )
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner.workflow_metadata.update_model_parameter_metadata_file",
+        mock.Mock(),
+    )
+
+    simtools_runner.run_applications(mock_args_dict)
+
+    copied_file = collection_output / "result.dat"
+    assert copied_file.exists()
+    assert copied_file.read_text(encoding="utf-8") == "test-data"
 
 
 def test_run_applications_passes_workflow_instrument_context(monkeypatch, tmp_test_directory):


### PR DESCRIPTION
After all applications in a workflow config run, optionally copy named output files into a designated collection directory. This supports e.g. reproducible test-resource generation via configs:

```
collection:
  output_path: tests/resources/model_parameters
  files:
  - Benn_LaPalma_sky_converted.lis
```

Means that only the `Benn_LaPalma_sky_converted.lis` file generated by the simtools application will be moved into the `collection.output_path`.

Fixes (sorry, unrelated) also an error on the reading of array_layout_name from the config files for derive corsika limits.