### PR TITLE
Fix `instrument` field in model parameter schema and restrict it to allowed names defined in `common_definitions.schema.yml`.

### DIFF
--- a/docs/changes/2232.bugfix.md
+++ b/docs/changes/2232.bugfix.md
@@ -1,0 +1,1 @@
+Fix `instrument` field in model parameter schema and restrict it to allowed names defined in `common_definitions.schema.yml`.

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -26,9 +26,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type:
-          - string
-          - "null"
+        anyOf:
+          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+          - type: "null"
         description: "Associated instrument."
       meta_parameter:
         type: boolean
@@ -143,9 +143,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type:
-          - string
-          - "null"
+        anyOf:
+          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+          - type: "null"
         description: "Associated instrument."
       site:
         type:
@@ -235,7 +235,7 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type: string
+        $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
         description: "Associated instrument."
       items:
         type: string

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -26,9 +26,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        anyOf:
-          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
-          - type: "null"
+        type:
+          - string
+          - "null"
         description: "Associated instrument."
       meta_parameter:
         type: boolean
@@ -235,7 +235,7 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+        type: string
         description: "Associated instrument."
       items:
         type: string


### PR DESCRIPTION
(that was clearly missed before...)