### PR TITLE
Allow integration tests to run from working directories containing a pytest configuration.

### DIFF
--- a/docs/changes/2312.bugfix.md
+++ b/docs/changes/2312.bugfix.md
@@ -1,0 +1,1 @@
+Allow integration tests to run from working directories containing a pytest configuration.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 import pytest
 
+SIMTOOLS_ROOT_PATH = Path(__file__).resolve().parent.parent
+
 
 def _configured_test_resources_path(config):
     """Return the absolute path to the configured test resources directory."""
     configured_path = config.getoption("test_resources_path", default=None)
-    path = configured_path or config.rootpath / "tests" / "resources"
+    path = configured_path or SIMTOOLS_ROOT_PATH / "tests" / "resources"
     return Path(path).expanduser().resolve()
 
 
@@ -37,3 +39,9 @@ def pytest_configure(config):
 def test_resources_path(pytestconfig):
     """Return the absolute path to the test resources directory."""
     return _configured_test_resources_path(pytestconfig)
+
+
+@pytest.fixture(scope="session")
+def simtools_root_path():
+    """Return the path to the simtools repository root."""
+    return SIMTOOLS_ROOT_PATH

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -15,16 +15,15 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(autouse=True)
-def simtools_settings(db_config, pytestconfig):
+def simtools_settings(db_config):
     """Load simtools settings for the test session."""
-    load_dotenv(pytestconfig.rootpath / ".env")
     settings.config.load(db_config=db_config)
 
 
 @pytest.fixture
-def db_config(pytestconfig):
+def db_config(simtools_root_path):
     """DB configuration from .env file."""
-    load_dotenv(pytestconfig.rootpath / ".env")
+    load_dotenv(simtools_root_path / ".env")
 
     _db_para = (
         "db_api_user",

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -16,7 +16,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(autouse=True)
 def simtools_settings(db_config):
-    """Load simtools settings for the test session."""
+    """Load simtools settings for a test."""
     settings.config.load(db_config=db_config)
 
 

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -38,7 +38,7 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize("config", test_parameters)
 
 
-def test_applications_from_config(tmp_test_directory, config, request):
+def test_applications_from_config(tmp_test_directory, config, request, simtools_root_path):
     """
     Test all applications from config files found in the config directory.
 
@@ -88,7 +88,7 @@ def test_applications_from_config(tmp_test_directory, config, request):
         capture_output=True,
         text=True,
         env=env,
-        cwd=request.config.rootpath,
+        cwd=simtools_root_path,
     )
     msg = f"Command {cmd!r} failed. stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     if result.returncode != 0 and config.get("xfail_network_error"):


### PR DESCRIPTION
Tested this with:

```
mkdir -p /tmp/simtools-pytest-test
printf '[tool.pytest.ini_options]\n' > /tmp/simtools-pytest-test/pyproject.toml
cd /tmp/simtools-pytest-test

 PATH="/Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/.venv/bin:$PATH"   /Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/.venv/bin/python -m pytest   -c pyproject.toml -q   '/Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-validate-optics_auto-help]'
.                                                                                                                                                                                                            [100%]
1 passed in 2.11s
PATH="/Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/.venv/bin:$PATH"   /Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/.venv/bin/python -m pytest   -c /tmp/simtools-pytest-test/pyproject.toml -q   '/Users/maierg/DESYCloud/CTA/Pipelines/MC-Pipeline/gammasim-tools/simtools-dev2/tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-validate-optics_auto-help]'
.                                                                                                                                                                                                            [100%]
1 passed in 2.08s
```

Closes #2258 
