### PR TITLE
Disable remote DB access for scheduled (nightly) integration tests

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -298,7 +298,8 @@ jobs:
           DB_API_USER="api"
           DB_API_PW="password"
           DB_API_PORT="27017"
-          if [ "${{ github.event_name }}" = "schedule" ]; then
+          # DISABLED: avoid failing test due to network issue when running on schedule.
+          if [ "${{ github.event_name }}" = "schedule" ] && false; then
             DB_SERVER="${{ secrets.DB_SERVER }}"
             DB_API_USER="${{ secrets.DB_API_USER }}"
             DB_API_PW="${{ secrets.DB_API_PW }}"

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -186,7 +186,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Restore cached simulation models repository
-        if: github.event_name != 'schedule'
+        # if: github.event_name != 'schedule'
         id: restore_simulation_models
         uses: actions/cache/restore@v5
         with:
@@ -196,7 +196,7 @@ jobs:
             simulation-models-${{ steps.simulation_model_branch.outputs.branch }}-
 
       - name: Clone simulation models repository
-        if: github.event_name != 'schedule'
+        # if: github.event_name != 'schedule'
         run: |
           CLONE_DIR="simulation-models-clone"
           CACHE_DIR="simulation-models"
@@ -235,14 +235,14 @@ jobs:
 
 
       - name: Save cached simulation models repository
-        if: github.event_name != 'schedule' && steps.restore_simulation_models.outputs.cache-hit != 'true'
+        # if: github.event_name != 'schedule' && steps.restore_simulation_models.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: simulation-models
           key: simulation-models-${{ steps.simulation_model_branch.outputs.branch }}-${{ github.run_id }}
 
       - name: Upload simulation models repository
-        if: github.event_name != 'schedule'
+        # if: github.event_name != 'schedule'
         uses: actions/upload-artifact@v7
         with:
           name: simulation-models-repo
@@ -326,7 +326,7 @@ jobs:
           path: ${{ env.SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH }}/..
 
       - name: Download simulation models repository
-        if: github.event_name != 'schedule'
+        # if: github.event_name != 'schedule'
         uses: actions/download-artifact@v8
         with:
           name: simulation-models-repo
@@ -347,7 +347,7 @@ jobs:
           pip install --no-cache-dir -e '.[tests,dev,doc]'
 
       - name: Upload data to MongoDB
-        if: github.event_name != 'schedule'
+        # if: github.event_name != 'schedule'
         run: |
           simtools-db-upload-model-repository \
             --db_simulation_model ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }} \

--- a/docs/changes/2241.maintenance.md
+++ b/docs/changes/2241.maintenance.md
@@ -1,0 +1,1 @@
+Disable remote-DB runs for nightly integration tests (fail too often with network issues).


### PR DESCRIPTION
The large amount of network failures on the GitHub side makes these tests almost unusable. 

I am not removing the corresponding code, but simply disable it - there is hope that things go back to normal in future.