### PR TITLE
Enforce file name limit for sim_telarray configuration files

### DIFF
--- a/docs/changes/2287.feature.md
+++ b/docs/changes/2287.feature.md
@@ -1,1 +1,1 @@
-Enfore file length limits for sim_telarray configuration files.
+Enforce file length limits for sim_telarray configuration files.

--- a/docs/changes/2287.feature.md
+++ b/docs/changes/2287.feature.md
@@ -1,0 +1,1 @@
+Enfore file length limits for sim_telarray configuration files.

--- a/src/simtools/constants.py
+++ b/src/simtools/constants.py
@@ -27,6 +27,7 @@ RESOURCE_PATH = files("simtools") / "resources"
 # Maximum value allowed for random seeds in sim_telarray
 SIMTEL_MAX_SEED = 2147483647
 # Maximum include filename length accepted by sim_telarray parser (80-char getword buffer).
+# The include token is written as "<filename>", so keep the filename itself safely below 80 chars.
 SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH = 77
 # Maximum value allowed for random seeds in CORSIKA
 CORSIKA_MAX_SEED = 900000000

--- a/src/simtools/constants.py
+++ b/src/simtools/constants.py
@@ -26,6 +26,8 @@ RESOURCE_PATH = files("simtools") / "resources"
 
 # Maximum value allowed for random seeds in sim_telarray
 SIMTEL_MAX_SEED = 2147483647
+# Maximum include filename length accepted by sim_telarray parser (80-char getword buffer).
+SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH = 77
 # Maximum value allowed for random seeds in CORSIKA
 CORSIKA_MAX_SEED = 900000000
 

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -11,6 +11,7 @@ import numpy as np
 import simtools.utils.general as gen
 import simtools.version
 from simtools import dependencies, settings
+from simtools.constants import SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH
 from simtools.simtel import simtel_table_writer
 from simtools.utils import names
 
@@ -334,7 +335,9 @@ class SimtelConfigWriter:
             # Default telescope in sim_telarray - 0th tel in telescope list
             _, first_telescope = next(iter(telescope_model.items()))
             invalid_telescope_name = "InvalidTelescope"
-            file.write(f"# include <{invalid_telescope_name}.cfg>\n\n")
+            invalid_telescope_config = f"{invalid_telescope_name}.cfg"
+            self._validate_include_file_name_length(invalid_telescope_config)
+            file.write(f"# include <{invalid_telescope_config}>\n\n")
             self.write_dummy_telescope_configuration_file(
                 deepcopy(first_telescope.parameters),
                 config_file_directory / f"{invalid_telescope_name}.cfg",
@@ -343,10 +346,19 @@ class SimtelConfigWriter:
 
             for count, (tel_name, tel_model) in enumerate(telescope_model.items()):
                 tel_config_file = tel_model.config_file_path.name
+                self._validate_include_file_name_length(tel_config_file)
                 file.write(f"% {tel_name}\n")
                 file.write(f"#elif TELESCOPE == {count + 1}\n\n")
                 file.write(f"# include <{tel_config_file}>\n\n")
             file.write("#endif \n\n")  # configuration files need to end with \n\n
+
+    def _validate_include_file_name_length(self, file_name):
+        """Validate include-file names against the sim_telarray parser word-length limit."""
+        if len(file_name) > SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH:
+            raise ValueError(
+                "sim_telarray include filename exceeds parser limit "
+                f"({len(file_name)}>{SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH}): {file_name}"
+            )
 
     def write_single_mirror_list_file(
         self, mirror_number, mirrors, single_mirror_list_file, set_focal_length_to_zero=False

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -39,6 +39,7 @@ db_collections_to_class_keys = {
     "configuration_corsika": ["configuration_corsika"],
 }
 
+
 @cache
 def array_elements():
     """

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -17,6 +17,7 @@ import logging
 import re
 from functools import cache
 from pathlib import Path
+from uuid import uuid4
 
 import yaml
 
@@ -24,6 +25,7 @@ from simtools.constants import (
     MODEL_PARAMETER_DESCRIPTION_METASCHEMA,
     MODEL_PARAMETER_SCHEMA_PATH,
     RESOURCE_PATH,
+    SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH,
 )
 
 _logger = logging.getLogger(__name__)
@@ -36,7 +38,6 @@ db_collections_to_class_keys = {
     "configuration_sim_telarray": ["configuration_sim_telarray"],
     "configuration_corsika": ["configuration_corsika"],
 }
-
 
 @cache
 def array_elements():
@@ -771,6 +772,23 @@ def simtel_config_file_name(
     name += f"_{label}" if label is not None else ""
     name += f"_{extra_label}" if extra_label is not None else ""
     name += ".cfg"
+
+    # Telescope config files are included by the array config and parsed by sim_telarray
+    # through a fixed-size getword buffer. Keep include targets within that parser limit.
+    if telescope_model_name is not None and len(name) > SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH:
+        token = uuid4().hex[:8]
+        prefix = "CTA"
+        prefix += f"-{array_name}" if array_name is not None else ""
+        prefix += f"-{site}"
+        suffix = f"_{token}.cfg"
+        telescope_component = f"-{telescope_model_name}"
+
+        available_length = SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH - len(prefix) - len(suffix)
+        if available_length < len(telescope_component):
+            telescope_component = telescope_component[: max(0, available_length)]
+
+        name = f"{prefix}{telescope_component}{suffix}"
+
     return name
 
 

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 import simtools.simtel.simtel_table_writer as simtel_table_writer
+from simtools.constants import SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 
 logger = logging.getLogger()
@@ -198,6 +199,31 @@ def test_write_array_config_file(
         lines = f.readlines()
         assert lines[-2].endswith("\n")
         assert lines[-1] == "\n"
+
+
+def test_write_array_config_file_raises_for_too_long_include_filename(
+    simtel_config_writer, io_handler, site_model_north, telescope_model_lst
+):
+    output_file = io_handler.get_output_file(file_name="simtel-config-writer_array-long-name.txt")
+    too_long_name = "a" * 74 + ".cfg"
+    telescope_model = {
+        "LSTN-01": mock.Mock(
+            config_file_path=Path(too_long_name),
+            parameters=telescope_model_lst.parameters,
+        )
+    }
+
+    with pytest.raises(ValueError, match=r"^sim_telarray include filename exceeds parser limit"):
+        simtel_config_writer.write_array_config_file(
+            config_file_path=output_file,
+            telescope_model=telescope_model,
+            site_model=site_model_north,
+        )
+
+
+def test_validate_include_file_name_length_accepts_boundary(simtel_config_writer):
+    max_len = SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH
+    simtel_config_writer._validate_include_file_name_length("a" * (max_len - 4) + ".cfg")
 
 
 def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -205,7 +205,7 @@ def test_write_array_config_file_raises_for_too_long_include_filename(
     simtel_config_writer, io_handler, site_model_north, telescope_model_lst
 ):
     output_file = io_handler.get_output_file(file_name="simtel-config-writer_array-long-name.txt")
-    too_long_name = "a" * 74 + ".cfg"
+    too_long_name = "a" * (SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH - 3) + ".cfg"
     telescope_model = {
         "LSTN-01": mock.Mock(
             config_file_path=Path(too_long_name),

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from simtools.constants import SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH
 from simtools.utils import names
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -388,6 +389,25 @@ def test_simtel_telescope_config_file_name():
         )
         == "CTA-South-LSTS-01_A_B.cfg"
     )
+
+
+def test_simtel_telescope_config_file_name_uses_uuid_suffix_when_too_long():
+    file_name = names.simtel_config_file_name(
+        "South",
+        telescope_model_name="LSTS-01-" + "x" * 120,
+        label="very-long-label-" + "y" * 80,
+        extra_label="extra-long-label-" + "z" * 80,
+    )
+
+    assert len(file_name) <= SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH
+    assert file_name.startswith("CTA-South-")
+    assert file_name.endswith(".cfg")
+    assert "very-long-label" not in file_name
+    assert "extra-long-label" not in file_name
+
+    token = file_name.rsplit("_", 1)[1].removesuffix(".cfg")
+    assert len(token) == 8
+    assert all(character in "0123456789abcdef" for character in token)
 
 
 def test_sim_telarray_config_file_name():


### PR DESCRIPTION
The idea is that if the generated file name (using site, telescope, labels, extra_labels) is too long, the labels + extralabels are replaced by a random string. 

Closes #2278 .