### PR TITLE
Improve efficiency and memory footprint for reading of reduced event data and histogram filling. 

### DIFF
--- a/docs/changes/2316.maintenance.md
+++ b/docs/changes/2316.maintenance.md
@@ -1,0 +1,1 @@
+Improve efficiency and memory footprint for reading of reduced event data and histogram filling.

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -65,9 +65,9 @@ Results are provided as a table with the following columns:
 | br_viewcone_max           | float64   | deg    | Viewcone max from broad-range simulations.   |
 +---------------------------+-----------+--------+----------------------------------------------+
 
-The input event data files are generated using the application simtools-generate-simtel-event-data
-and are required for each point in the observational parameter space (e.g., array pointing
-directions, level of night sky background, etc.).
+The input event data files are generated using the application simtools-generate-simtel-event-data.
+These files define most of the sampled observational parameter space (zenith, azimuth, and NSB
+level), and one file entry is required per point in that parameter space.
 
 Distributions of triggered events (e.g., core distance vs energy) can be plotted to verify the
 derived limits using the ``--plot_histograms`` option. Plots are organized into per-production
@@ -76,8 +76,10 @@ subdirectories derived from the input pattern names (for example ``production_pr
 Command line arguments
 ----------------------
 event_data_file (str or list of str, required)
-    Path or glob pattern for reduced event data files. Can be a single pattern or
-    multiple patterns (one per ``--event_data_file`` argument) to enable parallel
+    Path or glob pattern for reduced event data files. The matched files define most
+    of the sampled observational parameter space (zenith, azimuth, and NSB level),
+    with one file entry required per parameter-space point. Can be a single pattern
+    or multiple patterns (one per ``--event_data_file`` argument) to enable parallel
     multi-production processing.
 array_layout_name (str, required)
     Name of the array layout (as defined in array_layouts) for which to derive limits.
@@ -157,8 +159,9 @@ def _add_arguments(parser):
     parser.add_argument(
         "--event_data_file",
         help=(
-            "Event data file or glob pattern (one or more patterns for "
-            "multi-production processing)."
+            "Event data file or glob pattern. Matched files define most of the sampled "
+            "zenith/azimuth/NSB parameter space (one file entry per point); provide one "
+            "or more patterns for multi-production processing."
         ),
         nargs="+",
         action="extend",

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -128,13 +128,11 @@ def _execute_production_job(job_spec):
 
     Returns
     -------
-    dict
-        Result dictionary with limits and production metadata.
+    list[dict]
+        Result dictionaries with limits and production metadata.
     """
     production_index = job_spec["production_index"]
     production_pattern = job_spec["production_pattern"]
-    array_name = job_spec["array_name"]
-    telescope_ids = job_spec["telescope_ids"]
     allowed_losses = job_spec["allowed_losses"]
     energy_threshold_fraction = job_spec["energy_threshold_fraction"]
     plot_histograms = job_spec["plot_histograms"]
@@ -142,15 +140,16 @@ def _execute_production_job(job_spec):
     differential_loss_bins_per_decade = job_spec.get("differential_loss_bins_per_decade", 0)
     skip_invalid_event_data_files = job_spec.get("skip_invalid_event_data_files", False)
 
+    telescope_configs = job_spec["telescope_configs"]
+
     _logger.info(
         f"Processing production {production_index}: pattern={production_pattern}, "
-        f"array={array_name}"
+        f"arrays={len(telescope_configs)}"
     )
 
-    result = _process_file(
+    results = _process_production(
         production_pattern,
-        array_name,
-        telescope_ids,
+        telescope_configs,
         allowed_losses,
         energy_threshold_fraction,
         plot_histograms,
@@ -159,16 +158,17 @@ def _execute_production_job(job_spec):
         skip_invalid_event_data_files=skip_invalid_event_data_files,
     )
 
-    result.update(
-        {
-            "production_index": production_index,
-            "event_data_file": production_pattern,
-            "array_name": array_name,
-            "telescope_ids": telescope_ids,
-        }
-    )
+    for result, telescope_config in zip(results, telescope_configs):
+        result.update(
+            {
+                "production_index": production_index,
+                "event_data_file": production_pattern,
+                "array_name": telescope_config["array_name"],
+                "telescope_ids": telescope_config["telescope_ids"],
+            }
+        )
 
-    return result
+    return results
 
 
 def _resolve_telescope_configs(args_dict):
@@ -301,7 +301,8 @@ def generate_corsika_limits_grid(args_dict):
 
     telescope_configs = _resolve_telescope_configs(args_dict)
 
-    # Build deterministic job specs: Cartesian product of productions and telescope configs
+    # Build deterministic production jobs. Each worker reads a production once and
+    # accumulates the same complete histogram set for every telescope configuration.
     job_specs = []
     output_dir = io_handler.IOHandler().get_output_directory()
 
@@ -314,36 +315,102 @@ def generate_corsika_limits_grid(args_dict):
         )
 
     for prod_idx, production_pattern in enumerate(production_patterns):
-        for array_name, telescope_ids_raw in telescope_configs.items():
-            telescope_ids = normalize_array_element_identifier_container(telescope_ids_raw)
-
-            output_subdir = production_subdirs.get(production_pattern)
-
-            job_spec = {
+        normalized_telescope_configs = [
+            {
+                "array_name": array_name,
+                "telescope_ids": normalize_array_element_identifier_container(telescope_ids_raw),
+            }
+            for array_name, telescope_ids_raw in telescope_configs.items()
+        ]
+        job_specs.append(
+            {
                 "production_index": prod_idx,
                 "production_pattern": production_pattern,
-                "array_name": array_name,
-                "telescope_ids": telescope_ids,
+                "telescope_configs": normalized_telescope_configs,
                 "allowed_losses": allowed_losses,
                 "energy_threshold_fraction": energy_threshold_fraction,
                 "plot_histograms": args_dict["plot_histograms"],
-                "output_subdir": output_subdir,
+                "output_subdir": production_subdirs.get(production_pattern),
                 "differential_loss_bins_per_decade": differential_loss_bins_per_decade,
                 "skip_invalid_event_data_files": args_dict.get(
                     "skip_invalid_event_data_files", False
                 ),
             }
-            job_specs.append(job_spec)
+        )
 
     max_workers = int(args_dict.get("max_workers", 1))
     _logger.info(f"Executing {len(job_specs)} jobs with {max_workers or 'auto'} workers")
-    results = process_pool_map_ordered(
+    production_results = process_pool_map_ordered(
         _execute_production_job,
         job_specs,
         max_workers=max_workers,
     )
+    results = [result for production_result in production_results for result in production_result]
 
     write_results(results, args_dict, allowed_losses, energy_threshold_fraction)
+
+
+def _process_production(
+    file_path,
+    telescope_configs,
+    allowed_losses,
+    energy_threshold_fraction=0.01,
+    plot_histograms=False,
+    output_subdir=None,
+    differential_loss_bins_per_decade=0,
+    skip_invalid_event_data_files=False,
+):
+    """Read one production once and derive limits for all telescope configurations."""
+    energy_bins_per_decade = differential_loss_bins_per_decade or 10
+    event_source = EventDataHistograms(
+        file_path,
+        energy_bins_per_decade=energy_bins_per_decade,
+        skip_invalid_event_data_files=skip_invalid_event_data_files,
+        require_triggered_data=True,
+    )
+    accumulators = [
+        EventDataHistograms.create_accumulator(
+            array_name=config["array_name"],
+            telescope_list=config["telescope_ids"],
+            energy_bins_per_decade=energy_bins_per_decade,
+        )
+        for config in telescope_configs
+    ]
+
+    for reader, values in event_source.iter_event_data():
+        file_info_table, shower_data, triggered_shower, triggered_data = values
+        for config, histograms in zip(telescope_configs, accumulators):
+            if config["telescope_ids"]:
+                filtered_triggered_data, filtered_triggered_shower = reader.filter_by_telescopes(
+                    triggered_data,
+                    triggered_shower,
+                    telescope_list=config["telescope_ids"],
+                )
+            else:
+                filtered_triggered_data = triggered_data
+                filtered_triggered_shower = triggered_shower
+            histograms.accumulate(
+                file_info_table,
+                shower_data,
+                filtered_triggered_shower,
+                filtered_triggered_data,
+            )
+
+    results = []
+    for config, histograms in zip(telescope_configs, accumulators):
+        histograms.finalize(fill_efficiency_histogram=False)
+        results.append(
+            _derive_limits_from_histograms(
+                histograms,
+                config["array_name"],
+                allowed_losses,
+                energy_threshold_fraction,
+                plot_histograms,
+                output_subdir,
+                differential_loss_bins_per_decade,
+            )
+        )
+    return results
 
 
 def _process_file(
@@ -399,6 +466,27 @@ def _process_file(
     )
     histograms.fill(fill_efficiency_histogram=False)
 
+    return _derive_limits_from_histograms(
+        histograms,
+        array_name,
+        allowed_losses,
+        energy_threshold_fraction,
+        plot_histograms,
+        output_subdir,
+        differential_loss_bins_per_decade,
+    )
+
+
+def _derive_limits_from_histograms(
+    histograms,
+    array_name,
+    allowed_losses,
+    energy_threshold_fraction,
+    plot_histograms,
+    output_subdir,
+    differential_loss_bins_per_decade,
+):
+    """Compute, optionally plot, and return limits from finalized histograms."""
     limits = {
         "lower_energy_limit": compute_lower_energy_limit(
             histograms,

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -63,6 +63,8 @@ class EventDataHistograms:
         self.histograms = {}
         self.file_info = {}
         self._contains_triggered_data = False
+        self._filled_data_sets = 0
+        self._release_event_data_after_fill = False
 
         self.reader = None
         if not self.skip_invalid_event_data_files:
@@ -70,6 +72,30 @@ class EventDataHistograms:
                 self.event_data_files[0], telescope_list=self.telescope_list
             )
             self._contains_triggered_data = self._reader_has_triggered_data(self.reader)
+
+    @classmethod
+    def create_accumulator(cls, array_name=None, telescope_list=None, energy_bins_per_decade=10):
+        """Create an empty histogram accumulator for externally supplied event data.
+
+        This avoids opening the same input files for every telescope configuration when
+        one caller reads the event data once and distributes it to several accumulators.
+        """
+        instance = cls.__new__(cls)
+        instance._logger = logging.getLogger(__name__)
+        instance.event_data_file = None
+        instance.event_data_files = []
+        instance.array_name = array_name
+        instance.energy_bins_per_decade = max(int(energy_bins_per_decade), 1)
+        instance.skip_invalid_event_data_files = False
+        instance.require_triggered_data = True
+        instance.telescope_list = telescope_list
+        instance.histograms = {}
+        instance.file_info = {}
+        instance._contains_triggered_data = True
+        instance._filled_data_sets = 0
+        instance._release_event_data_after_fill = True
+        instance.reader = None
+        return instance
 
     def _normalize_event_data_files(self, event_data_file):
         """Return event-data files as a list of resolved file names."""
@@ -150,6 +176,50 @@ class EventDataHistograms:
         for data in self.histograms.values():
             self._fill_histogram_and_bin_edges(data)
 
+    def _release_event_data(self):
+        """Release raw event references after their histogram counts have been accumulated."""
+        for data in self.histograms.values():
+            data["event_data"] = None if data["1d"] else (None, None)
+
+    def accumulate(self, file_info_table, shower_data, event_data, triggered_data):
+        """Accumulate one already-read event dataset into all configured histograms."""
+        self._update_file_info(file_info_table)
+        current_histograms = self._define_histograms(event_data, triggered_data, shower_data)
+        self._merge_histograms(current_histograms)
+        self._fill_current_histograms()
+        if self._release_event_data_after_fill:
+            self._release_event_data()
+        self._filled_data_sets += 1
+
+    def finalize(self, fill_efficiency_histogram=True):
+        """Finalize accumulated histograms after all event datasets have been added."""
+        if self._filled_data_sets == 0:
+            raise ValueError("No readable event data files or datasets found.")
+        self.print_summary()
+        if fill_efficiency_histogram:
+            self.calculate_efficiency_data()
+        self.calculate_cumulative_data()
+
+    def iter_event_data(self):
+        """Yield reduced event datasets sequentially, keeping input memory bounded."""
+        total_files = len(self.event_data_files)
+        for file_index, (event_data_file, reader) in enumerate(self._iter_readers(), start=1):
+            for data_set in reader.data_sets:
+                try:
+                    values = self._read_data_set(
+                        reader,
+                        event_data_file,
+                        data_set,
+                        file_index=file_index,
+                        total_files=total_files,
+                    )
+                except (OSError, KeyError, ValueError) as exc:
+                    if self.skip_invalid_event_data_files:
+                        self._log_skipped_event_data_file(event_data_file, exc)
+                        break
+                    raise
+                yield reader, values
+
     def fill(self, fill_efficiency_histogram=True):
         """
         Fill histograms with event data.
@@ -165,37 +235,9 @@ class EventDataHistograms:
         fill_efficiency_histogram : bool, optional
             Whether to calculate and fill the efficiency histograms.
         """
-        total_files = len(self.event_data_files)
-        filled_data_sets = 0
-        for file_index, (event_data_file, reader) in enumerate(self._iter_readers(), start=1):
-            for data_set in reader.data_sets:
-                try:
-                    file_info_table, shower_data, event_data, triggered_data = self._read_data_set(
-                        reader,
-                        event_data_file,
-                        data_set,
-                        file_index=file_index,
-                        total_files=total_files,
-                    )
-                except (OSError, KeyError, ValueError) as exc:
-                    if self.skip_invalid_event_data_files:
-                        self._log_skipped_event_data_file(event_data_file, exc)
-                        break
-                    raise
-                self._update_file_info(file_info_table)
-                current_histograms = self._define_histograms(
-                    event_data, triggered_data, shower_data
-                )
-                self._merge_histograms(current_histograms)
-                self._fill_current_histograms()
-                filled_data_sets += 1
-
-        if filled_data_sets == 0:
-            raise ValueError("No readable event data files or datasets found.")
-        self.print_summary()
-        if fill_efficiency_histogram:
-            self.calculate_efficiency_data()
-        self.calculate_cumulative_data()
+        for _, values in self.iter_event_data():
+            self.accumulate(*values)
+        self.finalize(fill_efficiency_histogram=fill_efficiency_histogram)
 
     def _define_histograms(self, event_data, triggered_data, shower_data):
         """

--- a/src/simtools/sim_events/reader.py
+++ b/src/simtools/sim_events/reader.py
@@ -245,44 +245,72 @@ class EventDataReader:
         """
         triggered_shower = ShowerEventData()
 
-        shower_key_to_index = {}
-        duplicate_shower_keys = set()
-        for idx, (shower_id, event_id, file_id) in enumerate(
-            zip(shower_data.shower_id, shower_data.event_id, shower_data.file_id)
-        ):
-            key = (int(shower_id), int(event_id), int(file_id))
-            if key in shower_key_to_index:
-                duplicate_shower_keys.add(key)
-                continue
-            shower_key_to_index[key] = idx
+        key_dtype = np.dtype(
+            [("shower_id", np.int64), ("event_id", np.int64), ("file_id", np.int64)]
+        )
 
-        matched_indices = []
-        for tr_shower_id, tr_event_id, tr_file_id in zip(
-            triggered_shower_id, triggered_event_id, triggered_file_id
-        ):
-            trigger_key = (int(tr_shower_id), int(tr_event_id), int(tr_file_id))
-            if trigger_key in duplicate_shower_keys:
+        def build_keys(shower_ids, event_ids, file_ids):
+            keys = np.empty(len(shower_ids), dtype=key_dtype)
+            keys["shower_id"] = np.asarray(shower_ids, dtype=np.int64)
+            keys["event_id"] = np.asarray(event_ids, dtype=np.int64)
+            keys["file_id"] = np.asarray(file_ids, dtype=np.int64)
+            return keys
+
+        shower_keys = build_keys(
+            shower_data.shower_id,
+            shower_data.event_id,
+            shower_data.file_id,
+        )
+        trigger_keys = build_keys(
+            triggered_shower_id,
+            triggered_event_id,
+            triggered_file_id,
+        )
+
+        order = np.argsort(shower_keys, kind="stable")
+        sorted_shower_keys = shower_keys[order]
+        positions = np.searchsorted(sorted_shower_keys, trigger_keys)
+
+        found = positions < len(sorted_shower_keys)
+        if np.any(found):
+            found_indices = np.flatnonzero(found)
+            found[found_indices] = (
+                sorted_shower_keys[positions[found_indices]] == trigger_keys[found_indices]
+            )
+
+        duplicate_sorted = np.zeros(len(sorted_shower_keys), dtype=np.bool_)
+        if len(sorted_shower_keys) > 1:
+            equal_neighbors = sorted_shower_keys[1:] == sorted_shower_keys[:-1]
+            duplicate_sorted[:-1] |= equal_neighbors
+            duplicate_sorted[1:] |= equal_neighbors
+
+        duplicate_match = np.zeros(len(trigger_keys), dtype=np.bool_)
+        if np.any(found):
+            found_indices = np.flatnonzero(found)
+            duplicate_match[found_indices] = duplicate_sorted[positions[found_indices]]
+
+        for trigger_index in np.flatnonzero(~found | duplicate_match):
+            if duplicate_match[trigger_index]:
                 self._logger.warning(
-                    f"Found multiple matches for shower {tr_shower_id}"
-                    f" event {tr_event_id} file {tr_file_id}"
+                    f"Found multiple matches for shower {triggered_shower_id[trigger_index]}"
+                    f" event {triggered_event_id[trigger_index]}"
+                    f" file {triggered_file_id[trigger_index]}"
                 )
-                continue
-
-            matched_idx = shower_key_to_index.get(trigger_key)
-            if matched_idx is None:
+            else:
                 self._logger.warning(
-                    f"Found 0 matches for shower {tr_shower_id}"
-                    f" event {tr_event_id} file {tr_file_id}"
+                    f"Found 0 matches for shower {triggered_shower_id[trigger_index]}"
+                    f" event {triggered_event_id[trigger_index]}"
+                    f" file {triggered_file_id[trigger_index]}"
                 )
-                continue
 
-            matched_indices.append(matched_idx)
+        valid_matches = found & ~duplicate_match
+        matched_indices = order[positions[valid_matches]]
 
         for attr in vars(shower_data):
             if not attr.endswith("_unit"):
                 value = getattr(shower_data, attr)
                 if isinstance(value, list | np.ndarray):
-                    setattr(triggered_shower, attr, np.array(value)[matched_indices])
+                    setattr(triggered_shower, attr, np.asarray(value)[matched_indices])
 
         return triggered_shower
 
@@ -365,7 +393,7 @@ class EventDataReader:
         )
 
         if self.telescope_list:
-            triggered_data, triggered_shower = self._filter_by_telescopes(
+            triggered_data, triggered_shower = self.filter_by_telescopes(
                 triggered_data, triggered_shower
             )
 
@@ -405,9 +433,26 @@ class EventDataReader:
                     f"{', '.join(invalid_columns)}."
                 )
 
-    def _filter_by_telescopes(self, triggered_data, triggered_shower):
-        """Filter trigger data and triggered shower data by the specified telescope list."""
-        telescope_set = set(self.telescope_list)
+    def filter_by_telescopes(self, triggered_data, triggered_shower, telescope_list=None):
+        """
+        Filter trigger and shower data by an explicit or reader telescope list.
+
+        Parameters
+        ----------
+        triggered_data : TriggeredEventData
+            Triggered event data to filter.
+        triggered_shower : ShowerEventData
+            Shower data corresponding to the triggered events.
+        telescope_list : list, optional
+            List of telescopes to filter by. If None, uses the reader's telescope list.
+
+        Returns
+        -------
+        tuple
+            A tuple containing the filtered triggered event data and the corresponding
+            triggered shower data.
+        """
+        telescope_set = set(self.telescope_list if telescope_list is None else telescope_list)
         mask = np.fromiter(
             (not telescope_set.isdisjoint(event) for event in triggered_data.telescope_list),
             dtype=np.bool_,

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -5,6 +5,7 @@ from astropy.table import Table
 from astropy.tests.helper import assert_quantity_allclose
 
 import simtools.production_configuration.derive_corsika_limits as derive_corsika_limits
+from simtools.sim_events.reader import EventDataReader
 
 # Constants
 SIM_EVENTS_HISTOGRAMS_PATH = (
@@ -210,8 +211,10 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict, tm
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
     mock_pool.return_value = [
-        {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
-        {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+        [
+            {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
+            {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+        ]
     ]
 
     mock_io = mocker.patch(
@@ -229,7 +232,11 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict, tm
         args["array_layout_name"], args["site"], args["model_version"]
     )
     job_specs = mock_pool.call_args[0][1]
-    assert len(job_specs) == 2  # 2 layouts
+    assert len(job_specs) == 1  # one production containing both layouts
+    assert job_specs[0]["telescope_configs"] == [
+        {"array_name": "LST", "telescope_ids": ["LSTN-01", "LSTN-02"]},
+        {"array_name": "MST", "telescope_ids": ["LSTN-03", "LSTN-04"]},
+    ]
     assert mock_write.call_count == 1
 
 
@@ -256,8 +263,10 @@ def test_generate_corsika_limits_grid_by_version_layout_resolved(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
     mock_pool.return_value = [
-        {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
-        {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+        [
+            {"primary_particle": "gamma", "array_name": "LST", "telescope_ids": [1, 2]},
+            {"primary_particle": "gamma", "array_name": "MST", "telescope_ids": [3, 4]},
+        ]
     ]
 
     mock_io = mocker.patch(
@@ -285,7 +294,7 @@ def test_generate_corsika_limits_grid_with_array_element_list(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
     mock_pool.return_value = [
-        {"primary_particle": "gamma", "array_name": "array_element_list"},
+        [{"primary_particle": "gamma", "array_name": "array_element_list"}],
     ]
 
     mock_io = mocker.patch(
@@ -302,8 +311,12 @@ def test_generate_corsika_limits_grid_with_array_element_list(
     job_specs = mock_pool.call_args[0][1]
     assert len(job_specs) == 1
     job_spec = job_specs[0]
-    assert job_spec["array_name"] == "array_element_list"
-    assert job_spec["telescope_ids"] == ["LSTN-01", "LSTN-02", "MSTN-03"]
+    assert job_spec["telescope_configs"] == [
+        {
+            "array_name": "array_element_list",
+            "telescope_ids": ["LSTN-01", "LSTN-02", "MSTN-03"],
+        }
+    ]
     assert mock_write.call_count == 1
 
 
@@ -323,7 +336,7 @@ def test_generate_corsika_limits_grid_with_telescope_ids_file(
     mock_pool = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_pool.return_value = [{"primary_particle": "gamma", "array_name": "LST"}]
+    mock_pool.return_value = [[{"primary_particle": "gamma", "array_name": "LST"}]]
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
     )
@@ -335,8 +348,9 @@ def test_generate_corsika_limits_grid_with_telescope_ids_file(
     derive_corsika_limits.generate_corsika_limits_grid(args)
 
     job_spec = mock_pool.call_args[0][1][0]
-    assert job_spec["array_name"] == "LST"
-    assert job_spec["telescope_ids"] == ["LSTN-01", "LSTN-02"]
+    assert job_spec["telescope_configs"] == [
+        {"array_name": "LST", "telescope_ids": ["LSTN-01", "LSTN-02"]}
+    ]
     assert mock_write.call_count == 1
 
 
@@ -354,7 +368,7 @@ def test_generate_corsika_limits_grid_builds_output_subdirs_for_multiple_product
     mock_pool = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_pool.return_value = [_pool_result(event_data_file="prod_a/*.h5")]
+    mock_pool.return_value = [[_pool_result(event_data_file="prod_a/*.h5")]]
     mock_io = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.io_handler.IOHandler"
     )
@@ -1224,51 +1238,110 @@ def test_build_production_subdirectories_creates_dirs(tmp_test_directory):
         assert output_subdir.isdir()
 
 
-def test_execute_production_job_single_job(mocker):
-    """Test _execute_production_job executes one job correctly."""
-    mock_histograms = mocker.MagicMock()
-    mock_histograms.fill.return_value = None
-    mock_histograms.file_info = {}
-
-    mocker.patch(
-        SIM_EVENTS_HISTOGRAMS_PATH,
-        return_value=mock_histograms,
+def test_execute_production_job_groups_layouts_and_preserves_result_order(mocker):
+    """A production job returns layout results in configuration order."""
+    process_production = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits._process_production",
+        return_value=[{"lower_energy_limit": 1.0}, {"lower_energy_limit": 2.0}],
     )
-
-    mocker.patch(
-        COMPUTE_LOWER_ENERGY_LIMIT_PATH,
-        return_value=1.0 * u.TeV,
-    )
-    mocker.patch(
-        COMPUTE_LIMITS_PATH,
-        return_value={
-            "upper_radius_limit": 100.0 * u.m,
-            "viewcone_radius": 2.0 * u.deg,
-            "core_distance_vs_energy_curve": {"x": [100.0, 100.0], "y": [0.1, 1.0]},
-            "angular_distance_vs_energy_curve": {"x": [2.0, 2.0], "y": [0.1, 1.0]},
-        },
-    )
-
+    telescope_configs = [
+        {"array_name": "LST", "telescope_ids": ["LSTN-01"]},
+        {"array_name": "MST", "telescope_ids": ["MSTN-03"]},
+    ]
     job_spec = {
-        "production_index": 0,
+        "production_index": 3,
         "production_pattern": "pattern_*.hdf5",
-        "array_name": "LST",
-        "telescope_ids": ["LSTN-01"],
+        "telescope_configs": telescope_configs,
         "allowed_losses": DEFAULT_ALLOWED_LOSSES,
         "energy_threshold_fraction": 0.1,
         "plot_histograms": False,
         "output_subdir": None,
     }
 
-    result = derive_corsika_limits._execute_production_job(job_spec)
+    results = derive_corsika_limits._execute_production_job(job_spec)
 
-    # Result should include production metadata
-    assert result["production_index"] == 0
-    assert result["event_data_file"] == "pattern_*.hdf5"
-    assert result["array_name"] == "LST"
-    assert "lower_energy_limit" in result
-    assert "upper_radius_limit" in result
-    assert "viewcone_radius" in result
+    process_production.assert_called_once()
+    assert [result["array_name"] for result in results] == ["LST", "MST"]
+    assert [result["telescope_ids"] for result in results] == [
+        ["LSTN-01"],
+        ["MSTN-03"],
+    ]
+    assert all(result["production_index"] == 3 for result in results)
+
+
+def test_process_production_reads_once_and_matches_single_layout_results(
+    mocker, test_resources_path
+):
+    """Grouped layouts reuse one read and preserve the single-layout numerical results."""
+    event_file = (
+        test_resources_path
+        / "generated"
+        / "proton_run000001_za20deg_azm180deg_North_alpha_6.0.2_test."
+        "reduced_event_data.hdf5"
+    )
+    telescope_configs = [
+        {"array_name": "LSTN-01", "telescope_ids": ["LSTN-01"]},
+        {"array_name": "MSTN-03", "telescope_ids": ["MSTN-03"]},
+    ]
+
+    expected = [
+        derive_corsika_limits._process_file(
+            str(event_file),
+            config["array_name"],
+            config["telescope_ids"],
+            DEFAULT_ALLOWED_LOSSES,
+            differential_loss_bins_per_decade=5,
+        )
+        for config in telescope_configs
+    ]
+
+    read_spy = mocker.spy(EventDataReader, "read_event_data")
+    plot_mock = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits.plot_simtel_event_histograms.plot"
+    )
+    actual = derive_corsika_limits._process_production(
+        str(event_file),
+        telescope_configs,
+        DEFAULT_ALLOWED_LOSSES,
+        plot_histograms=True,
+        output_subdir=event_file.parent,
+        differential_loss_bins_per_decade=5,
+    )
+
+    assert read_spy.call_count == 1
+    expected_histograms = {
+        "energy",
+        "core_distance",
+        "angular_distance",
+        "x_core_shower_vs_y_core_shower",
+        "core_distance_vs_energy",
+        "angular_distance_vs_energy",
+        "energy_mc",
+        "core_distance_mc",
+        "angular_distance_mc",
+        "x_core_shower_vs_y_core_shower_mc",
+        "core_distance_vs_energy_mc",
+        "angular_distance_vs_energy_mc",
+        "core_distance_vs_energy_cumulative",
+        "angular_distance_vs_energy_cumulative",
+        "energy_cumulative",
+        "core_distance_cumulative",
+        "angular_distance_cumulative",
+    }
+    assert plot_mock.call_count == len(telescope_configs)
+    assert all(set(call.args[0]) == expected_histograms for call in plot_mock.call_args_list)
+    assert len(actual) == len(expected)
+    for actual_result, expected_result in zip(actual, expected):
+        assert actual_result.keys() == expected_result.keys()
+        for key, expected_value in expected_result.items():
+            actual_value = actual_result[key]
+            if isinstance(expected_value, u.Quantity):
+                assert u.allclose(actual_value, expected_value)
+            elif isinstance(expected_value, dict):
+                np.testing.assert_allclose(actual_value["x"], expected_value["x"])
+                np.testing.assert_allclose(actual_value["y"], expected_value["y"])
+            else:
+                assert actual_value == expected_value
 
 
 def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_directory):
@@ -1282,14 +1355,16 @@ def test_generate_corsika_limits_grid_multi_production(mocker, tmp_test_director
     )
     # Mock process_pool_map_ordered to return results directly
     mock_pool.return_value = [
-        _pool_result(production_index=0, event_data_file="pattern_1_*.hdf5"),
-        _pool_result(
-            production_index=1,
-            event_data_file="pattern_2_*.hdf5",
-            lower_energy_limit=0.6 * u.TeV,
-            upper_radius_limit=450.0 * u.m,
-            viewcone_radius=5.5 * u.deg,
-        ),
+        [_pool_result(production_index=0, event_data_file="pattern_1_*.hdf5")],
+        [
+            _pool_result(
+                production_index=1,
+                event_data_file="pattern_2_*.hdf5",
+                lower_energy_limit=0.6 * u.TeV,
+                upper_radius_limit=450.0 * u.m,
+                viewcone_radius=5.5 * u.deg,
+            )
+        ],
     ]
 
     mock_write = mocker.patch(
@@ -1344,7 +1419,7 @@ def test_generate_corsika_limits_grid_single_production_uses_pool(mocker, tmp_te
     mock_pool = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits.process_pool_map_ordered"
     )
-    mock_pool.return_value = [_pool_result()]
+    mock_pool.return_value = [[_pool_result()]]
 
     mock_execute_job = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits._execute_production_job"

--- a/tests/unit_tests/sim_events/test_reader.py
+++ b/tests/unit_tests/sim_events/test_reader.py
@@ -256,6 +256,30 @@ def test_get_triggered_shower_data_no_matches(mock_hdf5_file, caplog):
         assert "Found 0 matches" in caplog.text
 
 
+def test_get_triggered_shower_data_numpy_matching_preserves_order_and_duplicates(
+    mock_hdf5_file, caplog
+):
+    """NumPy matching keeps trigger order and rejects ambiguous shower keys."""
+    reader = EventDataReader(mock_hdf5_file)
+    _, shower_data, _, _ = reader.read_event_data(mock_hdf5_file)
+
+    for attribute, values in vars(shower_data).items():
+        if not attribute.endswith("_unit") and isinstance(values, np.ndarray):
+            setattr(shower_data, attribute, np.concatenate([values, values[:1]]))
+
+    with caplog.at_level(logging.WARNING):
+        triggered_shower = reader._get_triggered_shower_data(
+            shower_data,
+            [0, 0, 999],
+            [2, 1, 999],
+            [2, 1, 999],
+        )
+
+    np.testing.assert_array_equal(triggered_shower.shower_id, np.array([2]))
+    assert "Found multiple matches for shower 1 event 1 file 0" in caplog.text
+    assert "Found 0 matches for shower 999 event 999 file 999" in caplog.text
+
+
 def test_read_event_data_returns_expected_types_and_values(mock_hdf5_file):
     """Test that read_event_data returns expected types and values."""
     reader = EventDataReader(mock_hdf5_file)

--- a/tests/unit_tests/simtel/test_multi_illuminator_simulator.py
+++ b/tests/unit_tests/simtel/test_multi_illuminator_simulator.py
@@ -202,7 +202,7 @@ def test_simulate_filter_by_illuminators(
     "SimulatorLightEmission.get_available_wavelengths_from_config"
 )
 @patch("simtools.simtel.multi_illuminator_simulator.process_pool_map_ordered")
-def test_simulatefilter_by_telescopes(
+def test_simulate_filter_by_telescopes(
     mock_pool, mock_get_wavelengths, simple_visibility_data, base_config
 ):
     """Test simulate() with telescope filtering and auto-fetch wavelengths."""

--- a/tests/unit_tests/simtel/test_multi_illuminator_simulator.py
+++ b/tests/unit_tests/simtel/test_multi_illuminator_simulator.py
@@ -202,7 +202,7 @@ def test_simulate_filter_by_illuminators(
     "SimulatorLightEmission.get_available_wavelengths_from_config"
 )
 @patch("simtools.simtel.multi_illuminator_simulator.process_pool_map_ordered")
-def test_simulate_filter_by_telescopes(
+def test_simulatefilter_by_telescopes(
     mock_pool, mock_get_wavelengths, simple_visibility_data, base_config
 ):
     """Test simulate() with telescope filtering and auto-fetch wavelengths."""


### PR DESCRIPTION
This is an efficiency / performance improvement PR with no functional changes (meaning input and output is exactly the same as before).

The important improvement is the reading of the input files is reduced by several factors, as we don't read anymore per array layout but only once and fill then the array layout. In the production-type example of deriving CORSIKA limits for prod6 North (electrons), it reduces the work from 576 file passes to 96.