### PR TITLE
Several bug fixed from Copilot code review

### DIFF
--- a/docs/changes/2294.bugfix.md
+++ b/docs/changes/2294.bugfix.md
@@ -1,0 +1,1 @@
+Fix sim_telarray output validation and include paths, stabilize PSF calculations, correct waveform plot time axes, and validate expected event counts of zero.

--- a/src/simtools/camera/trace_analysis.py
+++ b/src/simtools/camera/trace_analysis.py
@@ -126,14 +126,14 @@ def find_signal_peaks(trace, prominence=None):
     return peaks if peaks.size > 0 else np.array([np.argmax(np.abs(trace))])
 
 
-def get_time_axis(sampling_rate, n_samples):
+def get_time_axis(time_slice, n_samples):
     """
-    Generate time axis using sampling frequency logic.
+    Generate a time axis from the sampling period.
 
     Parameters
     ----------
-    sampling_rate : astropy.units.Quantity
-        Sampling rate with time units (e.g., ns).
+    time_slice : astropy.units.Quantity
+        Length of one sampling time slice (e.g., ns).
     n_samples : int
         Number of samples.
 
@@ -142,7 +142,9 @@ def get_time_axis(sampling_rate, n_samples):
     np.ndarray
         Time axis array.
     """
-    dt = 1.0 / sampling_rate.to("ns").value if sampling_rate.to("ns").value > 0 else 1.0
+    dt = time_slice.to("ns").value
+    if dt <= 0:
+        dt = 1.0
     return np.linspace(0, (n_samples - 1) * dt, n_samples)
 
 

--- a/src/simtools/ray_tracing/psf_analysis.py
+++ b/src/simtools/ray_tracing/psf_analysis.py
@@ -387,11 +387,11 @@ class PSFImage:
         """
         self._logger.debug(f"Finding PSF for fraction = {fraction}")
 
-        x_pos_sq = [i**2 for i in self.photon_pos_x]
-        y_pos_sq = [i**2 for i in self.photon_pos_y]
-        x_pos_sig = sqrt(np.mean(x_pos_sq) - self.centroid_x**2)
-        y_pos_sig = sqrt(np.mean(y_pos_sq) - self.centroid_y**2)
+        x_pos_sig = np.std(self.photon_pos_x)
+        y_pos_sig = np.std(self.photon_pos_y)
         radius_sig = sqrt(x_pos_sig**2 + y_pos_sig**2)
+        if radius_sig == 0:
+            return 0.0
 
         target_number = fraction * self._number_of_detected_photons
         current_radius = 1.5 * radius_sig

--- a/src/simtools/ray_tracing/psf_analysis.py
+++ b/src/simtools/ray_tracing/psf_analysis.py
@@ -390,7 +390,7 @@ class PSFImage:
         x_pos_sig = np.std(self.photon_pos_x)
         y_pos_sig = np.std(self.photon_pos_y)
         radius_sig = sqrt(x_pos_sig**2 + y_pos_sig**2)
-        if radius_sig == 0:
+        if np.isclose(radius_sig, 0.0):
             return 0.0
 
         target_number = fraction * self._number_of_detected_photons

--- a/src/simtools/simtel/simtel_output_validator.py
+++ b/src/simtools/simtel/simtel_output_validator.py
@@ -62,7 +62,7 @@ def validate_sim_telarray(
         validate_metadata(data_files, array_models, allow_for_changes)
 
     validate_log_files(log_files, expected_mc_events, expected_shower_events, curved_atmo)
-    if expected_mc_events and expected_shower_events:
+    if expected_mc_events is not None and expected_shower_events is not None:
         validate_event_numbers(data_files, expected_mc_events, expected_shower_events)
 
 

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -268,7 +268,7 @@ class SimulatorArray(SimtelRunner):
             If sim_telarray output file does not exist.
         """
         output_file = self.runner_service.get_file_name(
-            file_type="simtel_output", run_number=run_number
+            file_type="sim_telarray_output", run_number=run_number
         )
         if not output_file.exists():
             raise FileNotFoundError(f"sim_telarray output file {output_file} does not exist.")

--- a/src/simtools/simtel/simulator_light_emission.py
+++ b/src/simtools/simtel/simulator_light_emission.py
@@ -648,7 +648,6 @@ class SimulatorLightEmission(SimtelRunner):
         parts = [
             simtel_bin,
             f"-I{self.telescope_model.config_file_directory}",
-            f"-I{simtel_bin}",
             f"-c {self.telescope_model.config_file_path}",
             "-DNUM_TELESCOPES=1",
         ]

--- a/src/simtools/visualization/plot_simtel_events.py
+++ b/src/simtools/visualization/plot_simtel_events.py
@@ -149,7 +149,7 @@ class PlotSimtelEvent:
         self.time_axis = None
         if len(event_data):
             self.time_axis = trace.get_time_axis(
-                sampling_rate=tel_desc["pixel_settings"]["time_slice"] * u.ns,
+                time_slice=tel_desc["pixel_settings"]["time_slice"] * u.ns,
                 n_samples=n_samples,  # assume all pixels with same number of samples
             )
 

--- a/tests/unit_tests/camera/test_trace_analysis.py
+++ b/tests/unit_tests/camera/test_trace_analysis.py
@@ -189,18 +189,18 @@ def test_find_signal_peaks_empty_trace():
 # get_time_axis tests - parametrized
 # ============================================================================
 @pytest.mark.parametrize(
-    ("sampling_rate_ns", "n_samples", "expected_max"),
+    ("time_slice_ns", "n_samples", "expected_max"),
     [
         (1, 5, 4),
-        (2, 4, 1.5),
+        (2, 4, 6),
         (0, 3, 2),
-        (4, 3, 0.5),
+        (4, 3, 8),
         (1, 1, 0),
     ],
 )
-def test_get_time_axis(sampling_rate_ns, n_samples, expected_max):
-    sampling_rate = sampling_rate_ns * u.ns
-    axis = trace.get_time_axis(sampling_rate, n_samples)
+def test_get_time_axis(time_slice_ns, n_samples, expected_max):
+    time_slice = time_slice_ns * u.ns
+    axis = trace.get_time_axis(time_slice, n_samples)
     expected = np.linspace(0, expected_max, n_samples)
     assert np.allclose(axis, expected)
 

--- a/tests/unit_tests/ray_tracing/test_psf_analysis.py
+++ b/tests/unit_tests/ray_tracing/test_psf_analysis.py
@@ -187,6 +187,17 @@ def test_find_psf(psf_image):
     assert psf > 0
 
 
+def test_find_psf_identical_positions(psf_image):
+    image = psf_image
+    image.photon_pos_x = np.ones(10)
+    image.photon_pos_y = np.ones(10)
+    image.centroid_x = 1.0
+    image.centroid_y = 1.0
+    image._number_of_detected_photons = 10
+
+    assert image._find_psf(fraction=0.8) == 0.0
+
+
 def test_get_effective_area(psf_image, caplog):
     image = psf_image
 

--- a/tests/unit_tests/simtel/test_simtel_output_validator.py
+++ b/tests/unit_tests/simtel/test_simtel_output_validator.py
@@ -652,6 +652,23 @@ def test_validate_sim_telarray(tmp_path, array_models, should_call_metadata):
                 mock_meta.assert_not_called()
 
 
+def test_validate_sim_telarray_checks_zero_expected_events(tmp_path):
+    data_file = tmp_path / "test.simtel.zst"
+    data_file.write_bytes(b"dummy")
+    log_file = tmp_path / "test.log"
+    log_file.write_text("test log")
+
+    with (
+        patch("simtools.simtel.simtel_output_validator.validate_log_files"),
+        patch("simtools.simtel.simtel_output_validator.validate_event_numbers") as mock_events,
+    ):
+        validate_sim_telarray(
+            [data_file], [log_file], expected_mc_events=0, expected_shower_events=0
+        )
+
+    mock_events.assert_called_once_with([data_file], 0, 0)
+
+
 def test_validate_metadata_with_matching_file(tmp_path, caplog):
     """Test validate_metadata logging when file matches."""
     caplog.set_level(logging.INFO)

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -220,6 +220,9 @@ def test_check_run_result_success(simtel_runner, mocker, tmp_path):
 
     result = simtel_runner._check_run_result(run_number=1)
     assert result is True
+    simtel_runner.runner_service.get_file_name.assert_called_once_with(
+        file_type="sim_telarray_output", run_number=1
+    )
 
 
 def test_check_run_result_file_not_exists(simtel_runner, mocker, tmp_path):

--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -44,12 +44,16 @@ def test__make_simtel_script_bypass_optics_condition(simulator_instance):
         patch.object(
             simulator_instance, "_get_light_emission_application_name", return_value="ff-1m"
         ),
+        patch("simtools.simtel.simulator_light_emission.settings") as mock_settings,
     ):
+        mock_settings.config.sim_telarray_exe = "/mock/simtel/bin/sim_telarray"
+        mock_settings.config.sim_telarray_path = Path("/mock/simtel")
         # Test flat_fielding - should include Bypass_Optics
         simulator_instance.light_emission_config = {"light_source_type": "flat_fielding"}
 
         options = simulator_instance._make_simtel_script()
         assert "Bypass_Optics=1" in options
+        assert "-I/mock/simtel/bin/sim_telarray" not in options
 
         # Test illuminator - should NOT include Bypass_Optics
         simulator_instance.light_emission_config = {"light_source_type": "illuminator"}


### PR DESCRIPTION
# Summary 

Fix sim_telarray output validation and include paths, stabilize PSF calculations, correct waveform plot time axes, and validate expected event counts of zero.

## Fixed bugs

### 21. Incorrect sim_telarray output file key

Changed `_check_run_result()` to request `sim_telarray_output`, consistent with file registration and command generation.

### 22. Executable path used as an include directory

Removed `-I<sim_telarray executable>`. The telescope model configuration directory is already supplied as an include directory.

This affects:

- `simulate_illuminator`
- `simulate_flasher --run_mode full_simulation`

Direct-injection flasher simulations are unaffected.

### 26. Numerically unstable PSF variance

Replaced the cancellation-prone variance calculation

```python
E[x²] - E[x]²
```

with `np.std()`. Degenerate images where all photons have identical positions now return a zero PSF instead of failing during the iterative calculation.

### 28. Inverted waveform time step

`pixel_settings["time_slice"]` is a sampling period in nanoseconds, not a frequency. The time axis now uses the time slice directly.

The misleading `sampling_rate` name was changed to `time_slice`.

This corrects the time axes in:

- Time-trace plots
- Waveform-matrix plots
- Step-trace plots

### 30. Zero expected events skipped validation

Replaced the truthiness check with explicit `None` checks. Expected counts of zero are now validated instead of being treated as unspecified.

## Reports not fixed

### 23. Shell options stored as combined list elements

No bug was found. These lists are not passed directly to `subprocess`. Their elements are joined into a shell command string, written to a Bash script, and subsequently interpreted by the shell. Shell word splitting therefore occurs as intended.

### 24. Exact equality for wavelength edges

The reported failure does not occur for the standard calculation:

- The default bounds convert to exactly `300.0` and `650.0` nm.
- The `testeff` wavelength grid uses integer 1 nm bins.

The suggested `np.isclose()` change would also be incomplete for arbitrary equivalent-unit inputs because the range mask uses exact inequalities as well. Supporting arbitrary converted boundaries robustly would require treating both the range selection and edge correction together.

### 25. `0.0001` factor in the NSB integral

The factor is required:

- `N1` is expressed per square metre.
- `nsb_reference_value` is expressed per square centimetre.
- Converting a flux from `m⁻²` to `cm⁻²` requires multiplication by `10⁻⁴`.

Removing it would make the reference NSB rate incorrect by a factor of `10⁴`.

### 27. Exact zero check for off-axis angle

No rounding path producing a near-zero substitute for zero was identified:

- Computed on-axis offsets remain exactly zero.
- Scalar input angles are rounded to five decimal places before use.

Using an arbitrary `1e-6` tolerance would instead classify deliberately supplied nonzero offsets as on-axis and discard their effective focal-length result.

### 29. Shell syntax constructed with `Path.joinpath()`

The resulting object is written as the contents of an executable shell script. It is not passed to `subprocess` as a literal executable path.

Although using `Path` as a command-string builder is unconventional, its string representation produces the intended shell command, including `|| echo 'Fan-out failed'`.

