### PR TITLE
Add illuminator_telescope_visibility model parameter schema

### DIFF
--- a/docs/changes/2220.feature.md
+++ b/docs/changes/2220.feature.md
@@ -1,0 +1,1 @@
+Add illuminator_telescope_visibility model parameter schema

--- a/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
+++ b/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
@@ -10,20 +10,44 @@ description: |-
   Illumination status table for telescope-illuminator pairs.
   Defines which telescopes can be illuminated by each illuminator at a site,
   accounting for shadowing, blocking, topography, and distance constraints.
+  Each row represents one illuminator-telescope combination with a boolean
+  visibility flag.
+short_description: Illuminator-telescope visibility lookup table.
 developer_note: |-
-  Telescope columns are site-specific and defined in the ECSV file header.
-  North site has ~13 telescope columns (LSTN-01 to LSTN-04, MSTN-01 to MSTN-15).
-  South site has ~60 telescope columns (LSTS-01 to LSTS-04, MSTS-01 to MSTS-14, SSTS-01 to SSTS-42).
-  Each site must have at least 2 illuminators and their respective telescopes.
-  All telescope columns must be boolean type (true=illuminated, false=shadowed/blocked).
-  The ECSV file contains:
-    - illuminator_name column (string): Illuminator identifier
-    - Multiple telescope columns (boolean): One column per telescope, indicating illumination status
-  Column names match expected telescope naming conventions (LSTN/MSTN for North, LSTS/MSTS/SSTS for South).
+  Long-format table with one row per illuminator-telescope pair.
+  North site has 2 illuminators and 13 telescopes (26 pairs).
+  South site has 4 illuminators and 60 telescopes (240 pairs).
+  visible=true means the telescope can be illuminated by that illuminator.
+  visible=false means the line of sight is blocked (shadowing, topography, etc.).
 data:
-  - type: file
-    unit: dimensionless
-    default: null
+  - type: dict
+    json_schema:
+      type: object
+      additionalProperties: false
+      required:
+        - columns
+        - rows
+      properties:
+        columns:
+          type: array
+          items:
+            - const: illuminator_id
+            - const: telescope_id
+            - const: visible
+          additionalItems: false
+          minItems: 3
+          maxItems: 3
+        rows:
+          type: array
+          items:
+            type: array
+            items:
+              - type: string
+              - type: string
+              - type: boolean
+            additionalItems: false
+            minItems: 3
+            maxItems: 3
 instrument:
   class: Site
 activity:

--- a/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
+++ b/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for illuminator_telescope_visibility model parameter
+schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: illuminator_telescope_visibility
+description: |-
+  Illumination status table for telescope-illuminator pairs.
+  Defines which telescopes can be illuminated by each illuminator at a site,
+  accounting for shadowing, blocking, topography, and distance constraints.
+developer_note: |-
+  Telescope columns are site-specific and defined in the ECSV file header.
+  North site has ~13 telescope columns (LSTN-01 to LSTN-04, MSTN-01 to MSTN-15).
+  South site has ~60 telescope columns (LSTS-01 to LSTS-04, MSTS-01 to MSTS-14, SSTS-01 to SSTS-42).
+  Each site must have at least 2 illuminators and their respective telescopes.
+  All telescope columns must be boolean type (true=illuminated, false=shadowed/blocked).
+  The ECSV file contains:
+    - illuminator_name column (string): Illuminator identifier
+    - Multiple telescope columns (boolean): One column per telescope, indicating illumination status
+  Column names match expected telescope naming conventions (LSTN/MSTN for North, LSTS/MSTS/SSTS for South).
+data:
+  - type: file
+    unit: dimensionless
+    default: null
+instrument:
+  class: Site
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: simtools


### PR DESCRIPTION
Define schema for telescope-illuminator visibility tables used in calibration simulations. Supports both North (~13 telescopes) and South (~60 telescopes) sites with boolean illumination status per telescope-illuminator pair.