### PR TITLE
Bugfix in overwrite model parameters for configuration-sim_telarray collection

### DIFF
--- a/docs/changes/2228.bugfix.md
+++ b/docs/changes/2228.bugfix.md
@@ -1,0 +1,1 @@
+Fix bug in overwrite-model parameter mechanism for configuration_sim_telarray parameters: parameters where set for all telescopes, and not for the specified ones.

--- a/docs/changes/2228.bugfix.md
+++ b/docs/changes/2228.bugfix.md
@@ -1,1 +1,1 @@
-Fix bug in overwrite-model parameter mechanism for configuration_sim_telarray parameters: parameters where set for all telescopes, and not for the specified ones.
+Fix bug in overwrite-model parameter mechanism for configuration_sim_telarray parameters: parameters were set for all telescopes, rather than only for the specified ones.

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -336,7 +336,9 @@ class ModelParameter:
         for key, parameter_changes in self.overwrite_model_parameter_dict.items():
             if not isinstance(parameter_changes, dict):
                 continue
-            if software_collection == "configuration_sim_telarray" and key != self.name:
+            if software_collection == "configuration_sim_telarray" and not (
+                names.matches_array_element_name_or_design_type(key, self.name)
+            ):
                 continue
 
             filtered_parameter_changes = self._filter_changes_for_collection(

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -336,6 +336,8 @@ class ModelParameter:
         for key, parameter_changes in self.overwrite_model_parameter_dict.items():
             if not isinstance(parameter_changes, dict):
                 continue
+            if software_collection == "configuration_sim_telarray" and key != self.name:
+                continue
 
             filtered_parameter_changes = self._filter_changes_for_collection(
                 parameter_changes,

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -152,6 +152,41 @@ def is_design_type(array_element_name):
     )
 
 
+def matches_array_element_name_or_design_type(key_name, array_element_name):
+    """
+    Return True when key_name matches array_element_name exactly or as same-type design.
+
+    Parameters
+    ----------
+    key_name: str
+        Name to check (e.g., "MSTN-01" or "MSTx-FlashCam").
+    array_element_name: str
+        Array element name to compare to (e.g., "MSTN-01" or "MSTN-FlashCam").
+
+    Returns
+    -------
+    bool
+        True if key_name matches array_element_name exactly or as same-type design.
+
+    """
+    if key_name is None or array_element_name is None:
+        return False
+
+    try:
+        validated_key_name = validate_array_element_name(key_name)
+        validated_array_element_name = validate_array_element_name(array_element_name)
+    except ValueError:
+        return False
+
+    if validated_key_name == validated_array_element_name:
+        return True
+
+    return is_design_type(validated_key_name) and (
+        get_array_element_type_from_name(validated_key_name)
+        == get_array_element_type_from_name(validated_array_element_name)
+    )
+
+
 @cache
 def _load_model_parameters():
     """

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -152,38 +152,37 @@ def is_design_type(array_element_name):
     )
 
 
-def matches_array_element_name_or_design_type(key_name, array_element_name):
+def matches_array_element_name_or_design_type(element_name, reference_element_name):
     """
-    Return True when key_name matches array_element_name exactly or as same-type design.
+    Check whether an array element name matches a reference exactly or by design type equivalence.
 
     Parameters
     ----------
-    key_name: str
-        Name to check (e.g., "MSTN-01" or "MSTx-FlashCam").
-    array_element_name: str
-        Array element name to compare to (e.g., "MSTN-01" or "MSTN-FlashCam").
+    element_name: str
+        Candidate element name to validate and compare (e.g., "MSTN-01" or "MSTx-FlashCam").
+    reference_element_name: str
+        Reference array element name used for comparison (e.g., "MSTN-01" or "MSTN-FlashCam").
 
     Returns
     -------
     bool
-        True if key_name matches array_element_name exactly or as same-type design.
-
+        True if both names are identical, or if they belong to the same design type.
     """
-    if key_name is None or array_element_name is None:
+    if element_name is None or reference_element_name is None:
         return False
 
     try:
-        validated_key_name = validate_array_element_name(key_name)
-        validated_array_element_name = validate_array_element_name(array_element_name)
+        validated_element_name = validate_array_element_name(element_name)
+        validated_reference_element_name = validate_array_element_name(reference_element_name)
     except ValueError:
         return False
 
-    if validated_key_name == validated_array_element_name:
+    if validated_element_name == validated_reference_element_name:
         return True
 
-    return is_design_type(validated_key_name) and (
-        get_array_element_type_from_name(validated_key_name)
-        == get_array_element_type_from_name(validated_array_element_name)
+    return is_design_type(validated_element_name) and (
+        get_array_element_type_from_name(validated_element_name)
+        == get_array_element_type_from_name(validated_reference_element_name)
     )
 
 

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -171,6 +171,40 @@ def test_load_simulation_software_parameter(telescope_model_lst, caplog):
     assert len(caplog.records) == 0
 
 
+def _realistic_simulation_overwrites_with_bad_entry(bad_entry_value):
+    """Build realistic simulation overwrite changes used by overwrite-collection tests."""
+    return {
+        "LSTS-design": {
+            "effective_focal_length": {
+                "value": [2923.7, 0.0, 0.0, 0.0, 0.0],
+            },
+        },
+        "MSTS-05": {
+            "effective_focal_length": {
+                "value": [1644.51, 0.0, 0.0, 0.0, 0.0],
+            },
+        },
+        "SSTS-design": {
+            "effective_focal_length": {
+                "value": [315.191, 0.0, 0.0, 0.0, 0.0],
+            },
+        },
+        "SSTS-22": {
+            "effective_focal_length": {
+                "value": [215.191, 0.0, 0.0, 0.0, 0.0],
+            },
+        },
+        "bad_entry": bad_entry_value,
+        "LSTS-01": {
+            "effective_focal_length": {
+                "value": [2923.7, 0.0, 0.0, 2.0, 0.0],
+            },
+            "min_photoelectrons": {"value": 20},
+            "unknown_parameter": {"value": 1},
+        },
+    }
+
+
 @pytest.mark.parametrize(
     (
         "overwrite_model_parameter_dict",
@@ -188,72 +222,14 @@ def test_load_simulation_software_parameter(telescope_model_lst, caplog):
             None,
         ),
         (
-            {
-                "LSTS-design": {
-                    "effective_focal_length": {
-                        "value": [2923.7, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "MSTS-05": {
-                    "effective_focal_length": {
-                        "value": [1644.51, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "SSTS-design": {
-                    "effective_focal_length": {
-                        "value": [315.191, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "SSTS-22": {
-                    "effective_focal_length": {
-                        "value": [215.191, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "bad_entry": "not a dict",
-                "LSTS-01": {
-                    "effective_focal_length": {
-                        "value": [2923.7, 0.0, 0.0, 2.0, 0.0],
-                    },
-                    "min_photoelectrons": {"value": 20},
-                    "unknown_parameter": {"value": 1},
-                },
-            },
+            _realistic_simulation_overwrites_with_bad_entry("not a dict"),
             "corsika",
             "configuration_corsika",
             {"effective_focal_length": {"value": [2923.7, 0.0, 0.0, 2.0, 0.0]}},
             None,
         ),
         (
-            {
-                "LSTS-design": {
-                    "effective_focal_length": {
-                        "value": [2923.7, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "MSTS-05": {
-                    "effective_focal_length": {
-                        "value": [1644.51, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "SSTS-design": {
-                    "effective_focal_length": {
-                        "value": [315.191, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "SSTS-22": {
-                    "effective_focal_length": {
-                        "value": [215.191, 0.0, 0.0, 0.0, 0.0],
-                    },
-                },
-                "bad_entry": [1, 2, 3],
-                "LSTS-01": {
-                    "effective_focal_length": {
-                        "value": [2923.7, 0.0, 0.0, 2.0, 0.0],
-                    },
-                    "min_photoelectrons": {"value": 20},
-                    "unknown_parameter": {"value": 1},
-                },
-            },
+            _realistic_simulation_overwrites_with_bad_entry([1, 2, 3]),
             "sim_telarray",
             "configuration_sim_telarray",
             {"min_photoelectrons": {"value": 20}},

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -235,6 +235,17 @@ def _realistic_simulation_overwrites_with_bad_entry(bad_entry_value):
             {"min_photoelectrons": {"value": 20}},
             "LSTS-01",
         ),
+        (
+            {
+                "LSTS-design": {
+                    "min_photoelectrons": {"value": 17},
+                },
+            },
+            "sim_telarray",
+            "configuration_sim_telarray",
+            {"min_photoelectrons": {"value": 17}},
+            "LSTS-01",
+        ),
     ],
 )
 def test_collect_flat_simulation_overwrites(
@@ -284,9 +295,10 @@ def test_collect_flat_simulation_overwrites(
             for v in overwrite_model_parameter_dict.values()
         )
     else:
-        expect_unknown_warning = isinstance(
-            overwrite_model_parameter_dict.get(telescope_copy.name), dict
-        ) and "unknown_parameter" in overwrite_model_parameter_dict[telescope_copy.name]
+        expect_unknown_warning = (
+            isinstance(overwrite_model_parameter_dict.get(telescope_copy.name), dict)
+            and "unknown_parameter" in overwrite_model_parameter_dict[telescope_copy.name]
+        )
 
     if expect_unknown_warning:
         assert "Skipping unknown overwrite parameter 'unknown_parameter'" in caplog.text

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -277,7 +277,18 @@ def test_collect_flat_simulation_overwrites(
         )
 
     assert result == expected
-    if "unknown_parameter" in str(overwrite_model_parameter_dict):
+
+    if software_collection != "configuration_sim_telarray":
+        expect_unknown_warning = any(
+            isinstance(v, dict) and "unknown_parameter" in v
+            for v in overwrite_model_parameter_dict.values()
+        )
+    else:
+        expect_unknown_warning = isinstance(
+            overwrite_model_parameter_dict.get(telescope_copy.name), dict
+        ) and "unknown_parameter" in overwrite_model_parameter_dict[telescope_copy.name]
+
+    if expect_unknown_warning:
         assert "Skipping unknown overwrite parameter 'unknown_parameter'" in caplog.text
     else:
         assert caplog.text == ""

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -171,6 +171,142 @@ def test_load_simulation_software_parameter(telescope_model_lst, caplog):
     assert len(caplog.records) == 0
 
 
+@pytest.mark.parametrize(
+    (
+        "overwrite_model_parameter_dict",
+        "simulation_software",
+        "software_collection",
+        "expected",
+        "name_override",
+    ),
+    [
+        (
+            {},
+            "corsika",
+            "configuration_corsika",
+            {},
+            None,
+        ),
+        (
+            {
+                "LSTS-design": {
+                    "effective_focal_length": {
+                        "value": [2923.7, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "MSTS-05": {
+                    "effective_focal_length": {
+                        "value": [1644.51, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "SSTS-design": {
+                    "effective_focal_length": {
+                        "value": [315.191, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "SSTS-22": {
+                    "effective_focal_length": {
+                        "value": [215.191, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "bad_entry": "not a dict",
+                "LSTS-01": {
+                    "effective_focal_length": {
+                        "value": [2923.7, 0.0, 0.0, 2.0, 0.0],
+                    },
+                    "min_photoelectrons": {"value": 20},
+                    "unknown_parameter": {"value": 1},
+                },
+            },
+            "corsika",
+            "configuration_corsika",
+            {"effective_focal_length": {"value": [2923.7, 0.0, 0.0, 2.0, 0.0]}},
+            None,
+        ),
+        (
+            {
+                "LSTS-design": {
+                    "effective_focal_length": {
+                        "value": [2923.7, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "MSTS-05": {
+                    "effective_focal_length": {
+                        "value": [1644.51, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "SSTS-design": {
+                    "effective_focal_length": {
+                        "value": [315.191, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "SSTS-22": {
+                    "effective_focal_length": {
+                        "value": [215.191, 0.0, 0.0, 0.0, 0.0],
+                    },
+                },
+                "bad_entry": [1, 2, 3],
+                "LSTS-01": {
+                    "effective_focal_length": {
+                        "value": [2923.7, 0.0, 0.0, 2.0, 0.0],
+                    },
+                    "min_photoelectrons": {"value": 20},
+                    "unknown_parameter": {"value": 1},
+                },
+            },
+            "sim_telarray",
+            "configuration_sim_telarray",
+            {"min_photoelectrons": {"value": 20}},
+            "LSTS-01",
+        ),
+    ],
+)
+def test_collect_flat_simulation_overwrites(
+    telescope_model_lst,
+    mocker,
+    caplog,
+    overwrite_model_parameter_dict,
+    simulation_software,
+    software_collection,
+    expected,
+    name_override,
+):
+    """Test _collect_flat_simulation_overwrites across filtering and flattening edge cases."""
+    telescope_copy = copy.deepcopy(telescope_model_lst)
+    if name_override is not None:
+        telescope_copy.name = name_override
+    telescope_copy.overwrite_model_parameter_dict = overwrite_model_parameter_dict
+
+    collection_map = {
+        "effective_focal_length": "configuration_corsika",
+        "min_photoelectrons": "configuration_sim_telarray",
+        "unknown_parameter": KeyError,
+    }
+
+    def _get_collection_name(parameter_name):
+        collection = collection_map[parameter_name]
+        if collection is KeyError:
+            raise KeyError(parameter_name)
+        return collection
+
+    mocker.patch(
+        "simtools.model.model_parameter.names.get_collection_name_from_parameter_name",
+        side_effect=_get_collection_name,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        result = telescope_copy._collect_flat_simulation_overwrites(
+            simulation_software,
+            software_collection,
+        )
+
+    assert result == expected
+    if "unknown_parameter" in str(overwrite_model_parameter_dict):
+        assert "Skipping unknown overwrite parameter 'unknown_parameter'" in caplog.text
+    else:
+        assert caplog.text == ""
+
+
 def test_overwrite_model_parameter(telescope_model_lst):
     tel_model = copy.deepcopy(telescope_model_lst)
 

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -604,6 +604,21 @@ def test_is_design_type():
     assert not names.is_design_type("MSTS-22")
 
 
+@pytest.mark.parametrize(
+    ("key_name", "array_element_name", "expected"),
+    [
+        ("LSTN-01", "LSTN-01", True),
+        ("LSTN-design", "LSTN-01", True),
+        ("MSTS-FlashCam", "MSTS-22", True),
+        ("MSTS-design", "LSTN-01", False),
+        ("LSTN-02", "LSTN-01", False),
+        ("not-a-name", "LSTN-01", False),
+    ],
+)
+def test_matches_array_element_name_or_design_type(key_name, array_element_name, expected):
+    assert names.matches_array_element_name_or_design_type(key_name, array_element_name) is expected
+
+
 def test_array_element_common_identifiers():
     id_to_name, name_to_id = names.array_element_common_identifiers()
     assert isinstance(id_to_name, dict)


### PR DESCRIPTION
Annoying one. An overwrite model parameter dict like

```
changes:
  # changed parameter for LSTs-01
  LSTS-01:
    effective_focal_length:
      version: '3.0.0'
      value: [2923.7, 0., 0., 2, 0.]
    min_photoelectrons:
      version: '2.0.0'
      value: 20
```

was overwriting `min_photoelectrons` for all telescopes. 