### PR TITLE
Restrict instrument command line parameters.

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Download built docs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docs-html
           path: docs/build/html

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -116,7 +116,7 @@ jobs:
             --cov=simtools --cov-report=xml --retries 2 --retry-delay 5
 
       # CTAO-DPPS-SonarQube
-      - uses: SonarSource/sonarqube-scan-action@v8.0.0
+      - uses: SonarSource/sonarqube-scan-action@v8.1.0
         if: contains(matrix.extra-args, 'sonarqube')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/changes/2232.bugfix.md
+++ b/docs/changes/2232.bugfix.md
@@ -1,0 +1,1 @@
+Fix `instrument` field in model parameter schema and restrict it to allowed names defined in `common_definitions.schema.yml`.

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -45,7 +45,6 @@ from pathlib import Path
 import simtools.data_model.model_data_writer as writer
 from simtools.application_control import build_application
 from simtools.simtel import simtel_table_reader
-from simtools.utils import names
 
 
 def _add_arguments(parser):
@@ -53,7 +52,9 @@ def _add_arguments(parser):
     parser.add_argument(
         "--parameter", type=str, required=True, help="Parameter for simulation model"
     )
-    parser.add_argument("--instrument", type=str, required=True, help="Instrument name")
+    parser.add_argument(
+        "--instrument", type=parser.instrument, required=True, help="Instrument name"
+    )
     parser.add_argument("--site", type=str, required=True, help="Site location")
     parser.add_argument("--parameter_version", type=str, required=True, help="Parameter version")
     parser.add_argument(
@@ -91,9 +92,6 @@ def main():
     app_context = build_application(
         initialization_kwargs={"output": True, "db_config": True},
     )
-    # Validate instrument name (reject plain site names like "North" or "South")
-    names.validate_instrument_name(app_context.args["instrument"])
-
     model_parameter_schema_version = app_context.args.get("model_parameter_schema_version")
     value = app_context.args["value"]
     data_writer = writer.ModelDataWriter()

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -45,6 +45,7 @@ from pathlib import Path
 import simtools.data_model.model_data_writer as writer
 from simtools.application_control import build_application
 from simtools.simtel import simtel_table_reader
+from simtools.utils import names
 
 
 def _add_arguments(parser):
@@ -90,6 +91,9 @@ def main():
     app_context = build_application(
         initialization_kwargs={"output": True, "db_config": True},
     )
+    # Validate instrument name (reject plain site names like "North" or "South")
+    names.validate_instrument_name(app_context.args["instrument"])
+
     model_parameter_schema_version = app_context.args.get("model_parameter_schema_version")
     value = app_context.args["value"]
     data_writer = writer.ModelDataWriter()

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -592,6 +592,25 @@ class CommandLineParser(argparse.ArgumentParser):
         return values if len(values) > 1 else values[0]
 
     @staticmethod
+    def instrument(value):
+        """
+        Argument parser type to check that a valid instrument name is given.
+
+        Parameters
+        ----------
+        value: str
+            Instrument name. Plain site names are not valid; use OBS-North/OBS-South
+            for site parameters.
+
+        Returns
+        -------
+        str
+            Validated instrument name.
+        """
+        names.validate_array_element_name(str(value))
+        return str(value)
+
+    @staticmethod
     def efficiency_interval(value):
         """
         Argument parser type to check that value is an efficiency in the interval [0,1].

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -26,9 +26,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type:
-          - string
-          - "null"
+        anyOf:
+          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+          - type: "null"
         description: "Associated instrument."
       meta_parameter:
         type: boolean
@@ -143,9 +143,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type:
-          - string
-          - "null"
+        anyOf:
+          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+          - type: "null"
         description: "Associated instrument."
       site:
         type:
@@ -235,7 +235,7 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type: string
+        $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
         description: "Associated instrument."
       items:
         type: string

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -26,9 +26,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        anyOf:
-          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
-          - type: "null"
+        type:
+          - string
+          - "null"
         description: "Associated instrument."
       meta_parameter:
         type: boolean
@@ -235,7 +235,7 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+        type: string
         description: "Associated instrument."
       items:
         type: string

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -26,9 +26,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type:
-          - string
-          - "null"
+        anyOf:
+          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+          - type: "null"
         description: "Associated instrument."
       meta_parameter:
         type: boolean
@@ -143,9 +143,9 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        anyOf:
-          - $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
-          - type: "null"
+        type:
+          - string
+          - "null"
         description: "Associated instrument."
       site:
         type:

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -436,6 +436,8 @@ def get_array_element_type_from_name(array_element_name):
     try:  # e.g. instrument is 'North' as given for the site parameters
         return validate_site_name(array_element_name)
     except ValueError:  # any other telescope or calibration device
+        if array_element_name.startswith("OBS"):
+            return validate_site_name(array_element_name.split("-")[1])
         return _validate_name(array_element_name.split("-")[0], array_elements())
 
 
@@ -936,3 +938,55 @@ def file_name_with_version(file_name, suffix):
     if re.search(r"\d{1,8}\.\d{1,8}\.\d{1,8}\Z", file_name):
         return Path(file_name + suffix)
     return Path(file_name).with_suffix(suffix)
+
+
+def validate_instrument_name(instrument_name):
+    """
+    Validate instrument name for use in model parameter submission.
+
+    Rejects plain site names (e.g., "North", "South") and requires either:
+    - Full observatory names (e.g., "OBS-North", "OBS-South")
+    - Valid array element names (e.g., "LSTN-01", "MSTN-design")
+
+    Parameters
+    ----------
+    instrument_name: str
+        Instrument name to validate.
+
+    Returns
+    -------
+    str
+        Validated instrument name.
+
+    Raises
+    ------
+    ValueError
+        If the instrument name is invalid (e.g., a plain site name).
+    """
+    if not instrument_name:
+        raise ValueError("Instrument name cannot be empty")
+
+    # Check if it's just a plain site name
+    try:
+        # If it's a valid site name and doesn't contain "-", it's invalid as an instrument
+        if validate_site_name(instrument_name) and "-" not in instrument_name:
+            raise ValueError(
+                f"Invalid instrument name '{instrument_name}'. "
+                "Use 'OBS-North', 'OBS-South', or a valid array element name "
+                "(e.g., 'LSTN-01', 'MSTN-design')."
+            )
+    except ValueError:
+        # If it's not a valid site name, continue with other checks
+        pass
+
+    # Validate it's a proper array element name or OBS name
+    try:
+        validate_array_element_name(instrument_name)
+    except ValueError as exc:
+        raise ValueError(
+            f"Invalid instrument name '{instrument_name}'. "
+            "Use 'OBS-North', 'OBS-South', or a valid array element name "
+            "(e.g., 'LSTN-01', 'MSTN-design')."
+        ) from exc
+
+    return instrument_name

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -436,8 +436,8 @@ def get_array_element_type_from_name(array_element_name):
     try:  # e.g. instrument is 'North' as given for the site parameters
         return validate_site_name(array_element_name)
     except ValueError:  # any other telescope or calibration device
-        if array_element_name.startswith("OBS"):
-            return validate_site_name(array_element_name.split("-")[1])
+        if array_element_name.startswith("OBS-"):
+            return validate_site_name(array_element_name.split("-", maxsplit=1)[1])
         return _validate_name(array_element_name.split("-")[0], array_elements())
 
 
@@ -938,55 +938,3 @@ def file_name_with_version(file_name, suffix):
     if re.search(r"\d{1,8}\.\d{1,8}\.\d{1,8}\Z", file_name):
         return Path(file_name + suffix)
     return Path(file_name).with_suffix(suffix)
-
-
-def validate_instrument_name(instrument_name):
-    """
-    Validate instrument name for use in model parameter submission.
-
-    Rejects plain site names (e.g., "North", "South") and requires either:
-    - Full observatory names (e.g., "OBS-North", "OBS-South")
-    - Valid array element names (e.g., "LSTN-01", "MSTN-design")
-
-    Parameters
-    ----------
-    instrument_name: str
-        Instrument name to validate.
-
-    Returns
-    -------
-    str
-        Validated instrument name.
-
-    Raises
-    ------
-    ValueError
-        If the instrument name is invalid (e.g., a plain site name).
-    """
-    if not instrument_name:
-        raise ValueError("Instrument name cannot be empty")
-
-    # Check if it's just a plain site name
-    try:
-        # If it's a valid site name and doesn't contain "-", it's invalid as an instrument
-        if validate_site_name(instrument_name) and "-" not in instrument_name:
-            raise ValueError(
-                f"Invalid instrument name '{instrument_name}'. "
-                "Use 'OBS-North', 'OBS-South', or a valid array element name "
-                "(e.g., 'LSTN-01', 'MSTN-design')."
-            )
-    except ValueError:
-        # If it's not a valid site name, continue with other checks
-        pass
-
-    # Validate it's a proper array element name or OBS name
-    try:
-        validate_array_element_name(instrument_name)
-    except ValueError as exc:
-        raise ValueError(
-            f"Invalid instrument name '{instrument_name}'. "
-            "Use 'OBS-North', 'OBS-South', or a valid array element name "
-            "(e.g., 'LSTN-01', 'MSTN-design')."
-        ) from exc
-
-    return instrument_name

--- a/tests/integration_tests/config/submit_model_parameter_from_external_submit_reference_point_altitude.yml
+++ b/tests/integration_tests/config/submit_model_parameter_from_external_submit_reference_point_altitude.yml
@@ -3,7 +3,7 @@ applications:
 - application: simtools-submit-model-parameter-from-external
   configuration:
     input_meta: null
-    instrument: North
+    instrument: OBS-North
     output_path: simtools-output
     parameter: reference_point_altitude
     parameter_version: 0.1.0

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -96,6 +96,23 @@ def test_telescope():
         parser.CommandLineParser.telescope("LST")
 
 
+def test_instrument():
+    assert parser.CommandLineParser.instrument("OBS-North") == "OBS-North"
+    assert parser.CommandLineParser.instrument("OBS-South") == "OBS-South"
+    assert parser.CommandLineParser.instrument("LSTN-01") == "LSTN-01"
+    assert parser.CommandLineParser.instrument("LSTN-design") == "LSTN-design"
+    assert parser.CommandLineParser.instrument("MSTS-FlashCam") == "MSTS-FlashCam"
+
+    with pytest.raises(ValueError, match=r"Invalid name North"):
+        parser.CommandLineParser.instrument("North")
+
+    with pytest.raises(ValueError, match=r"Invalid name South"):
+        parser.CommandLineParser.instrument("South")
+
+    with pytest.raises(ValueError, match=r"Invalid name InvalidName"):
+        parser.CommandLineParser.instrument("InvalidName")
+
+
 def test_efficiency_interval():
     assert parser.CommandLineParser.efficiency_interval(0.5) == pytest.approx(0.5)
     assert parser.CommandLineParser.efficiency_interval(0.0) == pytest.approx(0.0)

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -241,6 +241,8 @@ def test_get_array_element_type_from_name(invalid_name):
     assert names.get_array_element_type_from_name("SCTS-27") == "SCTS"
     assert names.get_array_element_type_from_name("MAGIC-2") == "MAGIC"
     assert names.get_array_element_type_from_name("VERITAS-4") == "VERITAS"
+    assert names.get_array_element_type_from_name("OBS-North") == "North"
+    assert names.get_array_element_type_from_name("OBS-South") == "South"
     for _name in ["", "01", "Not_a_telescope", "LST", "MST"]:
         with pytest.raises(ValueError, match=rf"^{invalid_name}"):
             names.get_array_element_type_from_name(_name)
@@ -684,3 +686,30 @@ def test_normalize_array_element_identifier_container():
 
     with pytest.raises(ValueError, match="Invalid JSON list string"):
         names.normalize_array_element_identifier_container("[1, 12")
+
+
+def test_validate_instrument_name():
+    """Test validation of instrument names for model parameter submission."""
+    # Valid OBS names
+    assert names.validate_instrument_name("OBS-North") == "OBS-North"
+    assert names.validate_instrument_name("OBS-South") == "OBS-South"
+
+    # Valid array element names
+    assert names.validate_instrument_name("LSTN-01") == "LSTN-01"
+    assert names.validate_instrument_name("LSTN-design") == "LSTN-design"
+    assert names.validate_instrument_name("MSTN-02") == "MSTN-02"
+    assert names.validate_instrument_name("MSTS-FlashCam") == "MSTS-FlashCam"
+
+    # Invalid: plain site names should be rejected
+    with pytest.raises(ValueError, match="Invalid instrument name 'North'"):
+        names.validate_instrument_name("North")
+
+    with pytest.raises(ValueError, match="Invalid instrument name 'South'"):
+        names.validate_instrument_name("South")
+
+    # Invalid: empty or non-existent names
+    with pytest.raises(ValueError, match="Instrument name cannot be empty"):
+        names.validate_instrument_name("")
+
+    with pytest.raises(ValueError, match="Invalid instrument name"):
+        names.validate_instrument_name("InvalidName")

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -686,30 +686,3 @@ def test_normalize_array_element_identifier_container():
 
     with pytest.raises(ValueError, match="Invalid JSON list string"):
         names.normalize_array_element_identifier_container("[1, 12")
-
-
-def test_validate_instrument_name():
-    """Test validation of instrument names for model parameter submission."""
-    # Valid OBS names
-    assert names.validate_instrument_name("OBS-North") == "OBS-North"
-    assert names.validate_instrument_name("OBS-South") == "OBS-South"
-
-    # Valid array element names
-    assert names.validate_instrument_name("LSTN-01") == "LSTN-01"
-    assert names.validate_instrument_name("LSTN-design") == "LSTN-design"
-    assert names.validate_instrument_name("MSTN-02") == "MSTN-02"
-    assert names.validate_instrument_name("MSTS-FlashCam") == "MSTS-FlashCam"
-
-    # Invalid: plain site names should be rejected
-    with pytest.raises(ValueError, match="Invalid instrument name 'North'"):
-        names.validate_instrument_name("North")
-
-    with pytest.raises(ValueError, match="Invalid instrument name 'South'"):
-        names.validate_instrument_name("South")
-
-    # Invalid: empty or non-existent names
-    with pytest.raises(ValueError, match="Instrument name cannot be empty"):
-        names.validate_instrument_name("")
-
-    with pytest.raises(ValueError, match="Invalid instrument name"):
-        names.validate_instrument_name("InvalidName")


### PR DESCRIPTION
Fix `instrument` field in model parameter schema and restrict it to allowed names defined in `common_definitions.schema.yml`.