### PR TITLE
Tag collision

### DIFF
--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -124,9 +124,10 @@ jobs:
             if [[ "${tag_name}" == *-generic ]]; then
               tag_name="${tag_name%-generic}-generic-amd64"
             fi
+            apptainer_tag="${tag_name}-apptainer"
             sif_file="${tag_name}.sif"
             apptainer build "${sif_file}" "docker://${image_tag}" || { echo "Failed to build Apptainer image for ${image_tag}" >&2; exit 1; }
-            apptainer push -U "${sif_file}" "oras://${image_tag%:*}:${tag_name}" || { echo "Failed to push Apptainer image for ${image_tag}" >&2; exit 1; }
+            apptainer push -U "${sif_file}" "oras://${image_tag%:*}:${apptainer_tag}" || { echo "Failed to push Apptainer image for ${image_tag}" >&2; exit 1; }
             rm -f "${sif_file}"
           done <<< "${{ steps.meta.outputs.tags }}"
 

--- a/docs/changes/2250.bugfix.md
+++ b/docs/changes/2250.bugfix.md
@@ -1,0 +1,1 @@
+Fix tag-collision for docker and oras (apptainer) images.


### PR DESCRIPTION
PR #2175 introduced the generation of apptainer images additional to the docker-type containers. Unexpected to me, there is a tag collision and the SIF overwrites the docker style image.

I expected that these are really different paths: "docker://${image_tag}" und "oras://${image_tag}". 

To fix this, add a `apptainer` string to the tag for the apptainer SIF images.

See [here](https://github.com/gammasim/simtools/pkgs/container/simtools-prod/versions) for the different container versions generated.

