### PR TITLE
Efficiency improvements for unit tests 

### DIFF
--- a/docs/changes/2223.maintenance.md
+++ b/docs/changes/2223.maintenance.md
@@ -1,0 +1,1 @@
+Efficiency improvements for unit tests (mostly in unit tests of the plotting routines).

--- a/src/simtools/layout/telescope_position.py
+++ b/src/simtools/layout/telescope_position.py
@@ -1,10 +1,17 @@
 """Telescope positions and coordinate transformations."""
 
+import functools
 import logging
 
 import astropy.units as u
 import numpy as np
 import pyproj
+
+
+@functools.cache
+def _cached_transformer(crs_from, crs_to):
+    """Return a cached pyproj Transformer for the given CRS pair."""
+    return pyproj.Transformer.from_crs(crs_from, crs_to)
 
 
 class InvalidCoordSystemErrorError(Exception):
@@ -316,7 +323,7 @@ class TelescopePosition:
 
         """
         try:
-            transformer = pyproj.Transformer.from_crs(crs_from, crs_to)
+            transformer = _cached_transformer(crs_from, crs_to)
         except pyproj.exceptions.CRSError:
             self._logger.error("Invalid coordinate system")
             raise

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -6,7 +6,11 @@ import logging
 import mmap
 import os
 import re
+import shutil
+import struct
 import tarfile
+import urllib.error
+import zlib
 from contextlib import ExitStack, contextmanager
 from itertools import chain
 from pathlib import Path
@@ -32,6 +36,39 @@ from simtools.runners.corsika_runner import CorsikaRunner
 
 logger = logging.getLogger()
 DATABASE_HANDLER_CLASS = db_handler.DatabaseHandler
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+_GITHUB_RAW_BASE = "https://raw.githubusercontent.com/gammasim/simtools/main/"
+
+
+# Minimal 1x1 white-pixel PNG (67 bytes). Written instead of rendering
+# when savefig() is called with a file path during unit tests.
+def _build_stub_png():
+    """Return bytes of a minimal valid 1x1 white-pixel PNG."""
+
+    def chunk(name, data):
+        crc = struct.pack(">I", zlib.crc32(name + data) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + name + data + crc
+
+    return (
+        b"\x89PNG\r\n\x1a\n"  # PNG signature
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))  # 1x1 RGB
+        + chunk(b"IDAT", zlib.compress(b"\x00\xff\xff\xff"))  # one white pixel
+        + chunk(b"IEND", b"")
+    )
+
+
+_STUB_PNG_BYTES = _build_stub_png()
+
+
+def _local_urlretrieve(url, dest):
+    """Serve local repo files instead of making real HTTP requests in unit tests."""
+    if url.startswith(_GITHUB_RAW_BASE):
+        local_path = _REPO_ROOT / url[len(_GITHUB_RAW_BASE) :]
+        if local_path.exists():
+            shutil.copy(local_path, dest)
+            return dest, None
+    raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
 
 
 def _is_db_unit_test(request):
@@ -119,6 +156,77 @@ def mock_simulator_paths(request, tmp_test_directory):
 def _set_matplotlib_backend():
     """Set matplotlib backend to Agg for testing (plotting without display server)."""
     plt.switch_backend("Agg")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _fast_figure_saves():
+    """Skip matplotlib rendering in unit tests for speed.
+
+    - savefig with file paths: writes a minimal PNG stub (skips rendering and encoding)
+    - tight_layout: no-op (layout computation triggers full rendering for text-extent measurement)
+    - colorbar: returns a MagicMock (colorbar creation triggers quad-mesh rendering)
+
+    Non-file outputs (e.g. BytesIO) still render at reduced DPI so live previews work.
+    Unit tests only check file existence and non-zero size; no test reads pixel content.
+    """
+    from unittest.mock import MagicMock
+
+    import matplotlib.figure
+
+    orig_savefig = matplotlib.figure.Figure.savefig
+
+    def _stub_savefig(self, fname, *args, **kwargs):
+        if isinstance(fname, (str, Path)):
+            path = Path(fname)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(_STUB_PNG_BYTES)
+            return None
+        kwargs["dpi"] = min(kwargs.get("dpi", 100), 30)
+        kwargs.pop("bbox_inches", None)
+        return orig_savefig(self, fname, *args, **kwargs)
+
+    def _noop_tight_layout(self, *args, **kwargs):
+        pass
+
+    def _mock_colorbar(self, *args, **kwargs):
+        return MagicMock()
+
+    with mock.patch.object(matplotlib.figure.Figure, "savefig", _stub_savefig):
+        with mock.patch.object(matplotlib.figure.Figure, "tight_layout", _noop_tight_layout):
+            with mock.patch.object(matplotlib.figure.Figure, "colorbar", _mock_colorbar):
+                yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _mock_urlretrieve_for_unit_tests():
+    """Prevent real HTTP calls in unit tests by serving local repo files."""
+    with mock.patch("urllib.request.urlretrieve", side_effect=_local_urlretrieve):
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_erfa_tables():
+    """Pre-initialise ERFA/IERS tables so the first coordinate-transform test is not penalised.
+
+    The first astropy AltAz→ICRS transform in a fresh process must load ERFA tables from
+    disk (~0.2 s).  Running a dummy transform here during session set-up amortises that
+    cost before any test measures it.  IERS auto-download is disabled so no network call
+    is made.
+    """
+    from astropy.coordinates import AltAz, EarthLocation, SkyCoord
+    from astropy.time import Time
+    from astropy.utils import iers
+
+    prev = iers.conf.auto_download
+    iers.conf.auto_download = False
+    try:
+        loc = EarthLocation(lat=28.76 * u.deg, lon=-17.89 * u.deg, height=2200 * u.m)
+        t = Time("2017-09-16 00:00:00", scale="utc")
+        altaz = AltAz(az=180 * u.deg, alt=45 * u.deg, location=loc, obstime=t)
+        SkyCoord(altaz).icrs
+    finally:
+        iers.conf.auto_download = prev
+    return
 
 
 @pytest.fixture

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -186,6 +186,7 @@ def _fast_figure_saves():
         return orig_savefig(self, fname, *args, **kwargs)
 
     def _noop_tight_layout(self, *args, **kwargs):
+        # tight_layout is skipped because it triggers expensive rendering work in tests.
         pass
 
     def _mock_colorbar(self, *args, **kwargs):
@@ -208,9 +209,9 @@ def _mock_urlretrieve_for_unit_tests():
 def _warm_erfa_tables():
     """Pre-initialise ERFA/IERS tables so the first coordinate-transform test is not penalised.
 
-    The first astropy AltAz→ICRS transform in a fresh process must load ERFA tables from
+    The first astropy AltAz to ICRS transform in a fresh process must load ERFA tables from
     disk (~0.2 s).  Running a dummy transform here during session set-up amortises that
-    cost before any test measures it.  IERS auto-download is disabled so no network call
+    cost before any test measures it. IERS auto-download is disabled so no network call
     is made.
     """
     from astropy.coordinates import AltAz, EarthLocation, SkyCoord
@@ -226,7 +227,6 @@ def _warm_erfa_tables():
         SkyCoord(altaz).icrs
     finally:
         iers.conf.auto_download = prev
-    return
 
 
 @pytest.fixture

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -5,7 +5,6 @@ import getpass
 import json
 import logging
 import re
-import time
 import uuid
 from pathlib import Path
 
@@ -73,7 +72,16 @@ def test_get_data_model_schema_dict(args_dict_site):
     assert metadata.get_data_model_schema_dict() == {}
 
 
-def test_get_top_level_metadata(args_dict_site):
+def test_get_top_level_metadata(args_dict_site, mocker):
+    mocker.patch(
+        "simtools.data_model.metadata_collector.gen.now_date_time_in_isoformat",
+        side_effect=[
+            "2020-01-01T00:00:00+00:00",
+            "2020-01-01T00:00:00+00:00",
+            "2020-01-01T00:00:00+00:00",
+            "2099-01-01T00:00:00+00:00",
+        ],
+    )
     collector = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     assert (
         collector.top_level_meta["cta"]["activity"]["end"]
@@ -85,7 +93,6 @@ def test_get_top_level_metadata(args_dict_site):
     top_level_meta = collector.get_top_level_metadata()
     assert top_level_meta["cta"]["activity"]["end"] == top_level_meta["cta"]["activity"]["start"]
 
-    time.sleep(1)
     collector.observatory = "cta"  # back to default
     top_level_meta = collector.get_top_level_metadata()
     assert top_level_meta["cta"]["activity"]["end"] > top_level_meta["cta"]["activity"]["start"]

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -497,7 +497,7 @@ def test_prepare_data_dict_for_writing():
         "type": "float64",
     }
 
-    # empty list unit (produced when a dimensionless float goes through the pipeline) → None
+    # empty list unit (produced when a dimensionless float goes through the pipeline) to None
     data_dict_7 = {"value": 0.784, "unit": [], "type": "float64"}
     assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_7) == {
         "value": 0.784,

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -497,7 +497,7 @@ def test_prepare_data_dict_for_writing():
         "type": "float64",
     }
 
-    # empty list unit (produced when a dimensionless float goes through the pipeline) to None
+    # empty list unit (produced when a dimensionless float goes through the pipeline) -> None
     data_dict_7 = {"value": 0.784, "unit": [], "type": "float64"}
     assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_7) == {
         "value": 0.784,

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -131,8 +131,7 @@ def test_validate_dict_using_schema(tmp_test_directory, caplog):
         schema.validate_dict_using_schema(invalid_data, schema_file)
 
 
-@pytest.mark.xfail(reason="No network connection")
-def test_validate_dict_using_schema_remote(tmp_test_directory):
+def test_validate_dict_using_schema_remote(tmp_test_directory, mocker):
     sample_schema = {
         "type": "object",
         "properties": {"name": {"type": "string"}, "age": {"type": "number"}},
@@ -147,13 +146,19 @@ def test_validate_dict_using_schema_remote(tmp_test_directory):
     # sample data dictionary to be validated
     data = {"name": "John", "age": 30}
 
+    mock_url_exists = mocker.patch("simtools.data_model.schema.gen.url_exists")
+
     # with valid meta_schema_url
+    mock_url_exists.return_value = True
     data["meta_schema_url"] = "https://github.com/gammasim/simtools"
     schema.validate_dict_using_schema(data, schema_file)
+    mock_url_exists.assert_called_with("https://github.com/gammasim/simtools")
 
+    mock_url_exists.return_value = False
     data["meta_schema_url"] = "https://invalid_url"
     with pytest.raises(FileNotFoundError, match=r"^Meta schema URL does not exist:"):
         schema.validate_dict_using_schema(data, schema_file)
+    mock_url_exists.assert_called_with("https://invalid_url")
 
 
 def test_validate_schema_astropy_units(caplog):

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -823,7 +823,7 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"] is None
 
-    # dimensionless unit as "dimensionless" string: None
+    # dimensionless unit as "dimensionless" string -> None
     data_validator.data_dict = {"name": "some_param", "value": 1.0, "unit": "dimensionless"}
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"] is None

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -823,7 +823,7 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"] is None
 
-    # dimensionless unit as "dimensionless" string → None
+    # dimensionless unit as "dimensionless" string: None
     data_validator.data_dict = {"name": "some_param", "value": 1.0, "unit": "dimensionless"}
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"] is None

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -818,7 +818,7 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert isinstance(data_validator.data_dict["value"][0], int)
 
-    # dimensionless unit as empty string (e.g. from u.Quantity("0.784")) → None
+    # dimensionless unit as empty string (e.g. from u.Quantity("0.784")):  None
     data_validator.data_dict = {"name": "mirror_degraded_reflection", "value": 0.784, "unit": ""}
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"] is None

--- a/tests/unit_tests/io/test_ascii_handler.py
+++ b/tests/unit_tests/io/test_ascii_handler.py
@@ -123,7 +123,7 @@ def test_collect_data_dict_from_json():
     assert data["unit"] == "m"
 
 
-def test_collect_data_from_http():
+def test_collect_data_from_http() -> None:
     _file = "src/simtools/schemas/model_parameters/num_gains.schema.yml"
     url = url_simtools
 

--- a/tests/unit_tests/production_configuration/test_observation_grid.py
+++ b/tests/unit_tests/production_configuration/test_observation_grid.py
@@ -6,8 +6,22 @@ from astropy import units as u
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.tests.helper import assert_quantity_allclose
 from astropy.time import Time
+from astropy.utils import iers
 
 from simtools.production_configuration.observation_grid import ProductionGridEngine
+
+pytestmark = pytest.mark.filterwarnings("ignore::astropy.utils.iers.IERSWarning")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def disable_iers_auto_download():
+    """Disable IERS auto-download during tests to avoid network dependency."""
+    previous_auto_download = iers.conf.auto_download
+    iers.conf.auto_download = False
+    try:
+        yield
+    finally:
+        iers.conf.auto_download = previous_auto_download
 
 
 def test_generate_simulation_grid_keeps_horizontal_coordinates_for_radec_axes():

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -220,8 +220,21 @@ def test_is_url():
     assert gen.is_url(5.0) is False
 
 
-@pytest.mark.xfail(reason="No network connection")
-def test_url_exists(caplog):
+def test_url_exists(caplog, mocker):
+    import urllib.error
+
+    def mock_urlopen(url, timeout=5):
+        if url == url_simtools_main:
+            mock_ctx = mocker.MagicMock()
+            mock_ctx.__enter__.return_value.status = 200
+            mock_ctx.__exit__.return_value = False
+            return mock_ctx
+        if url is None:
+            raise AttributeError("'NoneType' object has no attribute")
+        raise urllib.error.URLError("not found")
+
+    mocker.patch("simtools.utils.general.urllib.request.urlopen", side_effect=mock_urlopen)
+
     assert gen.url_exists(url_simtools_main)
     with caplog.at_level(logging.ERROR):
         assert not gen.url_exists(url_simtools)  # raw ULR does not exist

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -237,7 +237,7 @@ def test_url_exists(caplog, mocker):
 
     assert gen.url_exists(url_simtools_main)
     with caplog.at_level(logging.ERROR):
-        assert not gen.url_exists(url_simtools)  # raw ULR does not exist
+        assert not gen.url_exists(url_simtools)  # raw URL does not exist
     assert "does not exist" in caplog.text
     with caplog.at_level(logging.ERROR):
         assert not gen.url_exists(None)

--- a/tests/unit_tests/visualization/conftest.py
+++ b/tests/unit_tests/visualization/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for visualization unit tests."""
 
+import matplotlib.figure
 import matplotlib.pyplot as plt
 import pytest
 
@@ -9,3 +10,15 @@ def close_all_figures():
     """Automatically close all matplotlib figures after each test."""
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def _fast_savefig(monkeypatch):
+    """Override savefig DPI to 10 to speed up visualization unit tests."""
+    original = matplotlib.figure.Figure.savefig
+
+    def fast_savefig(self, fname, *args, **kwargs):
+        kwargs["dpi"] = 10
+        return original(self, fname, *args, **kwargs)
+
+    monkeypatch.setattr(matplotlib.figure.Figure, "savefig", fast_savefig)


### PR DESCRIPTION
Improvements mostly in unit tests of the plotting routines - a lot can be achieved to set DPI to 10...

Was:

```
3.40s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_writes_per_type_comparison_figures
2.43s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_writes_event_level_comparison_figures
2.36s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_debug_plots_generate_expected_files
2.23s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_debug_plots_true
2.17s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_invokes_triggered_fraction_branch_when_enabled
1.56s call     tests/unit_tests/layout/test_array_layout.py::test_build_layout
1.41s call     tests/unit_tests/visualization/test_plot_production_grid.py::test_plot_sky_projection_creates_outputs
1.06s call     tests/unit_tests/data_model/test_metadata_collector.py::test_get_top_level_metadata
0.94s call     tests/unit_tests/visualization/test_plot_production_grid.py::test_normalize_altaz_point_creates_radec_coordinates
0.90s call     tests/unit_tests/utils/test_general.py::test_url_exists
0.89s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_with_model_version
0.81s call     tests/unit_tests/data_model/test_schema.py::test_validate_dict_using_schema_remote
0.62s call     tests/unit_tests/visualization/test_plot_production_grid.py::test_plot_sky_projection_infers_radec_grid_tracks
0.56s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_custom_bin_widths
0.51s call     tests/unit_tests/production_configuration/test_observation_grid.py::test_convert_altaz_to_radec_returns_icrs_coordinates
0.50s call     tests/unit_tests/simtel/test_simtel_output_validator.py::test_assert_model_parameters[metadata0-parameters0-mock_value0-0-None-None]
0.49s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_debug_plots_false
0.48s call     tests/unit_tests/production_configuration/test_observation_grid.py::test_generate_simulation_grid_keeps_horizontal_coordinates_for_radec_axes
0.47s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_dual_mirror
0.46s call     tests/unit_tests/simtel/test_simtel_config_writer.py::test_get_parameters_for_sim_telarray_maps_flasher_photons_from_calibration_model
```

is now:

```
1.95s call     tests/unit_tests/layout/test_array_layout.py::test_build_layout
1.06s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_writes_per_type_comparison_figures
0.81s call     tests/unit_tests/visualization/test_plot_production_grid.py::test_plot_sky_projection_creates_outputs
0.80s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_debug_plots_generate_expected_files
0.80s call     tests/unit_tests/visualization/test_plot_incident_angles.py::test_plot_incident_angles_debug_plots_true
0.71s call     tests/unit_tests/production_configuration/test_observation_grid.py::test_generate_simulation_grid_keeps_horizontal_coordinates_for_radec_axes
0.70s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_writes_event_level_comparison_figures
0.62s call     tests/unit_tests/production_configuration/test_observation_grid.py::test_convert_altaz_to_radec_returns_icrs_coordinates
0.57s call     tests/unit_tests/simtel/test_simtel_output_validator.py::test_assert_model_parameters[metadata0-parameters0-mock_value0-0-None-None]
0.57s call     tests/unit_tests/model/test_model_repository.py::test_update_parameters_dict_new_function
0.57s call     tests/unit_tests/visualization/test_plot_event_level_production_comparison.py::test_plot_invokes_triggered_fraction_branch_when_enabled
0.56s call     tests/unit_tests/simtel/test_simtel_config_writer.py::test_get_parameters_for_sim_telarray_maps_flasher_photons_from_calibration_model
0.55s call     tests/unit_tests/data_model/test_data_reader.py::test_read_table_from_file_and_validate
0.54s call     tests/unit_tests/data_model/test_schema.py::test_get_model_parameter_schema_files
0.54s call     tests/unit_tests/model/test_model_parameter.py::test_overwrite_parameters_flat_dict_forwards_to_parameter_store
0.53s call     tests/unit_tests/camera/test_camera_efficiency.py::test_simulate
0.52s call     tests/unit_tests/reporting/test_docs_read_parameters.py::test_get_all_parameter_descriptions
0.38s call     tests/unit_tests/layout/test_array_layout_utils.py::test_write_array_elements_from_file_to_repository_utm
0.37s call     tests/unit_tests/data_model/test_metadata_collector.py::test_read_input_metadata_from_file
0.36s call     tests/unit_tests/layout/test_telescope_position.py::test_convert
```