### PR TITLE
Production grid validation

### DIFF
--- a/docs/changes/2327.feature.md
+++ b/docs/changes/2327.feature.md
@@ -1,0 +1,1 @@
+Add schema url to metadata of job grid table. Add functionality to `simtools-validate-file-using-schema` to read this schema from the header file.

--- a/docs/changes/2327.feature.md
+++ b/docs/changes/2327.feature.md
@@ -1,1 +1,1 @@
-Add schema url to metadata of job grid table. Add functionality to `simtools-validate-file-using-schema` to read this schema from the header file.
+Add schema URL to metadata of job grid table. Add functionality to `simtools-validate-file-using-schema` to read this schema from the header file.

--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -243,6 +243,7 @@ from simtools.production_configuration.simulation_jobs import (
     TOTAL_SHOWERS_ROUNDING_WARNINGS_MAX_DEFAULT,
     build_job_grid_metadata,
     build_simulation_jobs,
+    renumber_job_rows,
 )
 
 
@@ -405,8 +406,9 @@ def main():
         },
     )
 
+    job_rows = build_simulation_jobs(app_context.args)
     serialize_job_grid(
-        job_rows=build_simulation_jobs(app_context.args),
+        job_rows=renumber_job_rows(job_rows, app_context.args.get("run_number_offset", 0)),
         output_file=app_context.io_handler.get_output_file(app_context.args["output_file"]),
         metadata=build_job_grid_metadata(app_context.args),
     )

--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -394,13 +394,6 @@ def _add_arguments(parser):
     )
 
 
-def _renumber_job_rows(job_rows, run_number_offset):
-    """Set output run numbers continuously."""
-    for run_number, job_row in enumerate(job_rows, start=run_number_offset + 1):
-        job_row["run_number"] = run_number
-    return job_rows
-
-
 def main():
     """See CLI description."""
     app_context = build_application(
@@ -412,12 +405,8 @@ def main():
         },
     )
 
-    job_rows = _renumber_job_rows(
-        build_simulation_jobs(app_context.args),
-        run_number_offset=int(app_context.args.get("run_number_offset", 0)),
-    )
     serialize_job_grid(
-        job_rows=job_rows,
+        job_rows=build_simulation_jobs(app_context.args),
         output_file=app_context.io_handler.get_output_file(app_context.args["output_file"]),
         metadata=build_job_grid_metadata(app_context.args),
     )

--- a/src/simtools/constants.py
+++ b/src/simtools/constants.py
@@ -4,6 +4,8 @@ from importlib.resources import files
 
 # Schema path
 SCHEMA_PATH = files("simtools") / "schemas"
+# Schema URL
+SCHEMA_URL = "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas"
 # Path to metadata jsonschema
 METADATA_JSON_SCHEMA = SCHEMA_PATH / "metadata.metaschema.yml"
 # Path to plotting configuration json schema
@@ -16,17 +18,14 @@ MODEL_PARAMETER_METASCHEMA = SCHEMA_PATH / "model_parameter.metaschema.yml"
 MODEL_PARAMETER_DESCRIPTION_METASCHEMA = (
     SCHEMA_PATH / "model_parameter_and_data_schema.metaschema.yml"
 )
-# Path to sim_telarray metaparameter metaschema
+# Path to sim_telarray meta-parameter metaschema
 SIM_TELARRAY_META_PARAMETER_METASCHEMA = SCHEMA_PATH / "sim_telarray_meta_parameter.metaschema.yml"
-# Path to sim_telarray metaparameter registry
+# Path to sim_telarray meta-parameter registry
 SIM_TELARRAY_META_PARAMETER_REGISTRY = SCHEMA_PATH / "sim_telarray_meta_parameters.schema.yml"
 # Path to model parameter schema files
 MODEL_PARAMETER_SCHEMA_PATH = SCHEMA_PATH / "model_parameters"
 # URL to model parameter schema files
-MODEL_PARAMETER_SCHEMA_URL = (
-    "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/"
-    "/model_parameters"
-)
+MODEL_PARAMETER_SCHEMA_URL = SCHEMA_URL + "/model_parameters"
 # Path to resource files
 RESOURCE_PATH = files("simtools") / "resources"
 # Paths to test resources

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -514,7 +514,7 @@ def get_schema_file_from_file_metadata(file_name, observatory="cta"):
             metadata = Table.read(file_name).meta
         else:
             metadata = ascii_handler.collect_data_from_file(file_name=file_name, yaml_document=0)
-    except (FileNotFoundError, OSError):
+    except OSError:
         return None
 
     return _extract_schema_url_from_metadata_dict(metadata, observatory)

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from pathlib import Path
 
 import jsonschema
+from astropy.table import Table
 from referencing import Registry, Resource
 
 import simtools.utils.general as gen
@@ -477,7 +478,7 @@ def _get_schema_file_name(schema_file=None, file_name=None, data_dict=None):
             return url
 
     if file_name:
-        return _extract_schema_from_file(file_name)
+        return get_schema_file_from_file_metadata(file_name)
 
     return None
 
@@ -491,7 +492,7 @@ def _extract_schema_url_from_metadata_dict(metadata, observatory="cta"):
     return None
 
 
-def _extract_schema_from_file(file_name, observatory="cta"):
+def get_schema_file_from_file_metadata(file_name, observatory="cta"):
     """
     Extract schema file name from a metadata or data file.
 
@@ -509,8 +510,11 @@ def _extract_schema_from_file(file_name, observatory="cta"):
 
     """
     try:
-        metadata = ascii_handler.collect_data_from_file(file_name=file_name, yaml_document=0)
-    except FileNotFoundError:
+        if Path(file_name).suffix.lower() == ".ecsv":
+            metadata = Table.read(file_name).meta
+        else:
+            metadata = ascii_handler.collect_data_from_file(file_name=file_name, yaml_document=0)
+    except (FileNotFoundError, OSError):
         return None
 
     return _extract_schema_url_from_metadata_dict(metadata, observatory)

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -190,7 +190,11 @@ class DataValidator:
 
         for data_file in file_list:
             parameter_name = re.sub(r"-\d+\.\d+\.\d+", "", data_file.stem)
-            schema_path = schema_file or schema.get_model_parameter_schema_file(f"{parameter_name}")
+            schema_path = schema_file or (
+                schema.get_model_parameter_schema_file(f"{parameter_name}")
+                if is_model_parameter
+                else schema.get_schema_file_from_file_metadata(data_file)
+            )
             data_validator = DataValidator(
                 schema_file=schema_path,
                 data_file=data_file,

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -193,7 +193,10 @@ class DataValidator:
             schema_path = schema_file or (
                 schema.get_model_parameter_schema_file(f"{parameter_name}")
                 if is_model_parameter
-                else schema.get_schema_file_from_file_metadata(data_file)
+                else (
+                    schema.get_schema_file_from_file_metadata(data_file)
+                    or schema.get_model_parameter_schema_file(f"{parameter_name}")
+                )
             )
             data_validator = DataValidator(
                 schema_file=schema_path,

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -2,7 +2,6 @@
 
 import logging
 from dataclasses import dataclass
-from io import StringIO
 from pathlib import Path
 
 import numpy as np
@@ -10,6 +9,7 @@ from astropy import units as u
 from astropy.table import Table
 
 from simtools.constants import SCHEMA_PATH
+from simtools.data_model import validate_data
 from simtools.io.ascii_handler import collect_data_from_file
 from simtools.production_configuration.job_grid_summary import build_job_grid_summary
 from simtools.utils.value_conversion import get_value_as_quantity, get_value_in_unit
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
-_STREAM_CHUNK_SIZE = 10_000
 _JOB_GRID_SCHEMA_FILE = SCHEMA_PATH / "job_grid_density.schema.yml"
 _JOB_GRID_SCHEMA_URL = (
     "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/"
@@ -99,6 +98,17 @@ def _add_job_grid_schema_metadata(metadata):
     return metadata
 
 
+def _validate_job_grid_table(table):
+    """Validate a job-grid table against the job-grid schema."""
+    if len(table) == 0:
+        return table
+    validate_data.DataValidator(
+        schema_file=_JOB_GRID_SCHEMA_FILE,
+        data_table=table.copy(copy_data=True),
+    ).validate_and_transform()
+    return table
+
+
 def serialize_job_grid(job_rows, output_file, metadata=None):
     """
     Serialize executable job rows to ECSV output.
@@ -128,141 +138,23 @@ def serialize_job_grid(job_rows, output_file, metadata=None):
     ]
 
     output_table = _build_output_table(output_rows, output_columns, metadata)
+    _validate_job_grid_table(output_table)
     logger.info(f"Writing job grid with {len(job_rows)} rows to '{output_path}'.")
     output_table.write(output_path, format=_ECSV_FORMAT, overwrite=True)
 
 
 def _build_output_table(output_rows, output_columns, metadata=None):
     """Build an Astropy table for serialized output rows."""
-    output_table = Table(rows=output_rows, names=output_columns)
+    output_table = Table(
+        rows=[tuple(row[column] for column in output_columns) for row in output_rows],
+        names=output_columns,
+        dtype=[JOB_GRID_SCHEMA.column_dtypes[column] for column in output_columns],
+    )
     for column_name, unit in JOB_GRID_SCHEMA.column_units.items():
         if column_name in output_table.colnames:
             output_table[column_name].unit = unit
     output_table.meta = metadata or {}
     return output_table
-
-
-def _write_empty_ecsv_header(output_path, output_columns, metadata):
-    """Write an ECSV header using Astropy's schema/metadata handling."""
-    empty_table = Table(
-        names=output_columns,
-        dtype=[JOB_GRID_SCHEMA.column_dtypes[column] for column in output_columns],
-    )
-    for column_name, unit in JOB_GRID_SCHEMA.column_units.items():
-        empty_table[column_name].unit = unit
-    empty_table.meta = metadata
-    empty_table.write(output_path, format=_ECSV_FORMAT, overwrite=True)
-
-
-def _extract_ecsv_data_rows(table):
-    """Return Astropy-formatted ECSV data rows without metadata or column header."""
-    buffer = StringIO()
-    table.write(buffer, format=_ECSV_FORMAT)
-    data_rows = []
-    column_header_seen = False
-    for line in buffer.getvalue().splitlines():
-        if line.startswith("#"):
-            continue
-        if not column_header_seen:
-            column_header_seen = True
-            continue
-        data_rows.append(line)
-    return data_rows
-
-
-def _write_ecsv_data_rows(output_path, output_rows, output_columns):
-    """Append Astropy-formatted ECSV data rows to an existing ECSV file."""
-    output_table = _build_output_table(output_rows, output_columns)
-    data_rows = _extract_ecsv_data_rows(output_table)
-    with output_path.open("a", encoding="utf-8") as output:
-        for row in data_rows:
-            output.write(f"{row}\n")
-
-
-def _flush_stream_chunk(output_path, output_rows, output_columns, metadata, write_header):
-    """Write or append one chunk of serialized output rows."""
-    if write_header:
-        output_table = _build_output_table(output_rows, output_columns, metadata)
-        output_table.write(output_path, format=_ECSV_FORMAT, overwrite=True)
-    else:
-        _write_ecsv_data_rows(output_path, output_rows, output_columns)
-
-
-def _iter_with_first(first_row, row_iterator):
-    """Iterate over the first row followed by the remaining row iterator."""
-    yield first_row
-    yield from row_iterator
-
-
-def serialize_job_grid_stream(job_rows, output_file, metadata=None):
-    """
-    Stream executable job rows to ECSV output.
-
-    This avoids materializing serialized rows and the full Astropy table in memory.
-    All coordinate columns are required so every row carries HA/Dec and Az/Ze.
-
-    Parameters
-    ----------
-    job_rows : iterable of dict
-        Job rows in the in-memory schema.
-    output_file : str or pathlib.Path
-        Output file path. Must use the ``.ecsv`` suffix.
-    metadata : dict, optional
-        Metadata to store alongside the rows.
-
-    Returns
-    -------
-    int
-        Number of rows written to the output file.
-    """
-    output_path = Path(output_file)
-    metadata = metadata.copy() if metadata else {}
-    _add_job_grid_schema_metadata(metadata)
-    metadata["job_grid_format_version"] = JOB_GRID_SCHEMA.version
-
-    if output_path.suffix.lower() != _ECSV_SUFFIX:
-        raise ValueError("Job grid output file must use the '.ecsv' extension.")
-
-    row_iterator = iter(job_rows)
-    try:
-        first_row = next(row_iterator)
-    except StopIteration:
-        _write_empty_ecsv_header(output_path, JOB_GRID_SCHEMA.columns, metadata)
-        logger.info(f"Writing job grid with 0 rows to '{output_path}'.")
-        return 0
-
-    serialized_first_row = _serialize_job_row(first_row)
-    output_columns = JOB_GRID_SCHEMA.columns
-
-    output_rows = []
-    row_count = 0
-    write_header = True
-    serialized_rows = _iter_with_first(serialized_first_row, map(_serialize_job_row, row_iterator))
-    for serialized_row in serialized_rows:
-        output_rows.append({column: serialized_row.get(column) for column in output_columns})
-        row_count += 1
-        if len(output_rows) >= _STREAM_CHUNK_SIZE:
-            _flush_stream_chunk(
-                output_path,
-                output_rows,
-                output_columns,
-                metadata,
-                write_header=write_header,
-            )
-            output_rows = []
-            write_header = False
-
-    if output_rows:
-        _flush_stream_chunk(
-            output_path,
-            output_rows,
-            output_columns,
-            metadata,
-            write_header=write_header,
-        )
-
-    logger.info(f"Writing job grid with {row_count} rows to '{output_path}'.")
-    return row_count
 
 
 def read_job_grid(input_file):
@@ -284,7 +176,7 @@ def read_job_grid(input_file):
     if input_path.suffix.lower() != _ECSV_SUFFIX:
         raise ValueError("Job grid input file must use the '.ecsv' extension.")
 
-    table = Table.read(input_path, format=_ECSV_FORMAT)
+    table = _validate_job_grid_table(Table.read(input_path, format=_ECSV_FORMAT))
     rows = [{column_name: row[column_name] for column_name in table.colnames} for row in table]
     column_units = {column_name: table[column_name].unit for column_name in table.colnames}
     return [_deserialize_job_row(row, column_units) for row in rows], dict(table.meta)

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -20,6 +20,10 @@ _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
 _STREAM_CHUNK_SIZE = 10_000
 _JOB_GRID_SCHEMA_FILE = SCHEMA_PATH / "job_grid_density.schema.yml"
+_JOB_GRID_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/"
+    "job_grid_density.schema.yml"
+)
 
 
 @dataclass(frozen=True)
@@ -87,6 +91,14 @@ def _deserialize_job_row(serialized_row, column_units=None):
     }
 
 
+def _add_job_grid_schema_metadata(metadata):
+    """Add schema reference metadata used for validation."""
+    metadata.setdefault("cta", {}).setdefault("product", {}).setdefault("data", {}).setdefault(
+        "model", {}
+    )["url"] = _JOB_GRID_SCHEMA_URL
+    return metadata
+
+
 def serialize_job_grid(job_rows, output_file, metadata=None):
     """
     Serialize executable job rows to ECSV output.
@@ -103,6 +115,7 @@ def serialize_job_grid(job_rows, output_file, metadata=None):
     output_path = Path(output_file)
     serialized_rows = [_serialize_job_row(job_row) for job_row in job_rows]
     metadata = metadata.copy() if metadata else {}
+    _add_job_grid_schema_metadata(metadata)
     metadata["job_grid_format_version"] = JOB_GRID_SCHEMA.version
     metadata["job_grid_summary"] = build_job_grid_summary(job_rows)
 
@@ -204,6 +217,7 @@ def serialize_job_grid_stream(job_rows, output_file, metadata=None):
     """
     output_path = Path(output_file)
     metadata = metadata.copy() if metadata else {}
+    _add_job_grid_schema_metadata(metadata)
     metadata["job_grid_format_version"] = JOB_GRID_SCHEMA.version
 
     if output_path.suffix.lower() != _ECSV_SUFFIX:

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
-from simtools.constants import SCHEMA_PATH
+from simtools.constants import SCHEMA_PATH, SCHEMA_URL
 from simtools.data_model import validate_data
 from simtools.io.ascii_handler import collect_data_from_file
 from simtools.production_configuration.job_grid_summary import build_job_grid_summary
@@ -19,10 +19,7 @@ logger = logging.getLogger(__name__)
 _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
 _JOB_GRID_SCHEMA_FILE = SCHEMA_PATH / "job_grid_density.schema.yml"
-_JOB_GRID_SCHEMA_URL = (
-    "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/"
-    "job_grid_density.schema.yml"
-)
+_JOB_GRID_SCHEMA_URL = SCHEMA_URL + "job_grid_density.schema.yml"
 
 
 @dataclass(frozen=True)

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -99,11 +99,10 @@ def _validate_job_grid_table(table):
     """Validate a job-grid table against the job-grid schema."""
     if len(table) == 0:
         return table
-    validate_data.DataValidator(
+    return validate_data.DataValidator(
         schema_file=_JOB_GRID_SCHEMA_FILE,
         data_table=table.copy(copy_data=True),
     ).validate_and_transform()
-    return table
 
 
 def serialize_job_grid(job_rows, output_file, metadata=None):
@@ -133,9 +132,8 @@ def serialize_job_grid(job_rows, output_file, metadata=None):
     output_rows = [
         {column: row.get(column) for column in output_columns} for row in serialized_rows
     ]
-
     output_table = _build_output_table(output_rows, output_columns, metadata)
-    _validate_job_grid_table(output_table)
+    output_table = _validate_job_grid_table(output_table)
     logger.info(f"Writing job grid with {len(job_rows)} rows to '{output_path}'.")
     output_table.write(output_path, format=_ECSV_FORMAT, overwrite=True)
 

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -18,8 +18,7 @@ logger = logging.getLogger(__name__)
 
 _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
-_JOB_GRID_SCHEMA_FILE = SCHEMA_PATH / "job_grid_density.schema.yml"
-_JOB_GRID_SCHEMA_URL = SCHEMA_URL + "job_grid_density.schema.yml"
+_JOB_GRID_SCHEMA_FILE = "job_grid_density.schema.yml"
 
 
 @dataclass(frozen=True)
@@ -34,7 +33,7 @@ class JobGridSchema:
 
 def _load_job_grid_schema():
     """Load the job-grid format definition from its YAML schema."""
-    schema = collect_data_from_file(_JOB_GRID_SCHEMA_FILE)
+    schema = collect_data_from_file(SCHEMA_URL / _JOB_GRID_SCHEMA_FILE)
     table_definition = next(item for item in schema["data"] if item["type"] == "data_table")
     column_definitions = table_definition["table_columns"]
     column_units = {
@@ -91,7 +90,7 @@ def _add_job_grid_schema_metadata(metadata):
     """Add schema reference metadata used for validation."""
     metadata.setdefault("cta", {}).setdefault("product", {}).setdefault("data", {}).setdefault(
         "model", {}
-    )["url"] = _JOB_GRID_SCHEMA_URL
+    )["url"] = SCHEMA_URL + _JOB_GRID_SCHEMA_FILE
     return metadata
 
 
@@ -100,7 +99,7 @@ def _validate_job_grid_table(table):
     if len(table) == 0:
         return table
     return validate_data.DataValidator(
-        schema_file=_JOB_GRID_SCHEMA_FILE,
+        schema_file=SCHEMA_PATH / _JOB_GRID_SCHEMA_FILE,
         data_table=table.copy(copy_data=True),
     ).validate_and_transform()
 

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -33,7 +33,7 @@ class JobGridSchema:
 
 def _load_job_grid_schema():
     """Load the job-grid format definition from its YAML schema."""
-    schema = collect_data_from_file(SCHEMA_URL / _JOB_GRID_SCHEMA_FILE)
+    schema = collect_data_from_file(SCHEMA_PATH / _JOB_GRID_SCHEMA_FILE)
     table_definition = next(item for item in schema["data"] if item["type"] == "data_table")
     column_definitions = table_definition["table_columns"]
     column_units = {

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
 _JOB_GRID_SCHEMA_FILE = "job_grid_density.schema.yml"
+_JOB_GRID_SCHEMA_URL = SCHEMA_URL + "/" + _JOB_GRID_SCHEMA_FILE
 
 
 @dataclass(frozen=True)
@@ -90,14 +91,40 @@ def _add_job_grid_schema_metadata(metadata):
     """Add schema reference metadata used for validation."""
     metadata.setdefault("cta", {}).setdefault("product", {}).setdefault("data", {}).setdefault(
         "model", {}
-    )["url"] = SCHEMA_URL + "/" + _JOB_GRID_SCHEMA_FILE
+    )["url"] = _JOB_GRID_SCHEMA_URL
     return metadata
+
+
+def _normalize_job_grid_table_dtypes(table):
+    """Restore schema-declared integer dtypes after ECSV deserialization."""
+    normalized_table = table.copy(copy_data=True)
+    for column_name, expected_dtype in JOB_GRID_SCHEMA.column_dtypes.items():
+        if column_name not in normalized_table.colnames:
+            continue
+        if expected_dtype is str or not np.issubdtype(expected_dtype, np.integer):
+            continue
+
+        column = normalized_table[column_name]
+        if np.issubdtype(column.dtype, np.integer):
+            continue
+        if not np.issubdtype(column.dtype, np.floating):
+            continue
+
+        values = np.asarray(column.data)
+        if not np.all(np.isfinite(values)):
+            continue
+        if not np.allclose(values, np.round(values), rtol=0.0, atol=0.0):
+            continue
+
+        normalized_table[column_name] = np.round(values).astype(expected_dtype, copy=False)
+    return normalized_table
 
 
 def _validate_job_grid_table(table):
     """Validate a job-grid table against the job-grid schema."""
     if len(table) == 0:
         return table
+    table = _normalize_job_grid_table_dtypes(table)
     return validate_data.DataValidator(
         schema_file=SCHEMA_PATH / _JOB_GRID_SCHEMA_FILE,
         data_table=table.copy(copy_data=True),

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -90,7 +90,7 @@ def _add_job_grid_schema_metadata(metadata):
     """Add schema reference metadata used for validation."""
     metadata.setdefault("cta", {}).setdefault("product", {}).setdefault("data", {}).setdefault(
         "model", {}
-    )["url"] = SCHEMA_URL + _JOB_GRID_SCHEMA_FILE
+    )["url"] = SCHEMA_URL + "/" + _JOB_GRID_SCHEMA_FILE
     return metadata
 
 

--- a/src/simtools/production_configuration/simulation_jobs.py
+++ b/src/simtools/production_configuration/simulation_jobs.py
@@ -1319,11 +1319,25 @@ def build_simulation_jobs(args_dict):
                 )
             )
     _log_generated_row_summary(rows)
-    return _renumber_job_rows(rows, args_dict.get("run_number_offset", 0))
+    return rows
 
 
-def _renumber_job_rows(job_rows, run_number_offset):
-    """Set output run numbers continuously."""
+def renumber_job_rows(job_rows, run_number_offset):
+    """
+    Set output run numbers continuously.
+
+    Parameters
+    ----------
+    job_rows : list[dict]
+        List of job rows to renumber.
+    run_number_offset : int
+        Offset to apply to the run numbers (first run number will be offset + 1).
+
+    Returns
+    -------
+    list[dict]
+        List of job rows with updated run numbers.
+    """
     for run_number, job_row in enumerate(job_rows, start=run_number_offset + 1):
         job_row["run_number"] = run_number
     return job_rows

--- a/src/simtools/production_configuration/simulation_jobs.py
+++ b/src/simtools/production_configuration/simulation_jobs.py
@@ -26,7 +26,6 @@ from simtools.production_configuration.corsika_limits_lookup import (
 )
 from simtools.production_configuration.job_grid_summary import (
     build_job_grid_summary,
-    format_quantity_summary,
 )
 from simtools.production_configuration.observation_grid import ProductionGridEngine
 from simtools.utils.general import ensure_list
@@ -87,6 +86,21 @@ _LOCAL_CONSTRAINT_ARGUMENTS = {
     "local_azimuth_range": "deg",
 }
 _DIRECTION_GRID_DENSITY_UNIT = 1 / u.deg**2
+_SUMMARY_LOG_FIELDS = (
+    ("Minimum energy used by jobs %s.", "energy_min", None),
+    ("Maximum energy used by jobs %s.", "energy_max", None),
+    ("Minimum energy from configuration %s.", "configured_energy_min", None),
+    ("Maximum energy from configuration %s.", "configured_energy_max", None),
+    ("Minimum energy from lookup tables %s.", "energy_min_lookup_limit", u.GeV),
+    ("Core scatter max used by jobs %s.", "core_scatter_max", None),
+    ("Core scatter max from configuration %s.", "configured_core_scatter_max", None),
+    ("Core scatter max from lookup tables %s.", "lookup_core_scatter_max", None),
+    ("Minimum view cone used by jobs %s.", "view_cone_min", None),
+    ("Maximum view cone used by jobs %s.", "view_cone_max", None),
+    ("Minimum view cone from configuration %s.", "configured_view_cone_min", None),
+    ("Maximum view cone from configuration %s.", "configured_view_cone_max", None),
+    ("Maximum view cone from lookup tables %s.", "lookup_view_cone_max", None),
+)
 
 
 def _parse_axis_range_tokens(range_tokens):
@@ -989,11 +1003,6 @@ def _log_energy_scaling_configuration(energy_max_scaling):
     )
 
 
-def _format_quantity_summary(quantity_values):
-    """Format quantity min/max as a single value or range with explicit unit."""
-    return format_quantity_summary(quantity_values)
-
-
 def _format_quantity_value_range(rows, key, summary_unit=None):
     """Format one quantity field as either a fixed value or range across jobs."""
     values = [row[key] for row in rows if row.get(key) is not None]
@@ -1023,58 +1032,11 @@ def _log_generated_row_summary(rows):
         "Generated %d simulation rows.",
         summary["simulation_rows"],
     )
-    logger.info(
-        "Minimum energy used by jobs %s.",
-        _format_quantity_value_range(rows, "energy_min"),
-    )
-    logger.info(
-        "Maximum energy used by jobs %s.",
-        _format_quantity_value_range(rows, "energy_max"),
-    )
-    logger.info(
-        "Minimum energy from configuration %s.",
-        _format_quantity_value_range(rows, "configured_energy_min"),
-    )
-    logger.info(
-        "Maximum energy from configuration %s.",
-        _format_quantity_value_range(rows, "configured_energy_max"),
-    )
-    logger.info(
-        "Minimum energy from lookup tables %s.",
-        _format_quantity_value_range(rows, "energy_min_lookup_limit", summary_unit=u.GeV),
-    )
-    logger.info(
-        "Core scatter max used by jobs %s.",
-        _format_quantity_value_range(rows, "core_scatter_max"),
-    )
-    logger.info(
-        "Core scatter max from configuration %s.",
-        _format_quantity_value_range(rows, "configured_core_scatter_max"),
-    )
-    logger.info(
-        "Core scatter max from lookup tables %s.",
-        _format_quantity_value_range(rows, "lookup_core_scatter_max"),
-    )
-    logger.info(
-        "Minimum view cone used by jobs %s.",
-        _format_quantity_value_range(rows, "view_cone_min"),
-    )
-    logger.info(
-        "Maximum view cone used by jobs %s.",
-        _format_quantity_value_range(rows, "view_cone_max"),
-    )
-    logger.info(
-        "Minimum view cone from configuration %s.",
-        _format_quantity_value_range(rows, "configured_view_cone_min"),
-    )
-    logger.info(
-        "Maximum view cone from configuration %s.",
-        _format_quantity_value_range(rows, "configured_view_cone_max"),
-    )
-    logger.info(
-        "Maximum view cone from lookup tables %s.",
-        _format_quantity_value_range(rows, "lookup_view_cone_max"),
-    )
+    for log_message, field_name, summary_unit in _SUMMARY_LOG_FIELDS:
+        logger.info(
+            log_message,
+            _format_quantity_value_range(rows, field_name, summary_unit=summary_unit),
+        )
     logger.info(
         "Showers per job in generated job grid: minimum %d, maximum %d (configured maximum %d).",
         summary["showers_per_run_min"],
@@ -1114,36 +1076,38 @@ def _generate_observation_grids_per_layout(
         resolved_layout_name = resolved_layout_names[model_version]
         nsb_rate = nsb_rates_per_model_version[model_version]
         cache_key = (resolved_layout_name, nsb_rate, use_shared_axes_definition)
-        if cache_key in observation_grid_cache:
-            observation_grids_per_model_version[model_version] = observation_grid_cache[cache_key]
-            continue
-
-        if use_shared_axes_definition:
-            generated_grid = build_production_grid_engine(
-                args_dict,
-                array_layout_name=resolved_layout_name,
-                model_version=model_version,
-            ).generate_simulation_grid()
-        else:
-            corsika_limits = None
-            if corsika_limits_path is not None:
-                corsika_limits = CorsikaLimitsLookup(
-                    corsika_limits_path,
+        generated_grid = observation_grid_cache.get(cache_key)
+        if generated_grid is None:
+            if use_shared_axes_definition:
+                generated_grid = build_production_grid_engine(
+                    args_dict,
                     array_layout_name=resolved_layout_name,
+                    model_version=model_version,
+                ).generate_simulation_grid()
+            else:
+                corsika_limits = (
+                    CorsikaLimitsLookup(
+                        corsika_limits_path,
+                        array_layout_name=resolved_layout_name,
+                    )
+                    if corsika_limits_path is not None
+                    else None
                 )
-            generated_grid = _generate_observation_points_from_axes(
-                azimuth_values=grid_axes["azimuth_angle"],
-                zenith_values=grid_axes["zenith_angle"],
-                corsika_limits=corsika_limits,
-                nsb_rate=nsb_rate,
-            )
-            generated_grid = ProductionGridEngine(
-                axes={},
-                coordinate_system="horizontal",
-                observing_location=build_observing_location(args_dict["site"], model_version),
-            ).convert_coordinates(generated_grid, keep_horizontal_coordinates=True)
+                generated_grid = ProductionGridEngine(
+                    axes={},
+                    coordinate_system="horizontal",
+                    observing_location=build_observing_location(args_dict["site"], model_version),
+                ).convert_coordinates(
+                    _generate_observation_points_from_axes(
+                        azimuth_values=grid_axes["azimuth_angle"],
+                        zenith_values=grid_axes["zenith_angle"],
+                        corsika_limits=corsika_limits,
+                        nsb_rate=nsb_rate,
+                    ),
+                    keep_horizontal_coordinates=True,
+                )
+            observation_grid_cache[cache_key] = generated_grid
 
-        observation_grid_cache[cache_key] = generated_grid
         observation_grids_per_model_version[model_version] = generated_grid
 
     return observation_grids_per_model_version, resolved_layout_names

--- a/src/simtools/production_configuration/simulation_jobs.py
+++ b/src/simtools/production_configuration/simulation_jobs.py
@@ -1319,4 +1319,11 @@ def build_simulation_jobs(args_dict):
                 )
             )
     _log_generated_row_summary(rows)
-    return rows
+    return _renumber_job_rows(rows, args_dict.get("run_number_offset", 0))
+
+
+def _renumber_job_rows(job_rows, run_number_offset):
+    """Set output run numbers continuously."""
+    for run_number, job_row in enumerate(job_rows, start=run_number_offset + 1):
+        job_row["run_number"] = run_number
+    return job_rows

--- a/tests/unit_tests/applications/test_production_generate_grid.py
+++ b/tests/unit_tests/applications/test_production_generate_grid.py
@@ -130,15 +130,3 @@ def test_add_arguments_accepts_legacy_energy_max_scaling_index():
     args = parser.parse_args(["--energy_max_scaling_index", "-2.5"])
 
     assert args.energy_max_scaling_index == pytest.approx(-2.5)
-
-
-def test_renumber_job_rows_applies_run_number_offset():
-    job_rows = [{"run_number": 10}, {"run_number": 10}, {"run_number": 11}]
-
-    assert [
-        row["run_number"] for row in app._renumber_job_rows(job_rows, run_number_offset=42)
-    ] == [
-        43,
-        44,
-        45,
-    ]

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import jsonschema
 import pytest
 import yaml
+from astropy.table import Table
 from packaging.specifiers import InvalidSpecifier
 
 from simtools.constants import (
@@ -678,19 +679,29 @@ def test_extract_schema_url_from_metadata_dict():
     assert result is None
 
 
-def test_extract_schema_from_file(tmp_test_directory):
-    """Test _extract_schema_from_file function."""
+def test_get_schema_file_from_file_metadata(tmp_test_directory):
+    """Test get_schema_file_from_file_metadata function."""
     # Create a test file with schema URL (lowercase cta)
     test_file = Path(tmp_test_directory) / "test_with_schema.yml"
     metadata = {"cta": {"product": {"data": {"model": {"url": "https://schema.example.com"}}}}}
     with open(test_file, "w", encoding="utf-8") as f:
         yaml.dump(metadata, f)
 
-    result = schema._extract_schema_from_file(test_file)
+    result = schema.get_schema_file_from_file_metadata(test_file)
     assert result == "https://schema.example.com"
 
+    ecsv_file = Path(tmp_test_directory) / "test_with_schema.ecsv"
+    Table(
+        rows=[[1]],
+        names=["value"],
+        meta={"cta": {"product": {"data": {"model": {"url": "https://ecsv-schema.example.com"}}}}},
+    ).write(ecsv_file, format="ascii.ecsv")
+
+    result = schema.get_schema_file_from_file_metadata(ecsv_file)
+    assert result == "https://ecsv-schema.example.com"
+
     # Test with non-existent file
-    result = schema._extract_schema_from_file("non_existent_file.yml")
+    result = schema.get_schema_file_from_file_metadata("non_existent_file.yml")
     assert result is None
 
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -1222,7 +1222,6 @@ def test_validate_data_files_falls_back_to_model_parameter_schema_when_metadata_
     def _validate_and_transform(self, is_model_parameter=False, lists_as_strings=False):
         captured["schema_file"] = self.schema_file_name
         captured["data_file"] = self.data_file_name
-        return
 
     monkeypatch.setattr(
         validate_data.DataValidator, "validate_and_transform", _validate_and_transform

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -2,6 +2,7 @@
 
 import logging
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -1201,7 +1202,6 @@ def test_validate_data_files_reads_schema_from_ecsv_metadata(tmp_test_directory,
     def _validate_and_transform(self, is_model_parameter=False, lists_as_strings=False):
         captured["schema_file"] = self.schema_file_name
         captured["data_file"] = self.data_file_name
-        return
 
     monkeypatch.setattr(
         validate_data.DataValidator, "validate_and_transform", _validate_and_transform
@@ -1211,6 +1211,30 @@ def test_validate_data_files_reads_schema_from_ecsv_metadata(tmp_test_directory,
 
     assert captured["schema_file"] == "schema-from-ecsv"
     assert captured["data_file"] == test_file
+
+
+def test_validate_data_files_falls_back_to_model_parameter_schema_when_metadata_missing(
+    monkeypatch,
+):
+    """Test validate_data_files falls back to model-parameter schema for JSON data files."""
+    captured = {}
+
+    def _validate_and_transform(self, is_model_parameter=False, lists_as_strings=False):
+        captured["schema_file"] = self.schema_file_name
+        captured["data_file"] = self.data_file_name
+        return
+
+    monkeypatch.setattr(
+        validate_data.DataValidator, "validate_and_transform", _validate_and_transform
+    )
+
+    validate_data.DataValidator.validate_data_files(
+        file_name=num_gains_test_file,
+        is_model_parameter=False,
+    )
+
+    assert captured["schema_file"] == MODEL_PARAMETER_SCHEMA_PATH / "num_gains.schema.yml"
+    assert captured["data_file"] == Path(num_gains_test_file)
 
 
 def test_validate_data_files_no_input():

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -1187,6 +1187,32 @@ def test_validate_data_files_with_schema_file(caplog):
     assert "Validated data file" in caplog.text
 
 
+def test_validate_data_files_reads_schema_from_ecsv_metadata(tmp_test_directory, monkeypatch):
+    """Test validate_data_files resolves schema from ECSV metadata for data files."""
+    test_file = tmp_test_directory / "job_grid.ecsv"
+    Table(
+        rows=[[1]],
+        names=["run_number"],
+        meta={"cta": {"product": {"data": {"model": {"url": "schema-from-ecsv"}}}}},
+    ).write(test_file, format="ascii.ecsv")
+
+    captured = {}
+
+    def _validate_and_transform(self, is_model_parameter=False, lists_as_strings=False):
+        captured["schema_file"] = self.schema_file_name
+        captured["data_file"] = self.data_file_name
+        return
+
+    monkeypatch.setattr(
+        validate_data.DataValidator, "validate_and_transform", _validate_and_transform
+    )
+
+    validate_data.DataValidator.validate_data_files(file_name=test_file, is_model_parameter=False)
+
+    assert captured["schema_file"] == "schema-from-ecsv"
+    assert captured["data_file"] == test_file
+
+
 def test_validate_data_files_no_input():
     """Test validate_data_files with no input."""
     result = validate_data.DataValidator.validate_data_files()

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -69,62 +69,36 @@ def test_serialize_and_read_job_grid_ecsv(tmp_test_directory):
     assert metadata["job_grid_summary"]["energy_min_used"] == "30 GeV"
 
 
-def test_serialize_job_grid_stream_and_read_job_grid_ecsv(tmp_test_directory):
-    output_file = Path(tmp_test_directory) / "job_grid.ecsv"
-
-    row_count = job_grid_io.serialize_job_grid_stream(
-        iter(_job_rows()), output_file, metadata=_metadata()
-    )
-    rows, metadata = job_grid_io.read_job_grid(output_file)
-
-    assert row_count == 1
-    assert metadata["site"] == "North"
-    assert metadata["job_grid_format_version"] == job_grid_io.JOB_GRID_SCHEMA.version
-    assert metadata["cta"]["product"]["data"]["model"]["url"] == job_grid_io._JOB_GRID_SCHEMA_URL
-    assert rows[0]["energy_min"] == 30 * u.GeV
-    assert rows[0]["ha"] == 123 * u.deg
-    assert rows[0]["dec"] == -45 * u.deg
-
-
-def test_serialize_job_grid_stream_appends_astropy_formatted_chunks(
-    tmp_test_directory, monkeypatch
-):
+def test_serialize_job_grid_and_read_multiple_rows(tmp_test_directory):
     output_file = Path(tmp_test_directory) / "job_grid.ecsv"
     rows_to_write = _job_rows()
     second_row = dict(rows_to_write[0], run_number=11, array_layout_name="layout with spaces")
     rows_to_write.append(second_row)
-    monkeypatch.setattr(job_grid_io, "_STREAM_CHUNK_SIZE", 1)
-
-    row_count = job_grid_io.serialize_job_grid_stream(
-        iter(rows_to_write), output_file, metadata=_metadata()
-    )
+    job_grid_io.serialize_job_grid(rows_to_write, output_file, metadata=_metadata())
     rows, _ = job_grid_io.read_job_grid(output_file)
 
-    assert row_count == 2
     assert [row["run_number"] for row in rows] == [10, 11]
     assert rows[1]["array_layout_name"] == "layout with spaces"
 
 
-def test_serialize_job_grid_stream_requires_hadec_columns(tmp_test_directory):
+def test_serialize_job_grid_requires_hadec_columns(tmp_test_directory):
     output_file = Path(tmp_test_directory) / "job_grid.ecsv"
     rows_to_write = _job_rows()
     rows_to_write[0]["ha"] = None
     rows_to_write[0]["dec"] = None
 
     with pytest.raises(TypeError):
-        job_grid_io.serialize_job_grid_stream(
-            iter(rows_to_write), output_file, metadata=_metadata()
-        )
+        job_grid_io.serialize_job_grid(rows_to_write, output_file, metadata=_metadata())
 
 
-def test_serialize_job_grid_stream_writes_empty_grid_header(tmp_test_directory):
+def test_serialize_job_grid_writes_empty_grid_header(tmp_test_directory):
     output_file = Path(tmp_test_directory) / "empty_job_grid.ecsv"
 
-    row_count = job_grid_io.serialize_job_grid_stream(iter([]), output_file, metadata=_metadata())
+    job_grid_io.serialize_job_grid([], output_file, metadata=_metadata())
     output_table = Table.read(output_file, format="ascii.ecsv")
 
-    assert row_count == 0
     assert output_table.colnames == list(job_grid_io.JOB_GRID_SCHEMA.columns)
+    assert output_table.meta["job_grid_summary"]["simulation_rows"] == 0
 
 
 def test_job_grid_density_schema_matches_serialized_required_columns():
@@ -162,6 +136,18 @@ def test_read_job_grid_rejects_non_ecsv_input(tmp_test_directory):
     input_file.write_text("dummy", encoding="utf-8")
 
     with pytest.raises(ValueError, match="\\.ecsv"):
+        job_grid_io.read_job_grid(input_file)
+
+
+def test_read_job_grid_validates_schema_units(tmp_test_directory):
+    input_file = Path(tmp_test_directory) / "job_grid.ecsv"
+    job_grid_io.serialize_job_grid(_job_rows(), input_file, metadata=_metadata())
+
+    table = Table.read(input_file, format="ascii.ecsv")
+    table["energy_min"].unit = None
+    table.write(input_file, format="ascii.ecsv", overwrite=True)
+
+    with pytest.raises(u.UnitConversionError, match="not convertible"):
         job_grid_io.read_job_grid(input_file)
 
 

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -51,6 +51,7 @@ def test_serialize_and_read_job_grid_ecsv(tmp_test_directory):
 
     assert metadata["site"] == "North"
     assert metadata["job_grid_format_version"] == job_grid_io.JOB_GRID_SCHEMA.version
+    assert metadata["cta"]["product"]["data"]["model"]["url"] == job_grid_io._JOB_GRID_SCHEMA_URL
     assert output_table.colnames[0] == "run_number"
     assert output_table["energy_min"].unit == u.GeV
     assert output_table["energy_max"].unit == u.GeV
@@ -79,6 +80,7 @@ def test_serialize_job_grid_stream_and_read_job_grid_ecsv(tmp_test_directory):
     assert row_count == 1
     assert metadata["site"] == "North"
     assert metadata["job_grid_format_version"] == job_grid_io.JOB_GRID_SCHEMA.version
+    assert metadata["cta"]["product"]["data"]["model"]["url"] == job_grid_io._JOB_GRID_SCHEMA_URL
     assert rows[0]["energy_min"] == 30 * u.GeV
     assert rows[0]["ha"] == 123 * u.deg
     assert rows[0]["dec"] == -45 * u.deg

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -151,6 +151,18 @@ def test_read_job_grid_validates_schema_units(tmp_test_directory):
         job_grid_io.read_job_grid(input_file)
 
 
+def test_read_job_grid_rejects_non_integral_integer_columns(tmp_test_directory):
+    input_file = Path(tmp_test_directory) / "job_grid.ecsv"
+    job_grid_io.serialize_job_grid(_job_rows(), input_file, metadata=_metadata())
+
+    table = Table.read(input_file, format="ascii.ecsv")
+    table["run_number"] = [10.5]
+    table.write(input_file, format="ascii.ecsv", overwrite=True)
+
+    with pytest.raises(TypeError):
+        job_grid_io.read_job_grid(input_file)
+
+
 def test_read_job_grid_row_returns_correct_row(tmp_test_directory):
     output_file = Path(tmp_test_directory) / "job_grid.ecsv"
     rows = _job_rows()

--- a/tests/unit_tests/production_configuration/test_simulation_jobs.py
+++ b/tests/unit_tests/production_configuration/test_simulation_jobs.py
@@ -1501,7 +1501,7 @@ def test_build_rows_for_point_skips_when_effective_total_showers_is_zero():
     assert rows == []
 
 
-def testrenumber_job_rows_applies_run_number_offset():
+def test_renumber_job_rows_applies_run_number_offset():
     job_rows = [{"run_number": 10}, {"run_number": 10}, {"run_number": 11}]
 
     assert [row["run_number"] for row in renumber_job_rows(job_rows, run_number_offset=42)] == [

--- a/tests/unit_tests/production_configuration/test_simulation_jobs.py
+++ b/tests/unit_tests/production_configuration/test_simulation_jobs.py
@@ -18,7 +18,6 @@ from simtools.production_configuration.simulation_jobs import (
     _normalize_axis_spec_tokens,
     _parse_axis_range_tokens,
     _parse_axis_spec,
-    _renumber_job_rows,
     _resolve_coordinate_system,
     _resolve_energy_max_scaling,
     _resolve_shower_params,
@@ -36,6 +35,7 @@ from simtools.production_configuration.simulation_jobs import (
     get_viewcone_max_for_zenith_angle,
     normalize_energy_ranges,
     normalize_grid_axes,
+    renumber_job_rows,
     resolve_single_model_version,
     scale_energy_max_for_zenith_angle,
 )
@@ -1501,10 +1501,10 @@ def test_build_rows_for_point_skips_when_effective_total_showers_is_zero():
     assert rows == []
 
 
-def test_renumber_job_rows_applies_run_number_offset():
+def testrenumber_job_rows_applies_run_number_offset():
     job_rows = [{"run_number": 10}, {"run_number": 10}, {"run_number": 11}]
 
-    assert [row["run_number"] for row in _renumber_job_rows(job_rows, run_number_offset=42)] == [
+    assert [row["run_number"] for row in renumber_job_rows(job_rows, run_number_offset=42)] == [
         43,
         44,
         45,

--- a/tests/unit_tests/production_configuration/test_simulation_jobs.py
+++ b/tests/unit_tests/production_configuration/test_simulation_jobs.py
@@ -18,6 +18,7 @@ from simtools.production_configuration.simulation_jobs import (
     _normalize_axis_spec_tokens,
     _parse_axis_range_tokens,
     _parse_axis_spec,
+    _renumber_job_rows,
     _resolve_coordinate_system,
     _resolve_energy_max_scaling,
     _resolve_shower_params,
@@ -1498,3 +1499,13 @@ def test_build_rows_for_point_skips_when_effective_total_showers_is_zero():
     )
 
     assert rows == []
+
+
+def test_renumber_job_rows_applies_run_number_offset():
+    job_rows = [{"run_number": 10}, {"run_number": 10}, {"run_number": 11}]
+
+    assert [row["run_number"] for row in _renumber_job_rows(job_rows, run_number_offset=42)] == [
+        43,
+        44,
+        45,
+    ]


### PR DESCRIPTION
Remove inconsistencies in writing production grid table and improve validation using existing schema.

- validate production grid table both for writing and reading
- add schema url to metadata of output table
- improve `simtools-validate-file-using-schema` to read this schema from the header file.
- remove some dead code not used anymore