### PR TITLE
Export mirror list to ecsv

### DIFF
--- a/docs/changes/2273.feature.md
+++ b/docs/changes/2273.feature.md
@@ -1,0 +1,1 @@
+Add export functionality for mirror list model parameter file to `ecsv` format.

--- a/src/simtools/simtel/simtel_table_reader.py
+++ b/src/simtools/simtel/simtel_table_reader.py
@@ -660,11 +660,15 @@ def _read_simtel_data_for_mirror_list(file_path):
         data_and_tail = stripped.split("#%", maxsplit=1)
         data_row = _process_line_parts(data_and_tail[0].split())
 
-        if len(data_row) < 6:
+        if len(data_row) < 5:
             logger.debug(f"Skipping malformed mirror_list line: {stripped}")
             continue
 
-        mirror_panel_id = -1
+        # mirror_z is optional in some mirror list files; default to 0.0 cm when missing
+        if len(data_row) == 5:
+            data_row.append(0.0)
+
+        mirror_panel_id = len(rows)
         if len(data_and_tail) > 1:
             id_match = re.search(r"\bid\s*=\s*(-?\d+)\b", data_and_tail[1])
             if id_match:

--- a/src/simtools/simtel/simtel_table_reader.py
+++ b/src/simtools/simtel/simtel_table_reader.py
@@ -253,6 +253,30 @@ def _data_columns_nsb_reference_spectrum():
     return _data_columns_nsb_spectrum()
 
 
+def _data_columns_mirror_list():
+    """Column description for parameter mirror_list."""
+    return (
+        [
+            {"name": "mirror_x", "description": "Mirror x position", "unit": "cm"},
+            {"name": "mirror_y", "description": "Mirror y position", "unit": "cm"},
+            {
+                "name": "mirror_diameter",
+                "description": "Mirror diameter (flat-to-flat)",
+                "unit": "cm",
+            },
+            {"name": "focal_length", "description": "Mirror focal length", "unit": "cm"},
+            {"name": "shape_type", "description": "Mirror shape code", "unit": None},
+            {"name": "mirror_z", "description": "Mirror z position", "unit": "cm"},
+            {
+                "name": "mirror_panel_id",
+                "description": "Mirror number in original list",
+                "unit": None,
+            },
+        ],
+        "Mirror positions and focal lengths",
+    )
+
+
 def read_simtel_table(parameter_name, file_path):
     """
     Read sim_telarray table file for a given parameter.
@@ -279,6 +303,8 @@ def read_simtel_table(parameter_name, file_path):
         return _read_simtel_data_for_atmospheric_transmission(file_path)
     if parameter_name == "lightguide_efficiency_vs_wavelength":
         return _read_simtel_data_for_lightguide_efficiency(file_path)
+    if parameter_name == "mirror_list":
+        return _read_simtel_data_for_mirror_list(file_path)
 
     rows, meta_from_simtel, n_columns, n_dim = _read_simtel_data(file_path)
     columns_info, description = _data_columns(parameter_name, n_columns, n_dim)
@@ -599,6 +625,68 @@ def _read_simtel_data_for_atmospheric_transmission(file_path):
             "Description": "Atmospheric transmission",
             "context_from_sim_telarray": "\n".join(meta_lines),
             "observatory_level": observatory_level,
+        }
+    )
+
+    return table
+
+
+def _read_simtel_data_for_mirror_list(file_path):
+    """
+    Read mirror list data and return a table.
+
+    Parameters
+    ----------
+    file_path : str or Path
+
+    Returns
+    -------
+    astropy.table.Table
+    """
+    rows = []
+    meta_lines = []
+
+    lines = ascii_handler.read_file_encoded_in_utf_or_latin(file_path)
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if stripped.startswith("#"):
+            meta_lines.append(stripped.lstrip("#").strip())
+            continue
+
+        data_and_tail = stripped.split("#%", maxsplit=1)
+        data_row = _process_line_parts(data_and_tail[0].split())
+
+        if len(data_row) < 6:
+            logger.debug(f"Skipping malformed mirror_list line: {stripped}")
+            continue
+
+        mirror_panel_id = -1
+        if len(data_and_tail) > 1:
+            id_match = re.search(r"\bid\s*=\s*(-?\d+)\b", data_and_tail[1])
+            if id_match:
+                mirror_panel_id = int(id_match.group(1))
+
+        rows.append([*data_row[:6], mirror_panel_id])
+
+    if not rows:
+        raise ValueError("No valid mirror_list entries found in file")
+
+    columns_info, description = _data_columns_mirror_list()
+    table = Table(rows=rows, names=[col["name"] for col in columns_info])
+    for col, info in zip(table.colnames, columns_info):
+        table[col].unit = info.get("unit")
+        table[col].description = info.get("description")
+
+    table.meta.update(
+        {
+            "Name": "mirror_list",
+            "File": str(file_path),
+            "Description": description,
+            "context_from_sim_telarray": "\n".join(meta_lines),
         }
     )
 

--- a/tests/unit_tests/simtel/test_simtel_table_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_table_reader.py
@@ -22,6 +22,11 @@ def spe_meta_test_comment():
     return "Norm_spe processing of single-p.e. response."
 
 
+@pytest.fixture
+def mirror_list_test_file():
+    return "tests/resources/mirror_list_CTA-N-LST1_v2019-03-31_rotated_simtel.dat"
+
+
 def test_read_simtel_data(spe_test_file, spe_meta_test_comment):
     """Test reading of sim_telarray table file into strings."""
 
@@ -100,6 +105,58 @@ def test_read_simtel_table_to_table(spe_test_file, spe_meta_test_comment):
     ) as mock_read:
         simtel_table_reader.read_simtel_table("atmospheric_transmission", "test_file")
         mock_read.assert_called_once()
+
+
+def test_read_simtel_table_for_mirror_list(mirror_list_test_file):
+    """Test reading mirror_list table including mirror panel IDs from '#% id=' data."""
+    table = simtel_table_reader.read_simtel_table("mirror_list", mirror_list_test_file)
+
+    assert len(table) > 0
+    assert table.colnames == [
+        "mirror_x",
+        "mirror_y",
+        "mirror_diameter",
+        "focal_length",
+        "shape_type",
+        "mirror_z",
+        "mirror_panel_id",
+    ]
+    assert str(table["mirror_x"].unit) == "cm"
+    assert str(table["mirror_y"].unit) == "cm"
+    assert str(table["mirror_diameter"].unit) == "cm"
+    assert str(table["focal_length"].unit) == "cm"
+    assert str(table["mirror_z"].unit) == "cm"
+
+    assert table["mirror_x"][0] == pytest.approx(1022.49)
+    assert table["mirror_y"][0] == pytest.approx(-462.00)
+    assert table["mirror_panel_id"][0] == 198
+
+
+def test_read_simtel_table_as_row_data_for_mirror_list(mirror_list_test_file):
+    """Test row-data serialization of mirror_list table."""
+    row_data = simtel_table_reader.read_simtel_table_as_row_data(
+        "mirror_list", mirror_list_test_file
+    )
+
+    assert row_data["columns"] == [
+        "mirror_x",
+        "mirror_y",
+        "mirror_diameter",
+        "focal_length",
+        "shape_type",
+        "mirror_z",
+        "mirror_panel_id",
+    ]
+    assert row_data["column_units"] == [
+        "cm",
+        "cm",
+        "cm",
+        "cm",
+        "dimensionless",
+        "cm",
+        "dimensionless",
+    ]
+    assert row_data["rows"][0][6] == 198
 
 
 def test_read_simtel_table_as_row_data():
@@ -239,6 +296,7 @@ def test_data_simple_columns():
         "lightguide_efficiency_vs_incidence_angle",
         "nsb_spectrum",
         "atmospheric_profile",
+        "mirror_list",
     ]
     for column in columns:
         column_list, description = simtel_table_reader._data_columns(column, 2, None)


### PR DESCRIPTION
Allow to convert mirror list from simtel format to ecsv.

e.g. allow to run `python src/simtools/applications/db_get_parameter_from_db.py` with the configuration

```
export_model_file: true
export_model_file_as_table: true
output_path: ./tmp-test-resources/model_parameters/
parameter: mirror_list
parameter_version: 2.0.0
site: North
telescope: LSTN-01
```