### PR TITLE
Try to improve documentation of offset run number

### DIFF
--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -172,7 +172,12 @@ showers_per_run_scaling (str, optional)
     ``showers_per_run * cos(zenith_angle)`` and rounds up to at least one
     shower. Default is ``fixed``.
 run_number_offset (int, optional)
-    Offset added to generated run numbers. Default is ``0``.
+    Number of already assigned run numbers before this generated grid. The
+    first generated run is ``run_number_offset + 1``. For example, use
+    ``run_number_offset=100`` to continue a production after run 100 and start
+    this grid at run 101. The generated grid stores absolute ``run_number``
+    values; do not apply the same offset again when executing the grid.
+    Default is ``0``.
 
 Energy scaling
 --------------

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -53,6 +53,11 @@ simulation_output (str, optional)
     Base directory for simulation output packages passed through as ``pack_for_grid_register``.
 job_grid_file (str, required)
     Path to the pre-generated executable job grid file.
+run_number_offset (int, optional)
+    Offset passed to ``simtools-simulate-prod`` and added to each grid
+    ``run_number`` at execution time. Keep this at ``0`` for grids generated
+    with ``simtools-production-generate-grid --run_number_offset``, because
+    those grids already contain absolute run numbers.
 priority (int, optional)
     Job priority (default: 1).
 

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -406,7 +406,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 "type": int,
             },
             "run_number_offset": {
-                "help": "An offset for the run number to be simulated.",
+                "help": ("Offset added to run number when executing a simulation."),
                 "type": int,
                 "default": 0,
             },

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -652,9 +652,7 @@ def test_get_dictionary_with_corsika_configuration(mocker):
 
     # Test the "run_number_offset" key
     assert "run_number_offset" in corsika_config
-    assert (
-        "Offset added to the configured run_number" in corsika_config["run_number_offset"]["help"]
-    )
+    assert "Offset added to run number" in corsika_config["run_number_offset"]["help"]
     assert corsika_config["run_number_offset"]["type"] is int
     assert corsika_config["run_number_offset"]["default"] == 0
 

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -653,8 +653,7 @@ def test_get_dictionary_with_corsika_configuration(mocker):
     # Test the "run_number_offset" key
     assert "run_number_offset" in corsika_config
     assert (
-        corsika_config["run_number_offset"]["help"]
-        == "An offset for the run number to be simulated."
+        "Offset added to the configured run_number" in corsika_config["run_number_offset"]["help"]
     )
     assert corsika_config["run_number_offset"]["type"] is int
     assert corsika_config["run_number_offset"]["default"] == 0


### PR DESCRIPTION
I tried to improve the docstrings / help messages.

Note!!

The current `run_number_offset` semantics are not consistent across the production workflow: `Simulator` computes the effective run as `run_number + run_number_offset`, while `production_generate_grid` uses the offset to write absolute grid run numbers starting at `run_number_offset + 1`; if the resulting grid is then executed through the HTCondor generator with the same `run_number_offset`, the offset can be applied a second time. For example, generating a grid with `run_number_offset=100` produces `run_number=101`, but executing that row with `run_number_offset=100` would simulate run 201. We should decide whether offsets belong only at grid-generation time or only at execution time, then document/enforce that contract to prevent double application.