### PR TITLE
Fix Docs deploy CI

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -118,7 +118,7 @@ jobs:
           clean: false
 
       - name: Deploy dev docs on workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -98,6 +98,9 @@ jobs:
       contents: write
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
       - name: Download built docs
         uses: actions/download-artifact@v8
         with:
@@ -123,3 +126,4 @@ jobs:
           folder: docs/build/html
           target-folder: .
           clean: false
+          dry-run: true

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -118,7 +118,7 @@ jobs:
           clean: false
 
       - name: Deploy dev docs on workflow_dispatch
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/changes/2238.bugfix.md
+++ b/docs/changes/2238.bugfix.md
@@ -1,0 +1,1 @@
+Fix deployment of documentation (`CI-docs`).


### PR DESCRIPTION
The deployment of docs failed on release, see https://github.com/gammasim/simtools/actions/runs/26873057509 .

The issue was introduced with #2209, but only now with a release we notice it.

Successful run: https://github.com/gammasim/simtools/actions/runs/26873971830/job/79256452225