### PR TITLE
Fix integration tests to run from any working directory

### DIFF
--- a/docs/changes/2216.feature.md
+++ b/docs/changes/2216.feature.md
@@ -1,0 +1,1 @@
+Allow integration tests to be run from any directory, not only the simtools base directory.

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -13,8 +13,16 @@ from simtools.testing import assertions
 
 _logger = logging.getLogger(__name__)
 
-# Repo root for resolving relative test resource paths (src/simtools/testing/ -> repo root)
-_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+def _find_repo_root():
+    """Find the repository root by walking up until pyproject.toml is found."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("Repository root not found (no pyproject.toml in any parent directory)")
+
+
+_REPO_ROOT = _find_repo_root()
 
 
 def _versions_match(from_command_line, from_config_file):

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -15,11 +15,16 @@ _logger = logging.getLogger(__name__)
 
 
 def _find_repo_root():
-    """Find the repository root by walking up until pyproject.toml is found."""
+    """Find the repository root by walking up until pyproject.toml is found.
+
+    Falls back to the current working directory when pyproject.toml is not found
+    (e.g. when the package is imported from an installed wheel or sdist).
+    """
     for parent in Path(__file__).resolve().parents:
         if (parent / "pyproject.toml").exists():
             return parent
-    raise FileNotFoundError("Repository root not found (no pyproject.toml in any parent directory)")
+    _logger.warning("Repository root not found; using current working directory as fallback.")
+    return Path.cwd()
 
 
 _REPO_ROOT = _find_repo_root()

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -13,6 +13,9 @@ from simtools.testing import assertions
 
 _logger = logging.getLogger(__name__)
 
+# Repo root for resolving relative test resource paths (src/simtools/testing/ -> repo root)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
 
 def _versions_match(from_command_line, from_config_file):
     """Return True if validations should run for the given versions.
@@ -116,11 +119,17 @@ def _test_simtel_cfg_files(config, integration_test, from_command_line, from_con
             break
 
 
+def _resolve_path(path):
+    """Resolve a path, making relative paths absolute against the repo root."""
+    p = Path(path)
+    return p if p.is_absolute() else _REPO_ROOT / p
+
+
 def _validate_reference_output_file(config, integration_test):
     """Compare with reference output file."""
     test_file = integration_test.get("test_output_file") or config["configuration"]["output_file"]
     assert compare_files(
-        integration_test["reference_output_file"],
+        _resolve_path(integration_test["reference_output_file"]),
         Path(config["configuration"]["output_path"]).joinpath(test_file),
         integration_test.get("tolerance", 1.0e-5),
         integration_test.get("test_columns", None),
@@ -436,7 +445,7 @@ def _validate_simtel_cfg_files(config, simtel_cfg_file):
     Note the finetuned naming of configuration files by simtools.
 
     """
-    reference_file = Path(simtel_cfg_file)
+    reference_file = _resolve_path(simtel_cfg_file)
     test_file = (
         Path(config["configuration"]["output_path"])
         / f"model/{config['configuration']['model_version']}"

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,15 +1,12 @@
 """Common fixtures for integration tests."""
 
 import os
-from pathlib import Path
 
 import pytest
 from dotenv import load_dotenv
 
 import simtools.io.io_handler
 from simtools import settings
-
-_REPO_ROOT = Path(__file__).parent.parent.parent
 
 
 def pytest_addoption(parser):
@@ -18,16 +15,16 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(autouse=True)
-def simtools_settings(db_config):
+def simtools_settings(db_config, pytestconfig):
     """Load simtools settings for the test session."""
-    load_dotenv(_REPO_ROOT / ".env")
+    load_dotenv(pytestconfig.rootdir / ".env")
     settings.config.load(db_config=db_config)
 
 
 @pytest.fixture
-def db_config():
+def db_config(pytestconfig):
     """DB configuration from .env file."""
-    load_dotenv(_REPO_ROOT / ".env")
+    load_dotenv(pytestconfig.rootdir / ".env")
 
     _db_para = (
         "db_api_user",

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -17,14 +17,14 @@ def pytest_addoption(parser):
 @pytest.fixture(autouse=True)
 def simtools_settings(db_config, pytestconfig):
     """Load simtools settings for the test session."""
-    load_dotenv(pytestconfig.rootdir / ".env")
+    load_dotenv(pytestconfig.rootpath / ".env")
     settings.config.load(db_config=db_config)
 
 
 @pytest.fixture
 def db_config(pytestconfig):
     """DB configuration from .env file."""
-    load_dotenv(pytestconfig.rootdir / ".env")
+    load_dotenv(pytestconfig.rootpath / ".env")
 
     _db_para = (
         "db_api_user",

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,12 +1,15 @@
 """Common fixtures for integration tests."""
 
 import os
+from pathlib import Path
 
 import pytest
 from dotenv import load_dotenv
 
 import simtools.io.io_handler
 from simtools import settings
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
 
 
 def pytest_addoption(parser):
@@ -17,14 +20,14 @@ def pytest_addoption(parser):
 @pytest.fixture(autouse=True)
 def simtools_settings(db_config):
     """Load simtools settings for the test session."""
-    load_dotenv(".env")
+    load_dotenv(_REPO_ROOT / ".env")
     settings.config.load(db_config=db_config)
 
 
 @pytest.fixture
 def db_config():
     """DB configuration from .env file."""
-    load_dotenv(".env")
+    load_dotenv(_REPO_ROOT / ".env")
 
     _db_para = (
         "db_api_user",

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -79,7 +79,7 @@ def test_applications_from_config(tmp_test_directory, config, request):
         capture_output=True,
         text=True,
         env=env,
-        cwd=request.config.rootdir,
+        cwd=request.config.rootpath,
     )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     if result.returncode != 0 and config.get("xfail_network_error"):

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -13,6 +13,8 @@ from simtools.testing import configuration, helpers, log_inspector, validate_out
 
 logger = logging.getLogger()
 
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
 config_files = sorted(Path(__file__).parent.glob("config/*.yml"))
 test_configs, test_ids = configuration.get_list_of_test_configurations(config_files)
 test_parameters = []
@@ -79,6 +81,7 @@ def test_applications_from_config(tmp_test_directory, config, request):
         capture_output=True,
         text=True,
         env=env,
+        cwd=_REPO_ROOT,
     )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     if result.returncode != 0 and config.get("xfail_network_error"):

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -13,8 +13,6 @@ from simtools.testing import configuration, helpers, log_inspector, validate_out
 
 logger = logging.getLogger()
 
-_REPO_ROOT = Path(__file__).parent.parent.parent
-
 config_files = sorted(Path(__file__).parent.glob("config/*.yml"))
 test_configs, test_ids = configuration.get_list_of_test_configurations(config_files)
 test_parameters = []
@@ -81,7 +79,7 @@ def test_applications_from_config(tmp_test_directory, config, request):
         capture_output=True,
         text=True,
         env=env,
-        cwd=_REPO_ROOT,
+        cwd=request.config.rootdir,
     )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     if result.returncode != 0 and config.get("xfail_network_error"):

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -353,7 +353,7 @@ def test_validate_reference_output_file(mocker, output_path, test_path):
     validate_output._validate_reference_output_file(config, integration_test)
 
     mock_compare_files.assert_called_once_with(
-        integration_test["reference_output_file"],
+        Path(integration_test["reference_output_file"]),
         Path(config["configuration"]["output_path"]).joinpath(
             config["configuration"]["output_file"]
         ),


### PR DESCRIPTION
## Summary

Motivated by https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simpipe/-/work_items/34

Integration tests previously only worked when executed from the simtools base directory. This PR makes them runnable from any directory, e.g.:

```
pytest --no-cov -n auto --model_version=7.0.0 simtools/tests/integration_tests/
```

## Root causes fixed

Three places where relative paths were resolved against the process CWD rather than the repo root:

1. `load_dotenv(".env")` in `conftest.py` — CWD-relative
2. `subprocess.run` in `test_applications_from_config.py` — subprocesses inherited the pytest CWD, so `tests/resources/...` paths in 125+ YAML config entries failed
3. `validate_output.py` — reference files (e.g. `tests/resources/spe_LST_...ecsv`) opened directly by the test process

## Changes

- **`tests/integration_tests/conftest.py`**: Use `pytestconfig.rootdir` (pytest-native) to locate `.env`
- **`tests/integration_tests/test_applications_from_config.py`**: Use `request.config.rootdir` as subprocess `cwd`
- **`src/simtools/testing/validate_output.py`**: Add `_find_repo_root()` (walks up to `pyproject.toml`) and `_resolve_path()` to make reference file paths absolute
- **`tests/unit_tests/testing/test_validate_output.py`**: Update assertion to expect `Path` object from `_resolve_path`