### PR TITLE
McCabe cost complexity

### DIFF
--- a/docs/changes/2302.maintenance.md
+++ b/docs/changes/2302.maintenance.md
@@ -1,0 +1,1 @@
+Add McCabe complexity check to ruff settings.

--- a/docs/changes/2304.maintenance.md
+++ b/docs/changes/2304.maintenance.md
@@ -1,0 +1,1 @@
+Add ruff rule on floating point comparison (currently in ruff preview).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,25 +155,27 @@ format.quote-style = "double"
 format.line-ending = "auto"
 # no documentation linting for test files
 format.skip-magic-trailing-comma = false
+lint.select = [ "E4", "E7", "E9", "F" ]
 lint.extend-select = [
-  "A",   # built-in shadowing
-  "C4",  # comprehension
-  "C90", # mccabe complex structure
-  "COM", # flake8-commas
-  "D",   # pydocstyle
-  "ERA", # commented-out code
-  "F",   # pyflakes
-  "G",   # logging
-  "I",   # isort
-  "ICN", # import name conventions
-  "ISC", # implicit string concat rules
-  "N",   # pep8 naming
-  "NPY", # numpy
-  "PT",  # pytest
-  "PTH", # use pathlib
-  "RET", # return statements
-  "RUF", # ruff
-  "UP",  # pyupgrade
+  "A",      # built-in shadowing
+  "C4",     # comprehension
+  "C90",    # mccabe complex structure
+  "COM",    # flake8-commas
+  "D",      # pydocstyle
+  "ERA",    # commented-out code
+  "F",      # pyflakes
+  "G",      # logging
+  "I",      # isort
+  "ICN",    # import name conventions
+  "ISC",    # implicit string concat rules
+  "N",      # pep8 naming
+  "NPY",    # numpy
+  "PT",     # pytest
+  "PTH",    # use pathlib
+  "RET",    # return statements
+  "RUF",    # ruff
+  "RUF069", # float equality comparison (preview)
+  "UP",     # pyupgrade
 ]
 lint.ignore = [
   "COM812", # incompatible with ruff format
@@ -185,6 +187,7 @@ lint.ignore = [
   "PTH123", # open("foo") should be replaced by Path("foo").open()
   "RUF012", # Mutable class attributes should be annotated
 ]
+lint.explicit-preview-rules = true
 lint.per-file-ignores."**/tests/**" = [
   "D",
 ]
@@ -193,6 +196,7 @@ lint.per-file-ignores."**/tests_*.py" = [
 ]
 lint.mccabe.max-complexity = 12
 lint.pydocstyle.convention = "numpy"
+lint.preview = true
 
 [tool.pylint]
 # See discussion in issue 521

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ format.skip-magic-trailing-comma = false
 lint.extend-select = [
   "A",   # built-in shadowing
   "C4",  # comprehension
+  "C90", # mcabe complex structure
   "COM", # flake8-commas
   "D",   # pydocstyle
   "ERA", # commented-out code
@@ -190,6 +191,7 @@ lint.per-file-ignores."**/tests/**" = [
 lint.per-file-ignores."**/tests_*.py" = [
   "D",
 ]
+lint.mccabe.max-complexity = 12
 lint.pydocstyle.convention = "numpy"
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ format.skip-magic-trailing-comma = false
 lint.extend-select = [
   "A",   # built-in shadowing
   "C4",  # comprehension
-  "C90", # mcabe complex structure
+  "C90", # mccabe complex structure
   "COM", # flake8-commas
   "D",   # pydocstyle
   "ERA", # commented-out code

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -409,7 +409,7 @@ def is_safe_tar_member(member_name):
         return False
 
     # Verify the normalized path is still relative
-    normalized = PurePosixPath(*parts) if parts else PurePosixPath(".")
+    normalized = PurePosixPath(*parts) if parts else PurePosixPath()
     if normalized.is_absolute():
         return False
 

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -68,7 +68,7 @@ def test_rotate_telescope_position(caplog) -> None:
 def test_calculate_circular_mean():
     # Test opposite angles cancel out
     angles = np.array([0, np.pi])
-    assert transf.calculate_circular_mean(angles) == np.pi / 2
+    assert transf.calculate_circular_mean(angles) == pytest.approx(np.pi / 2)
 
     # Test mean of same angles
     angles = np.array([np.pi / 4, np.pi / 4, np.pi / 4])

--- a/tests/unit_tests/visualization/test_legend_handlers.py
+++ b/tests/unit_tests/visualization/test_legend_handlers.py
@@ -87,12 +87,12 @@ def test_calculate_center():
     handlebox = MockHandleBox(xdescent=10, ydescent=20, width=30, height=40)
 
     x0, y0 = leg_h.calculate_center(handlebox, width_factor=3, height_factor=4)
-    assert x0 == 10 + 30 / 3
-    assert y0 == 20 + 40 / 4
+    assert x0 == pytest.approx(10 + 30 / 3)
+    assert y0 == pytest.approx(20 + 40 / 4)
 
     x0, y0 = leg_h.calculate_center(handlebox, width_factor=2, height_factor=2)
-    assert x0 == 10 + 30 / 2
-    assert y0 == 20 + 40 / 2
+    assert x0 == pytest.approx(10 + 30 / 2)
+    assert y0 == pytest.approx(20 + 40 / 2)
 
 
 def test_base_hex_pixel_handler_create_hex_patch():


### PR DESCRIPTION
SonarQ is annoyingly often complaining about cost complexity of functions.

To catch this earlier, add to McCabe cost complexity test to the ruff configuration, see https://docs.astral.sh/ruff/rules/complex-structure/.

Mathematically this is not identical to the SonarQ approach, but the intention is the same. Hope that this reduces the number of Sonarq issues.