### PR TITLE
Add units to the columns of the illuminator visibility 

### DIFF
--- a/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
+++ b/src/simtools/schemas/model_parameters/illuminator_telescope_visibility.schema.yml
@@ -26,6 +26,7 @@ data:
       additionalProperties: false
       required:
         - columns
+        - column_units
         - rows
       properties:
         columns:
@@ -34,6 +35,15 @@ data:
             - const: illuminator_id
             - const: telescope_id
             - const: visible
+          additionalItems: false
+          minItems: 3
+          maxItems: 3
+        column_units:
+          type: array
+          items:
+            - const: dimensionless
+            - const: dimensionless
+            - const: dimensionless
           additionalItems: false
           minItems: 3
           maxItems: 3


### PR DESCRIPTION
This is needed to get the new table passing the schema (see [136 MR](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/136))