### PR TITLE
Add `--ignore_existing_parameter_version` to skip model-parameter version checks in applications and workflows.

### DIFF
--- a/docs/changes/2292.feature.md
+++ b/docs/changes/2292.feature.md
@@ -1,0 +1,1 @@
+Add `--ignore_existing_parameter_version` to skip model-parameter version checks in applications and workflows.

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -203,6 +203,11 @@ class CommandLineParser(argparse.ArgumentParser):
             help="export build information to file",
             type=str,
         )
+        _job_group.add_argument(
+            "--ignore_existing_parameter_version",
+            action="store_true",
+            help="skip checking for an existing model parameter version in the database",
+        )
 
     def initialize_user_arguments(self):
         """Initialize user arguments."""

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -135,7 +135,9 @@ class ModelDataWriter:
             output_file_format="json",
             output_path=output_path,
         )
-        if check_db_for_existing_parameter:
+        if check_db_for_existing_parameter and not settings.config.args.get(
+            "ignore_existing_parameter_version", False
+        ):
             writer.check_db_for_existing_parameter(parameter_name, instrument, parameter_version)
 
         output_file = writer.io_handler.get_output_file(

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -68,6 +68,8 @@ def run_applications(args_dict):
                     continue
 
                 app_configuration = config.get("configuration", {})
+                if args_dict.get("ignore_existing_parameter_version"):
+                    app_configuration["ignore_existing_parameter_version"] = True
                 app_activity_id = app_configuration.get("activity_id") or gen.get_uuid()
                 app_configuration["activity_id"] = app_activity_id
                 app_configuration.setdefault("label", app)

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -85,6 +85,15 @@ def test_site():
         parser.CommandLineParser.site("East")
 
 
+def test_ignore_existing_parameter_version_argument():
+    commandline_parser = parser.CommandLineParser()
+    commandline_parser.initialize_application_execution_arguments()
+
+    args = commandline_parser.parse_args(["--ignore_existing_parameter_version"])
+
+    assert args.ignore_existing_parameter_version is True
+
+
 def test_telescope():
     assert parser.CommandLineParser.telescope("LSTN-01") == "LSTN-01"
     assert parser.CommandLineParser.telescope("MSTx-NectarCam") == "MSTx-NectarCam"

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -248,6 +248,27 @@ def test_write_model_parameter(tmp_test_directory):
         mock_db_check.assert_called_once_with(num_gains_name, instrument, parameter_version)
 
 
+def test_write_model_parameter_ignores_existing_parameter_version(monkeypatch, tmp_test_directory):
+    parameter_version = "1.1.0"
+    instrument = "LSTN-01"
+    num_gains_name = "num_gains"
+    monkeypatch.setattr(settings.config, "_args", {"ignore_existing_parameter_version": True})
+
+    with patch(
+        "simtools.data_model.model_data_writer.ModelDataWriter.check_db_for_existing_parameter"
+    ) as mock_db_check:
+        writer.ModelDataWriter.write_model_parameter(
+            parameter_name=num_gains_name,
+            value=2,
+            instrument=instrument,
+            parameter_version=parameter_version,
+            output_file=num_gains_name + ".json",
+            output_path=tmp_test_directory,
+        )
+
+    mock_db_check.assert_not_called()
+
+
 def test_write_model_parameter_does_not_write_metadata_on_validation_failure(tmp_test_directory):
     output_file = "num_gains.json"
 

--- a/tests/unit_tests/runners/test_simtools_runner.py
+++ b/tests/unit_tests/runners/test_simtools_runner.py
@@ -362,6 +362,49 @@ def test_run_applications_runs_and_logs(monkeypatch, tmp_test_directory):
     workflow_update_mock.assert_not_called()
 
 
+def test_run_applications_propagates_ignore_existing_parameter_version(
+    monkeypatch, tmp_test_directory
+):
+    mock_args_dict = {
+        "config_file": "dummy_config.yml",
+        "steps": None,
+        "ignore_runtime_environment": False,
+        "ignore_existing_parameter_version": True,
+    }
+    mock_configurations = [
+        {"application": "app1", "run_application": True, "configuration": {"key": "value1"}},
+        {"application": "app2", "run_application": True, "configuration": {"key": "value2"}},
+    ]
+    log_file_path = tmp_test_directory / "simtools.log"
+
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner._read_application_configuration",
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+    )
+    monkeypatch.setattr(
+        "simtools.dependencies.get_version_string",
+        mock.Mock(return_value="simtools version: 1.2.3\n"),
+    )
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner.workflow_metadata.build_workflow_activity_metadata",
+        mock.Mock(return_value={"id": "wf-activity-id"}),
+    )
+    monkeypatch.setattr(
+        "simtools.runners.simtools_runner.workflow_metadata.update_model_parameter_metadata_file",
+        mock.Mock(),
+    )
+    submit_mock = mock.Mock(return_value=mock.Mock(stdout="stdout", stderr="stderr", returncode=0))
+    monkeypatch.setattr("simtools.job_execution.job_manager.submit", submit_mock)
+
+    simtools_runner.run_applications(mock_args_dict)
+
+    submitted_configurations = [call.kwargs["configuration"] for call in submit_mock.call_args_list]
+    assert all(
+        configuration["ignore_existing_parameter_version"] is True
+        for configuration in submitted_configurations
+    )
+
+
 def test_run_applications_copies_collection_files(monkeypatch, tmp_test_directory):
     """Copy collection files from application output_path to collection output_path."""
     tmp_path = Path(str(tmp_test_directory))


### PR DESCRIPTION
The existing parameter version check is in most use cases what we want - as we don't want to derive simulation model parameters and overwrite existing parameter values.

However, in the context of the CI for the simulation model parameter setting, we want to be able to run the setting workflows to ensure that all of the setting workflows are working. In this case, we want to ignore the existing parameter version requirement (all output will be generated temporarily in the CI only). This PR adds such functionality.

see e.g. [here](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-model-parameter-setting/-/jobs/764210) for a gitlab CI which fails due to above points. 