### PR TITLE
Small fix of constant values for derive corsika limits

### DIFF
--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -561,15 +561,15 @@ def _compute_limits(histograms, allowed_losses, bins_per_decade):
     }
 
 
-def _get_constant_data_value(histograms, name):
+def _get_constant_data_value(histograms, name, abs_tol=0.01):
     """Return an event-data value when its accumulated range is constant."""
     data_ranges = getattr(histograms, "data_ranges", None)
     if not isinstance(data_ranges, dict) or name not in data_ranges:
         return None
 
     minimum, maximum = data_ranges[name]
-    if np.isclose(minimum, maximum, rtol=1.0e-12, atol=1.0e-12):
-        return float(minimum)
+    if np.isclose(minimum, maximum, rtol=0, atol=abs_tol):
+        return float(minimum) if minimum > abs_tol else 0.0
     return None
 
 

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -569,7 +569,8 @@ def _get_constant_data_value(histograms, name, abs_tol=0.01):
 
     minimum, maximum = data_ranges[name]
     if np.isclose(minimum, maximum, rtol=0, atol=abs_tol):
-        return float(minimum) if minimum > abs_tol else 0.0
+        avg_value = (minimum + maximum) / 2.0
+        return float(avg_value) if avg_value > abs_tol else 0.0
     return None
 
 

--- a/src/simtools/runners/simtools_runner.py
+++ b/src/simtools/runners/simtools_runner.py
@@ -48,8 +48,10 @@ def run_applications(args_dict, run_time=None, replacements=None):
         args_dict.get("activity_id"),
         replacements=replacements,
     )
-    log_file = args_dict.get("log_file", log_file)
-    runtime_environment = args_dict.get("runtime_environment", runtime_environment)
+    if args_dict.get("log_file") is not None:
+        log_file = args_dict["log_file"]
+    if args_dict.get("runtime_environment") is not None:
+        runtime_environment = args_dict["runtime_environment"]
 
     workflow_start = datetime.now(UTC)
     associated_activities = []

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -823,6 +823,26 @@ def test_compute_limits_uses_exact_constant_angular_distance(mocker):
     assert result["angular_distance_vs_energy_curve"] == {"x": [0.0, 0.0], "y": [1.0, 10.0]}
 
 
+def test_get_constant_data_value():
+    """Return the constant value only when the stored range is effectively flat."""
+    histograms = type(
+        "HistogramContainer",
+        (),
+        {
+            "data_ranges": {
+                "angular_distance": (1.0, 1.0 + 1.0e-13),
+                "core_distance": (1.0, 2.0),
+            }
+        },
+    )()
+
+    assert derive_corsika_limits._get_constant_data_value(
+        histograms, "angular_distance"
+    ) == pytest.approx(1.0)
+    assert derive_corsika_limits._get_constant_data_value(histograms, "core_distance") is None
+    assert derive_corsika_limits._get_constant_data_value(histograms, "missing") is None
+
+
 def test_constant_angular_distance_is_not_rounded_in_results_table(mock_results):
     """Preserve the raw constant value instead of rounding to viewcone increments."""
     mock_results[0]["viewcone_radius"] = 0.1 * u.deg

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits.py
@@ -831,6 +831,8 @@ def test_get_constant_data_value():
         {
             "data_ranges": {
                 "angular_distance": (1.0, 1.0 + 1.0e-13),
+                "angular_distance_near_zero": (0.0, 1.0e-12),
+                "angular_distance_small": (0.009, 0.018),
                 "core_distance": (1.0, 2.0),
             }
         },
@@ -839,6 +841,12 @@ def test_get_constant_data_value():
     assert derive_corsika_limits._get_constant_data_value(
         histograms, "angular_distance"
     ) == pytest.approx(1.0)
+    assert derive_corsika_limits._get_constant_data_value(
+        histograms, "angular_distance_near_zero"
+    ) == pytest.approx(0.0)
+    assert derive_corsika_limits._get_constant_data_value(
+        histograms, "angular_distance_small"
+    ) == pytest.approx(0.0135)
     assert derive_corsika_limits._get_constant_data_value(histograms, "core_distance") is None
     assert derive_corsika_limits._get_constant_data_value(histograms, "missing") is None
 

--- a/tests/unit_tests/runners/test_simtools_runner.py
+++ b/tests/unit_tests/runners/test_simtools_runner.py
@@ -499,6 +499,34 @@ def test_run_applications_uses_log_file_override(monkeypatch, tmp_test_directory
     assert not default_log.exists()
 
 
+def test_run_applications_keeps_workflow_log_file_when_cli_log_file_is_none(
+    monkeypatch, tmp_test_directory
+):
+    tmp_test_directory = Path(tmp_test_directory)
+    default_log = tmp_test_directory / "tmp_application_output" / "simtools.log"
+    monkeypatch.setattr(
+        simtools_runner,
+        "_read_application_configuration",
+        mock.Mock(return_value=([], None, default_log, "wf-activity-id", None)),
+    )
+    monkeypatch.setattr(
+        simtools_runner.dependencies,
+        "get_version_string",
+        mock.Mock(return_value=""),
+    )
+
+    simtools_runner.run_applications(
+        {
+            "config_file": "workflow.config.yml",
+            "log_file": None,
+            "steps": None,
+            "ignore_runtime_environment": True,
+        }
+    )
+
+    assert default_log.is_file()
+
+
 def test_run_applications_propagates_ignore_existing_parameter_version(
     monkeypatch, tmp_test_directory
 ):


### PR DESCRIPTION
Adjust tolerance for equel viewcone minimum/maximum detection when deriving CORSIKA limits. 

Results in zero values for point-like obervations.