### PR TITLE
Run-time simplification / usage for generation of test resources.

### DIFF
--- a/docs/changes/2323.feature.md
+++ b/docs/changes/2323.feature.md
@@ -1,0 +1,1 @@
+Enable `---runtime_environment_file` setting of run time environment (e.g., a container environment) with correct path settings for test resource generation and generic application running.

--- a/docs/changes/2324.feature.md
+++ b/docs/changes/2324.feature.md
@@ -1,1 +1,1 @@
-Enable `---runtime_environment_file` setting of run time environment (e.g., a container environment) with correct path settings for test resource generation and generatic application running.
+Enable `--runtime_environment_file` to select a runtime environment (e.g., a container) with correct path settings for test resource generation and generic application running.

--- a/docs/changes/2324.feature.md
+++ b/docs/changes/2324.feature.md
@@ -1,1 +1,0 @@
-Enable `--runtime_environment_file` to select a runtime environment (e.g., a container) with correct path settings for test resource generation and generic application running.

--- a/docs/changes/2324.feature.md
+++ b/docs/changes/2324.feature.md
@@ -1,0 +1,1 @@
+Enable `---runtime_environment_file` setting of run time environment (e.g., a container environment) with correct path settings for test resource generation and generatic application running.

--- a/src/simtools/application_control.py
+++ b/src/simtools/application_control.py
@@ -18,6 +18,7 @@ from simtools.production_configuration.job_grid_io import (
     job_grid_row_to_simulate_prod_args,
     read_job_grid_row,
 )
+from simtools.runners.simtools_runner import prepare_runtime_environment
 from simtools.settings import config
 
 SECRET_ENV_VAR_NAMES = ["SIMTOOLS_DB_API_PW"]
@@ -169,6 +170,7 @@ class ApplicationContext:
     db_config: dict
     logger: logging.Logger
     io_handler: io_handler.IOHandler | None
+    run_time: list | None = None
 
 
 def build_application(
@@ -337,12 +339,27 @@ def startup_application(
     _resolve_model_version_to_latest_patch(args_dict, logger)
     _version_info(args_dict, io_handler_instance, logger)
 
+    run_time = _prepare_runtime_environment_from_cli(args_dict)
+
     return ApplicationContext(
         args=args_dict,
         db_config=db_config,
         logger=logger,
         io_handler=io_handler_instance,
+        run_time=run_time,
     )
+
+
+def _prepare_runtime_environment_from_cli(args_dict):
+    """Prepare runtime environment from CLI arguments when requested."""
+    runtime_environment_file = args_dict.get("runtime_environment_file")
+    if runtime_environment_file is None or args_dict.get("ignore_runtime_environment"):
+        return None
+
+    runtime_environment, run_time = prepare_runtime_environment(runtime_environment_file)
+    args_dict["runtime_environment"] = runtime_environment
+    args_dict["run_time"] = run_time
+    return run_time
 
 
 def get_application_label(file_path):

--- a/src/simtools/applications/generate_test_resource.py
+++ b/src/simtools/applications/generate_test_resource.py
@@ -53,7 +53,6 @@ Runtime environment file example
                 - "-v /path/to/simpipe:/workdir/external/simpipe:ro"
 """
 
-import argparse
 from pathlib import Path
 
 from simtools.application_control import build_application
@@ -71,19 +70,6 @@ def _add_arguments(parser):
         type=Path,
         help="Run only the selected workflow config file from integration_tests/config_files.",
     )
-    parser.add_argument("--runtime_environment_file", type=Path)
-    parser.add_argument(
-        "--ignore_runtime_environment",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-        help="Ignore runtime environments configured in application files.",
-    )
-    parser.add_argument(
-        "--overwrite_collection_files",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Allow collected files to overwrite existing files with identical names.",
-    )
 
 
 def main():
@@ -92,16 +78,8 @@ def main():
         initialization_kwargs={"db_config": False, "paths": False},
         startup_kwargs={"setup_io_handler": False, "resolve_sim_software_executables": False},
     )
-    resource_generation.generate_test_resources(
-        test_directory=app_context.args["test_directory"],
-        simtools_version=app_context.args["simtools_version"],
-        download_only=app_context.args["download_only"],
-        test_static_files=app_context.args["test_static_files"],
-        config_file=app_context.args["config_file"],
-        runtime_environment_file=app_context.args["runtime_environment_file"],
-        ignore_runtime_environment=app_context.args["ignore_runtime_environment"],
-        overwrite_collection_files=app_context.args["overwrite_collection_files"],
-    )
+
+    resource_generation.generate_test_resources(app_context.args, run_time=app_context.run_time)
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/run_application.py
+++ b/src/simtools/applications/run_application.py
@@ -74,7 +74,7 @@ from simtools.runners.simtools_runner import run_applications
 
 
 def _add_arguments(parser):
-    """Register application-specific command line arguments."""
+    """Register application-specific command-line arguments."""
     parser.add_argument(
         "--config_file",
         help="Application configuration.",

--- a/src/simtools/applications/run_application.py
+++ b/src/simtools/applications/run_application.py
@@ -69,10 +69,8 @@ step 2 and 3 (useful for debugging):
 
 """
 
-from pathlib import Path
-
 from simtools.application_control import build_application
-from simtools.runners.simtools_runner import prepare_runtime_environment, run_applications
+from simtools.runners.simtools_runner import run_applications
 
 
 def _add_arguments(parser):
@@ -90,29 +88,6 @@ def _add_arguments(parser):
         nargs="+",
         help="List of steps to be execution (e.g., '--steps 7 8 9'; do not specify to run all).",
     )
-    parser.add_argument(
-        "--ignore_runtime_environment",
-        action="store_true",
-        help="Ignore the runtime environment and run the application in the current environment.",
-        default=False,
-    )
-    parser.add_argument(
-        "--runtime_environment_file",
-        type=Path,
-        help=(
-            "Path to a standalone runtime-environment YAML file (top-level 'runtime_environment')."
-        ),
-        default=None,
-    )
-    parser.add_argument(
-        "--overwrite_collection_files",
-        action="store_true",
-        help=(
-            "Allow files copied by the workflow collection block to overwrite existing files "
-            "with identical names."
-        ),
-        default=False,
-    )
 
 
 def main():
@@ -126,17 +101,7 @@ def main():
         },
     )
 
-    run_time = None
-    if (
-        app_context.args.get("runtime_environment_file") is not None
-        and not app_context.args["ignore_runtime_environment"]
-    ):
-        runtime_environment, run_time = prepare_runtime_environment(
-            app_context.args["runtime_environment_file"]
-        )
-        app_context.args["runtime_environment"] = runtime_environment
-
-    run_applications(app_context.args, run_time=run_time)
+    run_applications(app_context.args, run_time=app_context.run_time)
 
 
 if __name__ == "__main__":

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -64,6 +64,7 @@ class CommandLineParser(argparse.ArgumentParser):
             self.initialize_output_arguments()
         self.initialize_config_files()
         self.initialize_application_execution_arguments()
+        self.initialize_run_time()
         self.initialize_user_arguments()
 
     def initialize_config_files(self):
@@ -142,6 +143,42 @@ class CommandLineParser(argparse.ArgumentParser):
             action="store_true",
         )
 
+    def initialize_run_time(self):
+        """Initialize run time arguments."""
+        _job_group = self.add_argument_group("run time")
+        _job_group.add_argument(
+            "--runtime_environment_file",
+            type=Path,
+            help=(
+                "Path to a standalone runtime-environment YAML file "
+                "(top-level 'runtime_environment')."
+            ),
+            default=None,
+        )
+        _job_group.add_argument(
+            "--apptainer_image",
+            help="Apptainer image path or a dictionary mapping labels to image paths.",
+            type=CommandLineParser.string_or_dict,
+            default=None,
+        )
+        _job_group.add_argument(
+            "--ignore_runtime_environment",
+            action="store_true",
+            help=(
+                "Ignore the runtime environment and run the application in the current environment."
+            ),
+            default=False,
+        )
+        _job_group.add_argument(
+            "--overwrite_collection_files",
+            action="store_true",
+            help=(
+                "Allow files copied by the workflow collection block to overwrite existing files "
+                "with identical names."
+            ),
+            default=False,
+        )
+
     def initialize_application_execution_arguments(self):
         """Initialize application execution arguments."""
         _job_group = self.add_argument_group("execution")
@@ -188,12 +225,7 @@ class CommandLineParser(argparse.ArgumentParser):
             nargs="+",
             default=["png"],
         )
-        _job_group.add_argument(
-            "--apptainer_image",
-            help="Apptainer image path or a dictionary mapping labels to image paths.",
-            type=CommandLineParser.string_or_dict,
-            default=None,
-        )
+
         _job_group.add_argument(
             "--version", action="version", version=f"%(prog)s {simtools.version.__version__}"
         )

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -40,6 +40,7 @@ def run_applications(args_dict, run_time=None, replacements=None):
         runtime_environment,
         log_file,
         workflow_activity_id,
+        collection_config,
     ) = _read_application_configuration(
         args_dict["config_file"],
         args_dict.get("steps"),
@@ -51,14 +52,6 @@ def run_applications(args_dict, run_time=None, replacements=None):
 
     if args_dict.get("runtime_environment") is not None:
         runtime_environment = args_dict["runtime_environment"]
-
-    collection_config = None
-    try:
-        workflow_config = ascii_handler.collect_data_from_file(args_dict["config_file"])
-        workflow_config = gen.replace_placeholders_recursively(workflow_config, replacements or {})
-        collection_config = workflow_config.get("collection")
-    except (OSError, TypeError):
-        logger.debug("Could not read collection configuration from workflow file.")
 
     workflow_start = datetime.now(UTC)
     associated_activities = []
@@ -375,14 +368,13 @@ def _read_application_configuration(
 
     Returns
     -------
-    dict
-        Application configuration.
-    dict:
-        Runtime environment configuration.
-    Path
-        Path to the log file.
-    str
-        Workflow activity id.
+    tuple
+        Tuple containing:
+        - configurations: list of application configurations
+        - runtime_environment: dict with runtime environment configuration
+        - log_file: Path to the log file
+        - workflow_activity_id: str with workflow activity id
+        - collection_config: dict or None with collection configuration
 
     """
     job_configuration = ascii_handler.collect_data_from_file(configuration_file)
@@ -421,6 +413,7 @@ def _read_application_configuration(
         job_configuration.get("runtime_environment"),
         log_path / "simtools.log",
         workflow_activity_id,
+        job_configuration.get("collection"),
     )
 
 

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -569,8 +569,9 @@ def read_runtime_environment(runtime_environment):
 
     Parameters
     ----------
-    runtime_environment : str or None
-        Path to the runtime environment configuration file.
+    runtime_environment : dict or None
+        Runtime environment configuration.
+    docs/changes/2323.feature.md
 
     Returns
     -------

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -47,11 +47,8 @@ def run_applications(args_dict, run_time=None, replacements=None):
         args_dict.get("activity_id"),
         replacements=replacements,
     )
-    if args_dict.get("log_file") is not None:
-        log_file = args_dict["log_file"]
-
-    if args_dict.get("runtime_environment") is not None:
-        runtime_environment = args_dict["runtime_environment"]
+    log_file = args_dict.get("log_file", log_file)
+    runtime_environment = args_dict.get("runtime_environment", runtime_environment)
 
     workflow_start = datetime.now(UTC)
     associated_activities = []
@@ -555,11 +552,7 @@ def _set_input_output_directories(path):
     try:
         setting_workflow = gen.extract_subdirectories_from_path(path, anchor="input")
     except ValueError:
-        if path.parent != Path():
-            setting_workflow = str(path.parent)
-        else:
-            setting_workflow = path.stem
-
+        setting_workflow = str(path.parent) if path.parent != Path() else path.stem
         logger.info(
             "Could not derive setting workflow from 'input' anchor; "
             f"using fallback '{setting_workflow}'"

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -2,6 +2,7 @@
 
 import glob
 import logging
+import os
 import shutil
 from copy import deepcopy
 from datetime import UTC, datetime
@@ -562,7 +563,7 @@ def _set_input_output_directories(path):
     return output_path, setting_workflow
 
 
-def read_runtime_environment(runtime_environment, workdir="/workdir/external/"):
+def read_runtime_environment(runtime_environment):
     """
     Read the runtime environment (e.g. docker runtime) and generate the required command.
 
@@ -582,11 +583,12 @@ def read_runtime_environment(runtime_environment, workdir="/workdir/external/"):
     engine = runtime_environment.get("container_engine", "docker")
     if shutil.which(engine) is None:
         raise RuntimeError(f"Container engine '{engine}' not found.")
-    cmd = [engine, "run", "--rm", "-v", f"{Path.cwd()}:{workdir}", "-w", workdir]
+    cmd = [engine, "run", "--rm"]
 
     if options := runtime_environment.get("options"):
         for opt in options:
-            cmd.extend(opt.split())
+            expanded_opt = os.path.expandvars(opt)
+            cmd.extend(expanded_opt.split())
 
     if env := runtime_environment.get("environment_file"):
         cmd += ["--env-file", env]

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -198,12 +198,7 @@ def _copy_pattern_files(pattern, source_directories, destination, overwrite_file
 
 
 def _collect_source_directories(configurations, source_directory=None):
-    """Return unique source directories from application configurations.
-
-    ``source_directory`` selects application configuration keys containing
-    directories to search. It can be a string or a list of strings and defaults
-    to ``output_path``.
-    """
+    """Return unique source directories from application configurations."""
     source_directories = []
     source_directory_keys = _normalize_collection_source_directories(source_directory)
     for config in configurations:
@@ -577,7 +572,7 @@ def _set_input_output_directories(path):
             f"using fallback '{setting_workflow}'"
         )
 
-    output_path = Path("output") / Path(setting_workflow)
+    output_path = Path("simtools-output") / Path(setting_workflow)
     return output_path, setting_workflow
 
 

--- a/src/simtools/testing/resource_generation.py
+++ b/src/simtools/testing/resource_generation.py
@@ -122,6 +122,34 @@ def _get_selected_config_files(config_dir, config_file=None):
     )
 
 
+def _construct_download_url(base_url_info, base_key, path):
+    """Construct the full download URL from base URL info, base key, and path.
+
+    Parameters
+    ----------
+    base_url_info : dict
+        Dictionary containing 'url' and 'version' keys for the base URL.
+    base_key : str
+        The key identifying the base URL configuration.
+    path : str
+        The path component which may contain version placeholders.
+
+    Returns
+    -------
+    str
+        The fully constructed download URL.
+    """
+    version = base_url_info["version"]
+    placeholder = f"__{base_key.upper()}_VERSION__"
+    if placeholder in path:
+        path = path.replace(placeholder, version)
+    if version and not path.startswith(version + "/"):
+        path_with_version = version + "/" + path.lstrip("/")
+    else:
+        path_with_version = path
+    return base_url_info["url"].rstrip("/") + "/" + path_with_version.lstrip("/")
+
+
 def _validate_download_entry(entry, index):
     """Validate a download entry from YAML configuration."""
     if not isinstance(entry, dict):
@@ -192,9 +220,7 @@ def download_files(config_file, target_dir):
             raise ValueError(f"Base URL key '{base_key}' not found in base_urls configuration")
 
         base_url_info = processed_base_urls[base_key]
-        version = base_url_info["version"]
-        path_with_version = version + "/" + entry["path"].lstrip("/") if version else entry["path"]
-        url = base_url_info["url"].rstrip("/") + "/" + path_with_version.lstrip("/")
+        url = _construct_download_url(base_url_info, base_key, entry["path"])
 
         destination = Path(target_dir) / entry["target_path"]
         destination.parent.mkdir(parents=True, exist_ok=True)

--- a/src/simtools/testing/resource_generation.py
+++ b/src/simtools/testing/resource_generation.py
@@ -70,55 +70,35 @@ def get_resource_generation_directory(test_directory, simtools_version):
     return config_dir
 
 
-def run_configured_applications(
-    config_dir,
-    log_dir,
-    config_file=None,
-    ignore_runtime_environment=True,
-    overwrite_collection_files=False,
-    run_time=None,
-    runtime_environment=None,
-    replacements=None,
-):
+def run_configured_applications(args_dict, config_dir, log_dir, run_time, replacements):
     """Run all resource-generation workflows using one prepared runtime.
 
     Parameters
     ----------
+    args_dict : dict
+        Dictionary containing command line arguments.
     config_dir : str or pathlib.Path
         Directory containing the ``*.config.yml`` workflow files.
     log_dir : str or pathlib.Path
         Destination directory for one log file per workflow.
-    config_file : str or pathlib.Path or None, optional
-        Run only the selected workflow file. Relative paths are resolved either
-        from the working directory or against ``config_dir``.
-    ignore_runtime_environment : bool, optional
-        Run applications in the current environment instead of a configured runtime.
-    overwrite_collection_files : bool, optional
-        Allow collection output files to overwrite existing files.
-    run_time : list[str] or None, optional
-        Prepared runtime command reused for every workflow.
-    runtime_environment : dict or None, optional
-        Runtime-environment configuration recorded in workflow metadata.
-    replacements : dict[str, str] or None, optional
+    run_time : list or None
+        Prepared runtime command. If provided, reuse it instead of preparing
+        the runtime environment from the workflow configuration.
+    replacements : dict[str, str] or None
         Placeholders replaced recursively in each workflow configuration.
     """
-    config_dir = Path(config_dir)
-    log_dir = Path(log_dir)
-    for workflow_config in _get_selected_config_files(config_dir, config_file):
+    for workflow_config in _get_selected_config_files(config_dir, args_dict.get("config_file")):
         logger.info("Executing applications configured in %s", workflow_config)
-        args_dict = {
+        tmp_args_dict = {
             "config_file": str(workflow_config),
             "log_file": str(log_dir / f"{workflow_config.name.removesuffix('.config.yml')}.log"),
             "steps": None,
-            "ignore_runtime_environment": ignore_runtime_environment,
-            "overwrite_collection_files": overwrite_collection_files,
+            "runtime_environment": args_dict.get("runtime_environment"),
+            "ignore_runtime_environment": args_dict.get("ignore_runtime_environment", False),
+            "overwrite_collection_files": args_dict.get("overwrite_collection_files", False),
         }
-        if runtime_environment is not None:
-            args_dict["runtime_environment"] = runtime_environment
         simtools_runner.run_applications(
-            args_dict,
-            run_time=run_time,
-            replacements=replacements,
+            tmp_args_dict, run_time=run_time, replacements=replacements
         )
 
 
@@ -324,40 +304,26 @@ def validate_static_files(manifest_file):
     logger.info("Validated %d static files using %s", len(declared_files), manifest_file)
 
 
-def generate_test_resources(
-    test_directory,
-    simtools_version,
-    download_only=False,
-    test_static_files=False,
-    config_file=None,
-    runtime_environment_file=None,
-    ignore_runtime_environment=None,
-    overwrite_collection_files=False,
-):
+def generate_test_resources(args_dict, run_time=None):
     """Download inputs and run resource-generation workflows for a release.
 
     Parameters
     ----------
-    test_directory : str or pathlib.Path
-        Root directory of the ``simtools-tests`` repository.
-    simtools_version : str
-        Version directory to generate, for example ``v0.32.0``.
-    download_only : bool, optional
-        Download external files without running workflows.
-    test_static_files : bool, optional
-        Validate static files against their manifest without downloading or running workflows.
-    config_file : str or pathlib.Path or None, optional
-        Run only the selected workflow file from ``integration_tests/config_files``.
-    runtime_environment_file : str or pathlib.Path or None, optional
-        Standalone runtime-environment YAML reused for all workflows.
-    ignore_runtime_environment : bool or None, optional
-        Run in the current environment. By default, this is true when no standalone runtime is
-        provided and false when one is provided.
-    overwrite_collection_files : bool, optional
-        Allow collected files to overwrite existing files.
+    args_dict : dict
+        Dictionary containing command line arguments.
+        Optional key ``overwrite_collection_files`` (bool) allows collection
+        output files to be overwritten when different source files have the
+        same basename. Defaults to False.
+    run_time : list or None
+        Prepared runtime command. If provided, reuse it instead of preparing
+        the runtime environment from the workflow configuration.
     """
-    integration_test_dir = get_integration_test_directory(test_directory, simtools_version)
-    if test_static_files:
+    test_directory = Path(args_dict["test_directory"])
+    simtools_version = args_dict["simtools_version"]
+    integration_test_dir = get_integration_test_directory(
+        args_dict["test_directory"], args_dict["simtools_version"]
+    )
+    if args_dict.get("test_static_files"):
         validate_static_files(integration_test_dir / "static" / STATIC_MANIFEST)
         return
 
@@ -367,28 +333,15 @@ def generate_test_resources(
         "__SIMTOOLS_VERSION__": simtools_version,
     }
     downloaded_files = download_files(config_dir / "download_files.yml", integration_test_dir)
-    if download_only:
+    if args_dict.get("download_only"):
         return
-
-    if ignore_runtime_environment is None:
-        ignore_runtime_environment = runtime_environment_file is None
-
-    runtime_environment = None
-    run_time = None
-    if runtime_environment_file is not None and not ignore_runtime_environment:
-        runtime_environment, run_time = simtools_runner.prepare_runtime_environment(
-            runtime_environment_file
-        )
 
     try:
         run_configured_applications(
+            args_dict=args_dict,
             config_dir=config_dir,
             log_dir=integration_test_dir / "log_files",
-            config_file=config_file,
-            ignore_runtime_environment=ignore_runtime_environment,
-            overwrite_collection_files=overwrite_collection_files,
             run_time=run_time,
-            runtime_environment=runtime_environment,
             replacements=replacements,
         )
     finally:

--- a/src/simtools/testing/resource_generation.py
+++ b/src/simtools/testing/resource_generation.py
@@ -95,10 +95,11 @@ def run_configured_applications(args_dict, config_dir, log_dir, run_time, replac
             "config_file": str(workflow_config),
             "log_file": str(log_dir / f"{workflow_config.name.removesuffix('.config.yml')}.log"),
             "steps": None,
-            "runtime_environment": args_dict.get("runtime_environment"),
             "ignore_runtime_environment": args_dict.get("ignore_runtime_environment", False),
             "overwrite_collection_files": args_dict.get("overwrite_collection_files", False),
         }
+        if "runtime_environment" in args_dict:
+            tmp_args_dict["runtime_environment"] = args_dict["runtime_environment"]
         simtools_runner.run_applications(
             tmp_args_dict, run_time=run_time, replacements=replacements
         )

--- a/src/simtools/testing/resource_generation.py
+++ b/src/simtools/testing/resource_generation.py
@@ -87,6 +87,8 @@ def run_configured_applications(args_dict, config_dir, log_dir, run_time, replac
     replacements : dict[str, str] or None
         Placeholders replaced recursively in each workflow configuration.
     """
+    config_dir = Path(config_dir)
+    log_dir = Path(log_dir)
     for workflow_config in _get_selected_config_files(config_dir, args_dict.get("config_file")):
         logger.info("Executing applications configured in %s", workflow_config)
         tmp_args_dict = {

--- a/src/simtools/testing/resource_generation.py
+++ b/src/simtools/testing/resource_generation.py
@@ -358,7 +358,9 @@ def generate_test_resources(args_dict, run_time=None):
         "__TEST_DIRECTORY__": str(test_directory),
         "__SIMTOOLS_VERSION__": simtools_version,
     }
-    downloaded_files = download_files(config_dir / "download_files.yml", integration_test_dir)
+    downloaded_files = []
+    if not args_dict.get("config_file"):
+        downloaded_files = download_files(config_dir / "download_files.yml", integration_test_dir)
     if args_dict.get("download_only"):
         return
 

--- a/tests/unit_tests/applications/test_run_application.py
+++ b/tests/unit_tests/applications/test_run_application.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 
 import argparse
-from pathlib import Path
 from types import SimpleNamespace
-
-import pytest
 
 from simtools.applications import run_application
 
 
-def test_add_arguments_runtime_environment_file():
+def test_add_arguments():
+    """Test that _add_arguments only adds config_file and steps arguments."""
     parser = argparse.ArgumentParser()
 
     run_application._add_arguments(parser)
@@ -17,31 +15,28 @@ def test_add_arguments_runtime_environment_file():
         [
             "--config_file",
             "config.yml",
-            "--runtime_environment_file",
-            "run_time.yml",
+            "--steps",
+            "1",
+            "2",
         ]
     )
 
-    assert args.runtime_environment_file == Path("run_time.yml")
+    assert args.config_file == "config.yml"
+    assert args.steps == [1, 2]
 
 
-def test_main_uses_runtime_environment_file(monkeypatch):
+def test_main_pass_args_to_run_applications(monkeypatch):
+    """Test that main passes arguments and run_time to run_applications."""
     args = {
         "config_file": "config.yml",
-        "ignore_runtime_environment": False,
-        "runtime_environment_file": Path("run_time.yml"),
+        "steps": [1, 2],
     }
     calls = {}
 
     monkeypatch.setattr(
         run_application,
         "build_application",
-        lambda **_: SimpleNamespace(args=args),
-    )
-    monkeypatch.setattr(
-        run_application,
-        "prepare_runtime_environment",
-        lambda runtime_file: ({"image": f"image-from-{runtime_file}"}, ["runtime", "image"]),
+        lambda **_: SimpleNamespace(args=args, run_time=["mock", "runtime"]),
     )
 
     def _fake_run_applications(app_args, run_time=None):
@@ -52,27 +47,21 @@ def test_main_uses_runtime_environment_file(monkeypatch):
 
     run_application.main()
 
-    assert calls["app_args"]["runtime_environment"] == {"image": "image-from-run_time.yml"}
-    assert calls["run_time"] == ["runtime", "image"]
+    assert calls["app_args"] == args
+    assert calls["run_time"] == ["mock", "runtime"]
 
 
-def test_main_ignores_runtime_environment_file_when_requested(monkeypatch):
+def test_main_handles_none_run_time(monkeypatch):
+    """Test that main handles the case where run_time is None."""
     args = {
         "config_file": "config.yml",
-        "ignore_runtime_environment": True,
-        "runtime_environment_file": Path("run_time.yml"),
     }
     calls = {}
 
     monkeypatch.setattr(
         run_application,
         "build_application",
-        lambda **_: SimpleNamespace(args=args),
-    )
-    monkeypatch.setattr(
-        run_application,
-        "prepare_runtime_environment",
-        lambda _: pytest.fail("should not prepare runtime"),
+        lambda **_: SimpleNamespace(args=args, run_time=None),
     )
 
     def _fake_run_applications(app_args, run_time=None):
@@ -83,5 +72,5 @@ def test_main_ignores_runtime_environment_file_when_requested(monkeypatch):
 
     run_application.main()
 
-    assert "runtime_environment" not in calls["app_args"]
+    assert calls["app_args"] == args
     assert calls["run_time"] is None

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -269,6 +269,7 @@ def test_initialize_default_arguments():
             "configuration",
             "execution",
             "user",
+            "run time",
         ]
 
     _parser_2 = parser.CommandLineParser()

--- a/tests/unit_tests/runners/test_simtools_runner.py
+++ b/tests/unit_tests/runners/test_simtools_runner.py
@@ -84,7 +84,15 @@ def _patch_run_applications_dependencies(
 ):
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(
+            return_value=(
+                mock_configurations,
+                None,
+                log_file_path,
+                "wf-activity-id",
+                collection_config,
+            )
+        ),
     )
     if collection_config is not None:
         monkeypatch.setattr(
@@ -120,13 +128,13 @@ def _runner_args(config_file="dummy_config.yml", steps=None, ignore_runtime_envi
 def test_set_input_output_directories():
     path = "input/LSTN-01/pm_photoelectron_spectrum/20250304T073000/config.yml"
     output_path, setting_workflow = simtools_runner._set_input_output_directories(path)
-    assert str(output_path) == "output/LSTN-01/pm_photoelectron_spectrum/20250304T073000"
+    assert str(output_path) == "simtools-output/LSTN-01/pm_photoelectron_spectrum/20250304T073000"
 
     assert setting_workflow == "LSTN-01/pm_photoelectron_spectrum/20250304T073000"
 
     path = "tests/config_files/application_config/config.yml"
     output_path, setting_workflow = simtools_runner._set_input_output_directories(path)
-    assert str(output_path) == "output/tests/config_files/application_config"
+    assert str(output_path) == "simtools-output/tests/config_files/application_config"
     assert setting_workflow == "tests/config_files/application_config"
 
 
@@ -230,7 +238,7 @@ def test_read_application_configuration_applies_replacements(monkeypatch, tmp_te
         },
     )
 
-    configurations, _, _, _ = simtools_runner._read_application_configuration(
+    configurations, _, _, _, _ = simtools_runner._read_application_configuration(
         "workflow.config.yml",
         steps=None,
         replacements={
@@ -264,7 +272,7 @@ def test_read_application_configuration_selected_steps(
         lambda config, output_path, setting_workflow: {**config, "output_path": str(output_path)},
     )
 
-    configs, _, _, workflow_activity_id = simtools_runner._read_application_configuration(
+    configs, _, _, workflow_activity_id, _ = simtools_runner._read_application_configuration(
         DUMMY_CONFIG_FILE, [2], mock_logger
     )
     assert configs[0]["run_application"] is False
@@ -293,7 +301,7 @@ def test_read_application_configuration_empty_applications(
         lambda config, output_path, setting_workflow: config,
     )
 
-    configs, _, log_file, workflow_activity_id = simtools_runner._read_application_configuration(
+    configs, _, log_file, workflow_activity_id, _ = simtools_runner._read_application_configuration(
         DUMMY_CONFIG_FILE, None, mock_logger
     )
     assert configs == []
@@ -322,7 +330,7 @@ def test_read_application_configuration_uses_first_app_output_path_for_log(
         lambda config, output_path, setting_workflow: config,
     )
 
-    _, _, log_file, _ = simtools_runner._read_application_configuration(
+    _, _, log_file, _, _ = simtools_runner._read_application_configuration(
         DUMMY_CONFIG_FILE, None, mock_logger
     )
     assert log_file == Path("my-output") / "simtools.log"
@@ -350,7 +358,7 @@ def test_read_application_configuration_falls_back_to_derived_path_when_first_ap
         },
     )
 
-    _, _, log_file, _ = simtools_runner._read_application_configuration(
+    _, _, log_file, _, _ = simtools_runner._read_application_configuration(
         DUMMY_CONFIG_FILE, None, mock_logger
     )
     assert log_file == Path("output/test_workflow") / "simtools.log"
@@ -399,7 +407,7 @@ def test_run_applications_runs_and_logs(monkeypatch, tmp_test_directory):
     # Patch _read_application_configuration
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id", None)),
     )
     workflow_build_mock = mock.Mock(return_value={"id": "wf-activity-id"})
     workflow_update_mock = mock.Mock()
@@ -465,7 +473,7 @@ def test_run_applications_uses_log_file_override(monkeypatch, tmp_test_directory
     monkeypatch.setattr(
         simtools_runner,
         "_read_application_configuration",
-        mock.Mock(return_value=([], None, default_log, "wf-activity-id")),
+        mock.Mock(return_value=([], None, default_log, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         simtools_runner.ascii_handler,
@@ -508,7 +516,7 @@ def test_run_applications_propagates_ignore_existing_parameter_version(
 
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         "simtools.dependencies.get_version_string",
@@ -666,7 +674,7 @@ def test_run_applications_passes_workflow_instrument_context(monkeypatch, tmp_te
 
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         "simtools.dependencies.get_version_string",
@@ -717,7 +725,7 @@ def test_run_applications_retries_metadata_file_detection_after_submit(
 
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         "simtools.dependencies.get_version_string",
@@ -768,7 +776,7 @@ def test_run_applications_handles_job_execution_exception(monkeypatch, tmp_test_
 
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=(mock_configurations, None, log_file_path, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         "simtools.dependencies.get_version_string",
@@ -812,15 +820,10 @@ def test_read_runtime_environment_with_full_options(monkeypatch):
         "container_engine": common_container_engine,
         "options": common_options,
     }
-    workdir = TEST_WORKDIR
     expected_command = [
         common_container_engine,
         "run",
         "--rm",
-        "-v",
-        f"{Path.cwd()}:{workdir}",
-        "-w",
-        workdir,
         *common_options,
         "--env-file",
         common_env_file,
@@ -832,11 +835,11 @@ def test_read_runtime_environment_with_full_options(monkeypatch):
     with pytest.raises(
         RuntimeError, match=f"Container engine '{common_container_engine}' not found."
     ):
-        simtools_runner.read_runtime_environment(runtime_environment, workdir)
+        simtools_runner.read_runtime_environment(runtime_environment)
 
     monkeypatch.setattr(shutil, "which", mock.Mock(return_value="podman"))
     monkeypatch.setattr("simtools.runners.simtools_runner._pull_image", mock.Mock())
-    result = simtools_runner.read_runtime_environment(runtime_environment, workdir)
+    result = simtools_runner.read_runtime_environment(runtime_environment)
 
     assert result == expected_command
 
@@ -848,25 +851,19 @@ def test_read_runtime_environment_with_minimal_options(monkeypatch):
     }
     monkeypatch.setattr(shutil, "which", mock.Mock(return_value="docker"))
     monkeypatch.setattr("simtools.runners.simtools_runner._pull_image", mock.Mock())
-    workdir = TEST_WORKDIR
     expected_command = [
         "docker",
         "run",
         "--rm",
-        "-v",
-        f"{Path.cwd()}:{workdir}",
-        "-w",
-        workdir,
         runtime_environment["image"],
     ]
-    result = simtools_runner.read_runtime_environment(runtime_environment, workdir)
+    result = simtools_runner.read_runtime_environment(runtime_environment)
     assert result == expected_command
 
 
 def test_read_runtime_environment_with_no_runtime_environment():
     runtime_environment = None
-    workdir = TEST_WORKDIR
-    result = simtools_runner.read_runtime_environment(runtime_environment, workdir)
+    result = simtools_runner.read_runtime_environment(runtime_environment)
     assert result == []
 
 
@@ -944,20 +941,15 @@ def test_read_runtime_environment_with_missing_options(monkeypatch):
     }
     monkeypatch.setattr(shutil, "which", mock.Mock(return_value="docker"))
     monkeypatch.setattr("simtools.runners.simtools_runner._pull_image", mock.Mock())
-    workdir = TEST_WORKDIR
     expected_command = [
         "docker",
         "run",
         "--rm",
-        "-v",
-        f"{Path.cwd()}:{workdir}",
-        "-w",
-        workdir,
         "--network",
         runtime_environment["network"],
         runtime_environment["image"],
     ]
-    result = simtools_runner.read_runtime_environment(runtime_environment, workdir)
+    result = simtools_runner.read_runtime_environment(runtime_environment)
     assert result == expected_command
 
 
@@ -981,7 +973,13 @@ def test_run_applications_with_runtime_environment_ignored(monkeypatch, tmp_test
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
         mock.Mock(
-            return_value=(mock_configurations, runtime_environment, log_file_path, "wf-activity-id")
+            return_value=(
+                mock_configurations,
+                runtime_environment,
+                log_file_path,
+                "wf-activity-id",
+                None,
+            )
         ),
     )
     monkeypatch.setattr(
@@ -1040,10 +1038,6 @@ def test_read_runtime_environment_with_environment_file_and_options(monkeypatch)
         "podman",
         "run",
         "--rm",
-        "-v",
-        f"{Path.cwd()}:/workdir/external/",
-        "-w",
-        "/workdir/external/",
         "--privileged",
         "--user",
         "root",
@@ -1066,7 +1060,7 @@ def test_run_applications_with_empty_configuration_list(monkeypatch, tmp_test_di
 
     monkeypatch.setattr(
         "simtools.runners.simtools_runner._read_application_configuration",
-        mock.Mock(return_value=([], None, log_file_path, "wf-activity-id")),
+        mock.Mock(return_value=([], None, log_file_path, "wf-activity-id", None)),
     )
     monkeypatch.setattr(
         "simtools.dependencies.get_version_string",
@@ -1236,7 +1230,7 @@ def test_read_application_configuration_prefers_path_uuid7(
         lambda config, output_path, setting_workflow: config,
     )
 
-    _, _, _, workflow_activity_id = simtools_runner._read_application_configuration(
+    _, _, _, workflow_activity_id, _ = simtools_runner._read_application_configuration(
         configuration_file,
         steps=None,
         workflow_activity_id="generated-by-run-application",
@@ -1272,7 +1266,7 @@ def test_read_application_configuration_ignores_top_level_activity_id(
         lambda config, output_path, setting_workflow: config,
     )
 
-    _, _, _, workflow_activity_id = simtools_runner._read_application_configuration(
+    _, _, _, workflow_activity_id, _ = simtools_runner._read_application_configuration(
         configuration_file,
         steps=None,
         workflow_activity_id="generated-by-run-application",

--- a/tests/unit_tests/test_application_control.py
+++ b/tests/unit_tests/test_application_control.py
@@ -371,6 +371,47 @@ def test_startup_application_without_resolving_sim_software_executables():
     )
 
 
+def test_startup_application_prepares_runtime_environment_from_cli():
+    """Test startup_application prepares runtime environment from CLI file argument."""
+    mock_args_dict = {
+        "log_level": "info",
+        "runtime_environment_file": Path("runtime.yml"),
+        "ignore_runtime_environment": False,
+    }
+    mock_db_config = {}
+    mock_parse_function = MagicMock(return_value=(mock_args_dict, mock_db_config))
+
+    with patch(
+        "simtools.application_control.prepare_runtime_environment",
+        return_value=({"image": "test-image"}, ["podman", "run"]),
+    ) as mock_prepare:
+        app_context = startup_application(mock_parse_function, setup_io_handler=False)
+
+    mock_prepare.assert_called_once_with(Path("runtime.yml"))
+    assert app_context.run_time == ["podman", "run"]
+    assert app_context.args["runtime_environment"] == {"image": "test-image"}
+    assert app_context.args["run_time"] == ["podman", "run"]
+
+
+def test_startup_application_runtime_environment_ignored_from_cli():
+    """Test startup_application ignores runtime environment when requested by CLI flag."""
+    mock_args_dict = {
+        "log_level": "info",
+        "runtime_environment_file": Path("runtime.yml"),
+        "ignore_runtime_environment": True,
+    }
+    mock_db_config = {}
+    mock_parse_function = MagicMock(return_value=(mock_args_dict, mock_db_config))
+
+    with patch("simtools.application_control.prepare_runtime_environment") as mock_prepare:
+        app_context = startup_application(mock_parse_function, setup_io_handler=False)
+
+    mock_prepare.assert_not_called()
+    assert app_context.run_time is None
+    assert "runtime_environment" not in app_context.args
+    assert "run_time" not in app_context.args
+
+
 def test_resolve_model_version_to_latest_patch_no_model_version():
     """Test _resolve_model_version_to_latest_patch when model_version is not in args."""
 

--- a/tests/unit_tests/testing/test_resource_generation.py
+++ b/tests/unit_tests/testing/test_resource_generation.py
@@ -136,8 +136,10 @@ def test_run_configured_applications_runs_all_configs(tmp_test_directory, monkey
     )
 
     resource_generation.run_configured_applications(
+        args_dict={},
         config_dir=config_root,
         log_dir=Path(tmp_test_directory) / "log_files",
+        run_time=None,
         replacements={"__SIMTOOLS_VERSION__": "v0.32.0"},
     )
 
@@ -170,12 +172,15 @@ def test_run_configured_applications_reuses_runtime(tmp_test_directory, monkeypa
     )
 
     resource_generation.run_configured_applications(
+        args_dict={
+            "ignore_runtime_environment": False,
+            "overwrite_collection_files": True,
+            "runtime_environment": {"image": "image"},
+        },
         config_dir=config_root,
         log_dir=Path(tmp_test_directory) / "log_files",
-        ignore_runtime_environment=False,
-        overwrite_collection_files=True,
         run_time=["podman", "run", "image"],
-        runtime_environment={"image": "image"},
+        replacements=None,
     )
 
     assert [config[0]["config_file"] for config in called_configs] == [str(model_config)]
@@ -206,9 +211,13 @@ def test_run_configured_applications_selects_one_config_by_path(tmp_test_directo
     )
 
     resource_generation.run_configured_applications(
+        args_dict={
+            "config_file": Path("application_config") / "simulate_prod.config.yml",
+        },
         config_dir=config_root,
         log_dir=Path(tmp_test_directory) / "log_files",
-        config_file=Path("application_config") / "simulate_prod.config.yml",
+        run_time=None,
+        replacements=None,
     )
 
     assert [config[0]["config_file"] for config in called_configs] == [
@@ -222,9 +231,13 @@ def test_run_configured_applications_raises_for_missing_selected_config(tmp_test
 
     with pytest.raises(FileNotFoundError, match="Selected workflow config does not exist"):
         resource_generation.run_configured_applications(
+            args_dict={
+                "config_file": Path("missing.config.yml"),
+            },
             config_dir=config_root,
             log_dir=Path(tmp_test_directory) / "log_files",
-            config_file=Path("missing.config.yml"),
+            run_time=None,
+            replacements=None,
         )
 
 
@@ -401,9 +414,11 @@ def test_generate_test_resources_tests_static_files_only(tmp_test_directory, mon
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
-        test_static_files=True,
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+            "test_static_files": True,
+        }
     )
 
     assert calls == [manifest]
@@ -429,9 +444,11 @@ def test_generate_test_resources_download_only_does_not_run_applications(
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
-        download_only=True,
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+            "download_only": True,
+        }
     )
 
     assert called == []
@@ -447,7 +464,6 @@ def test_generate_test_resources_prepares_shared_runtime_once(tmp_test_directory
     )
     config_dir.mkdir(parents=True)
     (config_dir / "download_files.yml").write_text("files: []\n", encoding="utf-8")
-    runtime_file = Path(tmp_test_directory) / "runtime.yml"
     prepare_mock = []
     run_calls = []
 
@@ -465,14 +481,14 @@ def test_generate_test_resources_prepares_shared_runtime_once(tmp_test_directory
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
-        runtime_environment_file=runtime_file,
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+        },
+        run_time=["podman", "run", "image"],
     )
 
-    assert prepare_mock == [runtime_file]
     assert len(run_calls) == 1
-    assert run_calls[0]["ignore_runtime_environment"] is False
     assert run_calls[0]["run_time"] == ["podman", "run", "image"]
 
 
@@ -496,13 +512,15 @@ def test_generate_test_resources_forwards_selected_config_file(tmp_test_director
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
-        config_file=selected_config,
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+            "config_file": selected_config,
+        }
     )
 
     assert len(run_calls) == 1
-    assert run_calls[0]["config_file"] == selected_config
+    assert run_calls[0]["args_dict"]["config_file"] == selected_config
 
 
 def test_generate_test_resources_ignores_supplied_runtime(tmp_test_directory, monkeypatch):
@@ -528,14 +546,15 @@ def test_generate_test_resources_ignores_supplied_runtime(tmp_test_directory, mo
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
-        runtime_environment_file=Path(tmp_test_directory) / "runtime.yml",
-        ignore_runtime_environment=True,
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+            "ignore_runtime_environment": True,
+        }
     )
 
     assert len(run_calls) == 1
-    assert run_calls[0]["ignore_runtime_environment"] is True
+    assert run_calls[0]["args_dict"]["ignore_runtime_environment"] is True
     assert run_calls[0]["run_time"] is None
 
 
@@ -588,8 +607,10 @@ def test_generate_test_resources_removes_empty_download_directory(tmp_test_direc
     )
 
     resource_generation.generate_test_resources(
-        test_directory=tmp_test_directory,
-        simtools_version="v0.32.0",
+        args_dict={
+            "test_directory": tmp_test_directory,
+            "simtools_version": "v0.32.0",
+        }
     )
 
     assert not (integration_test_dir / "folder").exists()


### PR DESCRIPTION
Enable `---runtime_environment_file` setting of run time environment (e.g., a container environment) with correct path settings for test resource generation and generic application running.

Allows e.g. to generate test resources with:

```
simtools-generate-test-resources --test_directory . --simtools_version v0.33.0 \
     --runtime_environment_file simtools-tests/v0.33.0/integration_tests/run_time.yml \
     --overwrite_collection_files
```

with the run time defined as

```
---
runtime_environment:
  container_engine: podman
  image: ghcr.io/gammasim/simtools-prod:v0.33.0-v78010-v2025-11-30-rc-generic
  network: simtools-mongo-network
  environment_file: .env
  options:
    - "--arch amd64"
    - "-v $PWD/..:/workdir/external/:ro"
    - "-v $PWD/simtools-tests:/workdir/simtools-tests"
```

This will allow to e.g. generate consistently test resources using a given image.