### PR TITLE
Bug fix in setting CORSIKA run numbers

### DIFF
--- a/docs/changes/2259.bugfix.md
+++ b/docs/changes/2259.bugfix.md
@@ -1,0 +1,1 @@
+Fix writing of CORSIKA input file: add setting of runnumber (`RUNNR`), `HOST`, `USER`.

--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -632,9 +632,11 @@ class CorsikaConfig:
         list
             Value(s) of the parameter.
         """
-        par_value = []
+        par_value = self.config.get(par_name, [])
+        if isinstance(par_value, dict):
+            par_value = []
         for values in self.config.values():
-            if par_name in values:
+            if isinstance(values, dict) and par_name in values:
                 par_value = values[par_name]
         if len(par_value) == 0:
             raise KeyError(f"Parameter {par_name} is not a CORSIKA config parameter")
@@ -664,6 +666,10 @@ class CorsikaConfig:
             text += line
         return text
 
+    def _get_top_level_run_parameters(self):
+        """Return top-level configuration parameters for the CORSIKA input file."""
+        return {key: values for key, values in self.config.items() if not isinstance(values, dict)}
+
     def generate_corsika_input_file(self, use_multipipe, input_file, output_file):
         """
         Generate a CORSIKA input file.
@@ -682,6 +688,8 @@ class CorsikaConfig:
 
         with open(input_file, "w", encoding="utf-8") as file:
             file.write("\n* [ RUN PARAMETERS ]\n")
+            text_run_parameters = self._get_text_single_line(self._get_top_level_run_parameters())
+            file.write(text_run_parameters)
             text_parameters = self._get_text_single_line(self.config["USER_INPUT"])
             file.write(text_parameters)
 

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -461,12 +461,23 @@ def test_rotate_azimuth_by_180deg(corsika_config_mock_array_model):
 
 def test_get_config_parameter(corsika_config_mock_array_model):
     cc = corsika_config_mock_array_model
+    cc.config["RUNNR"] = [42]
+    assert cc.get_config_parameter("RUNNR") == 42
     assert isinstance(cc.get_config_parameter("NSHOW"), int)
     assert isinstance(cc.get_config_parameter("THETAP"), list)
     with pytest.raises(
         KeyError, match="Parameter not_really_a_parameter is not a CORSIKA config parameter"
     ):
         cc.get_config_parameter("not_really_a_parameter")
+
+
+def test_get_top_level_run_parameters(corsika_config_mock_array_model):
+    corsika_config_mock_array_model.config["RUNNR"] = [42]
+    assert corsika_config_mock_array_model._get_top_level_run_parameters() == {
+        "RUNNR": [42],
+        "USER": [settings.config.user],
+        "HOST": [settings.config.hostname],
+    }
 
 
 def test_get_text_single_line(corsika_config_mock_array_model):
@@ -486,6 +497,7 @@ def test_generate_corsika_input_file(corsika_config_mock_array_model, tmp_path):
     logger.info("test_generate_corsika_input_file")
     input_file = tmp_path / "test_corsika.input"
     output_file = tmp_path / "test_corsika.corsika.zst"
+    corsika_config_mock_array_model.config["RUNNR"] = [42]
     corsika_config_mock_array_model.generate_corsika_input_file(
         use_multipipe=False,
         input_file=input_file,
@@ -493,7 +505,11 @@ def test_generate_corsika_input_file(corsika_config_mock_array_model, tmp_path):
     )
     assert input_file.exists()
     with open(input_file) as f:
-        assert "TELFIL |" not in f.read()
+        input_file_text = f.read()
+        assert "RUNNR 42 " in input_file_text
+        assert f"USER {settings.config.user} " in input_file_text
+        assert f"HOST {settings.config.hostname} " in input_file_text
+        assert "TELFIL |" not in input_file_text
 
 
 def test_generate_corsika_input_file_multipipe(corsika_config_mock_array_model, tmp_path):


### PR DESCRIPTION
`RUNNR` was not set in the CORSIKA input file - probably missed this when switching from corsika_autoinputs to a sole simtools solution.

For manual testing, run:

```
python src/simtools/applications/simulate_prod.py --config tests/integration_tests/config/simulate_prod_gamma_40_deg_south_corsika_only.yml
```

and

```
grep RUN simtools-output/corsika/run000007/gamma_run000007_za40deg_azm180deg_South_beta_6.0.2_test.corsika.input
* [ RUN PARAMETERS ]
RUNNR 7
```