### PR TITLE
Fix model parameter validation for dimensionless floats.

### DIFF
--- a/docs/changes/2222.bugfix.md
+++ b/docs/changes/2222.bugfix.md
@@ -1,0 +1,1 @@
+Fix model parameter validation for dimensionless floats.

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -599,7 +599,9 @@ class ModelDataWriter:
                     unit.replace("None", "null") if isinstance(unit, str) else unit
                     for unit in data_dict["unit"]
                 ]
-                if all(u == data_dict["unit"][0] for u in data_dict["unit"]):
+                if not data_dict["unit"]:
+                    data_dict["unit"] = None
+                elif all(u == data_dict["unit"][0] for u in data_dict["unit"]):
                     data_dict["unit"] = data_dict["unit"][0]
         except KeyError:
             pass

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -1019,9 +1019,15 @@ class DataValidator:
             "int" in self.data_dict.get("type", "float"),
         )
         if isinstance(self.data_dict["unit"], str):
-            self.data_dict["unit"] = gen.convert_string_to_list(
-                self.data_dict["unit"], force_comma_separation=True
+            normalized = value_conversion.normalize_dimensionless_unit(
+                self.data_dict["unit"].strip()
             )
+            if normalized is None:
+                self.data_dict["unit"] = None
+            else:
+                self.data_dict["unit"] = gen.convert_string_to_list(
+                    normalized, force_comma_separation=True
+                )
 
     def _convert_results_to_model_format(self):
         """

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -497,6 +497,14 @@ def test_prepare_data_dict_for_writing():
         "type": "float64",
     }
 
+    # empty list unit (produced when a dimensionless float goes through the pipeline) → None
+    data_dict_7 = {"value": 0.784, "unit": [], "type": "float64"}
+    assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_7) == {
+        "value": 0.784,
+        "unit": None,
+        "type": "float64",
+    }
+
 
 def test_get_unit_from_schema(num_gains_schema):
     w1 = writer.ModelDataWriter()

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -818,6 +818,16 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert isinstance(data_validator.data_dict["value"][0], int)
 
+    # dimensionless unit as empty string (e.g. from u.Quantity("0.784")) → None
+    data_validator.data_dict = {"name": "mirror_degraded_reflection", "value": 0.784, "unit": ""}
+    data_validator._prepare_model_parameter()
+    assert data_validator.data_dict["unit"] is None
+
+    # dimensionless unit as "dimensionless" string → None
+    data_validator.data_dict = {"name": "some_param", "value": 1.0, "unit": "dimensionless"}
+    data_validator._prepare_model_parameter()
+    assert data_validator.data_dict["unit"] is None
+
 
 def test_get_value_and_units_as_lists():
     data_validator = validate_data.DataValidator()


### PR DESCRIPTION
This was tested before for `num_gains` - an integer value and therefore not caught.

e.g. failed for:

```
['simtools-submit-model-parameter-from-external', '--instrument', 'LSTN-design', '--input_meta', 'input/LSTN-design/mirror_degraded_reflection/019e7353-b82f-760d-963d-ef958a4759d3/*meta.yml', '--output_path', 'output/LSTN-design/mirror_degraded_reflection/019e7353-b82f-760d-963d-ef958a4759d3/', '--parameter', 'mirror_degraded_reflection', '--parameter_version', '3.0.0', '--site', 'North', '--value', '0.784', '--activity_id', '019e7405-81bb-7a04-90bd-a283b953e17d', '--label', 'simtools-submit-model-parameter-from-external', '--disable_log_file']
```

