### PR TITLE
Calculate shower-reuse as function of energy, core, and angular distance.

### DIFF
--- a/docs/changes/2331.feature.md
+++ b/docs/changes/2331.feature.md
@@ -1,0 +1,4 @@
+Calculate mean, max, and stdev of shower-reuse as function of energy, core, and angular distance:
+
+- filled and saved with `simtools-write-trigger-histograms`
+- plotted with `simtools-plot-simtel-events`

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -12,6 +12,11 @@ from simtools.utils.value_conversion import get_value_as_quantity
 
 _ANGULAR_DISTANCE = "Angular Distance (deg)"
 _CORE_DISTANCE = "Core Distance (m)"
+_REUSE_STAT_LABELS = {
+    "mean": "Mean Reuse",
+    "max": "Max Reuse",
+    "std": "Reuse Std Dev",
+}
 
 
 class EventDataHistograms:
@@ -71,6 +76,7 @@ class EventDataHistograms:
         self._contains_triggered_data = False
         self._filled_data_sets = 0
         self._release_event_data_after_fill = False
+        self._reuse_stat_accumulators = {}
 
         self.reader = None
         if not self.skip_invalid_event_data_files:
@@ -115,6 +121,7 @@ class EventDataHistograms:
         instance._contains_triggered_data = True
         instance._filled_data_sets = 0
         instance._release_event_data_after_fill = True
+        instance._reuse_stat_accumulators = {}
         instance.reader = None
         return instance
 
@@ -145,6 +152,7 @@ class EventDataHistograms:
             self.loaded_bin_edges = loaded_bin_edges
         self._filled_data_sets = 1
         self._contains_triggered_data = contains_triggered_data
+        self._reuse_stat_accumulators = {}
 
     @staticmethod
     def _validate_angular_distance_bin_width(angular_distance_bin_width):
@@ -255,7 +263,10 @@ class EventDataHistograms:
     def _release_event_data(self):
         """Release raw event references after their histogram counts have been accumulated."""
         for data in self.histograms.values():
-            data["event_data"] = None if data["1d"] else tuple(None for _ in data["event_data"])
+            if data["1d"] or data["event_data"] is None:
+                data["event_data"] = None
+            else:
+                data["event_data"] = tuple(None for _ in data["event_data"])
 
     def accumulate(self, file_info_table, shower_data, event_data, triggered_data):
         """Accumulate one already-read event dataset into all configured histograms."""
@@ -264,6 +275,7 @@ class EventDataHistograms:
         current_histograms = self._define_histograms(event_data, triggered_data, shower_data)
         self._merge_histograms(current_histograms)
         self._fill_current_histograms()
+        self._accumulate_reuse_histograms(event_data, triggered_data)
         if self._release_event_data_after_fill:
             self._release_event_data()
         self._filled_data_sets += 1
@@ -431,7 +443,229 @@ class EventDataHistograms:
             )
 
         hists.update(hists_mc)
+        hists.update(self._define_reuse_histograms())
         return hists
+
+    def _define_reuse_histograms(self):
+        """Return definitions for reuse summary histograms."""
+        energy_axis_title = "Energy (TeV)"
+        reuse_histograms = {}
+        definitions = (
+            (
+                "energy",
+                self.energy_bins,
+                [energy_axis_title],
+                {"x": "log", "y": "linear"},
+            ),
+            (
+                "core_distance",
+                self.core_distance_bins,
+                [_CORE_DISTANCE],
+                {"x": "linear", "y": "linear"},
+            ),
+            (
+                "angular_distance",
+                self.view_cone_bins,
+                [_ANGULAR_DISTANCE],
+                {"x": "linear", "y": "linear"},
+            ),
+            (
+                "core_distance_vs_energy",
+                (self.core_distance_bins, self.energy_bins),
+                [_CORE_DISTANCE, energy_axis_title],
+                {"x": "linear", "y": "log"},
+            ),
+            (
+                "angular_distance_vs_energy",
+                (self.view_cone_bins, self.energy_bins),
+                [_ANGULAR_DISTANCE, energy_axis_title],
+                {"x": "linear", "y": "log"},
+            ),
+        )
+
+        for statistic, label in _REUSE_STAT_LABELS.items():
+            for base_name, bin_edges, axis_titles, plot_scales in definitions:
+                reuse_histograms[f"reuse_{statistic}_vs_{base_name}"] = (
+                    self.get_histogram_definition(
+                        event_data_column=() if isinstance(bin_edges, tuple) else None,
+                        histogram=None,
+                        bin_edges=bin_edges,
+                        title=f"Triggered reuse {statistic}",
+                        axis_titles=[*axis_titles, label],
+                        suffix="",
+                        is_1d=not isinstance(bin_edges, tuple),
+                        plot_scales=plot_scales,
+                    )
+                )
+        return reuse_histograms
+
+    def _accumulate_reuse_histograms(self, event_data, triggered_data):
+        """Accumulate reuse summary statistics into their histogram definitions."""
+        if not self._can_accumulate_reuse_histograms(event_data, triggered_data):
+            return
+
+        try:
+            reuse_counts = self._triggered_reuse_counts(triggered_data)
+            coordinates = {
+                "energy": np.asarray(event_data.simulated_energy, dtype=float),
+                "core_distance": np.asarray(event_data.core_distance_shower, dtype=float),
+                "angular_distance": np.asarray(triggered_data.angular_distance, dtype=float),
+            }
+        except (AttributeError, TypeError, ValueError):
+            return
+        histogram_specs = {
+            "energy": (coordinates["energy"], self.energy_bins),
+            "core_distance": (coordinates["core_distance"], self.core_distance_bins),
+            "angular_distance": (coordinates["angular_distance"], self.view_cone_bins),
+            "core_distance_vs_energy": (
+                (coordinates["core_distance"], coordinates["energy"]),
+                (self.core_distance_bins, self.energy_bins),
+            ),
+            "angular_distance_vs_energy": (
+                (coordinates["angular_distance"], coordinates["energy"]),
+                (self.view_cone_bins, self.energy_bins),
+            ),
+        }
+
+        for statistic in _REUSE_STAT_LABELS:
+            for name, (values, bin_edges) in histogram_specs.items():
+                histogram_name = f"reuse_{statistic}_vs_{name}"
+                histogram = self.histograms.get(histogram_name)
+                if histogram is None:
+                    continue
+                accumulator = self._reuse_stat_accumulators.setdefault(
+                    histogram_name,
+                    self._create_reuse_stat_accumulator(bin_edges),
+                )
+                self._update_reuse_stat_accumulator(accumulator, values, reuse_counts, bin_edges)
+                histogram["histogram"] = self._finalize_reuse_statistic(accumulator, statistic)
+
+    @staticmethod
+    def _can_accumulate_reuse_histograms(event_data, triggered_data):
+        """Return whether the required inputs for reuse summaries are available."""
+        required_event_attrs = (
+            "file_id",
+            "shower_id",
+            "simulated_energy",
+            "core_distance_shower",
+        )
+        required_triggered_attrs = ("file_id", "shower_id", "angular_distance")
+        return (
+            event_data is not None
+            and triggered_data is not None
+            and all(hasattr(event_data, attr) for attr in required_event_attrs)
+            and all(hasattr(triggered_data, attr) for attr in required_triggered_attrs)
+        )
+
+    @staticmethod
+    def _triggered_reuse_counts(triggered_data):
+        """Return triggered reuse count per triggered event row."""
+        triggered_keys = np.column_stack(
+            (
+                np.asarray(triggered_data.file_id, dtype=np.int64),
+                np.asarray(triggered_data.shower_id, dtype=np.int64),
+            )
+        )
+        counts = {}
+        for key in map(tuple, triggered_keys):
+            counts[key] = counts.get(key, 0) + 1
+        return np.array([counts[tuple(key)] for key in triggered_keys], dtype=float)
+
+    def _create_reuse_stat_accumulator(self, bin_edges):
+        """Return empty accumulation arrays for one reuse-statistic histogram."""
+        shape = (
+            tuple(len(edges) - 1 for edges in bin_edges)
+            if isinstance(bin_edges, tuple)
+            else (len(bin_edges) - 1,)
+        )
+        return {
+            "count": np.zeros(shape, dtype=int),
+            "sum": np.zeros(shape, dtype=float),
+            "sum_sq": np.zeros(shape, dtype=float),
+            "max": np.full(shape, np.nan, dtype=float),
+        }
+
+    def _update_reuse_stat_accumulator(self, accumulator, values, reuse_counts, bin_edges):
+        """Update one reuse-statistic accumulator with one dataset."""
+        if isinstance(values, tuple):
+            x_values, y_values = values
+            shape = accumulator["count"].shape
+            x_indices = np.digitize(x_values, bin_edges[0]) - 1
+            y_indices = np.digitize(y_values, bin_edges[1]) - 1
+            valid = (
+                np.isfinite(reuse_counts)
+                & np.isfinite(x_values)
+                & np.isfinite(y_values)
+                & (x_indices >= 0)
+                & (x_indices < shape[0])
+                & (y_indices >= 0)
+                & (y_indices < shape[1])
+            )
+            self._accumulate_reuse_bin_values(
+                accumulator,
+                np.column_stack((x_indices[valid], y_indices[valid])),
+                reuse_counts[valid],
+            )
+            return
+
+        indices = np.digitize(values, bin_edges) - 1
+        valid = (
+            np.isfinite(reuse_counts)
+            & np.isfinite(values)
+            & (indices >= 0)
+            & (indices < accumulator["count"].shape[0])
+        )
+        self._accumulate_reuse_bin_values(accumulator, indices[valid], reuse_counts[valid])
+
+    @staticmethod
+    def _accumulate_reuse_bin_values(accumulator, indices, reuse_counts):
+        """Update count, sum, sum-of-squares, and max for addressed bins."""
+        grouped_values = {}
+        if np.ndim(indices) == 1:
+            for index, reuse_count in zip(indices, reuse_counts, strict=False):
+                grouped_values.setdefault(int(index), []).append(float(reuse_count))
+        else:
+            for index_pair, reuse_count in zip(indices, reuse_counts, strict=False):
+                grouped_values.setdefault(tuple(map(int, index_pair)), []).append(
+                    float(reuse_count)
+                )
+
+        for index, bin_values in grouped_values.items():
+            values = np.asarray(bin_values, dtype=float)
+            values = values[values > 0.0]
+            if values.size == 0:
+                continue
+            accumulator["count"][index] += len(values)
+            accumulator["sum"][index] += float(np.sum(values))
+            accumulator["sum_sq"][index] += float(np.sum(values**2))
+            current_max = accumulator["max"][index]
+            value_max = float(np.max(values))
+            accumulator["max"][index] = (
+                value_max if np.isnan(current_max) else max(current_max, value_max)
+            )
+
+    @staticmethod
+    def _finalize_reuse_statistic(accumulator, statistic):
+        """Return finalized reuse statistic values from accumulation arrays."""
+        count = accumulator["count"]
+        result = np.full(count.shape, np.nan, dtype=float)
+        valid = count > 0
+
+        if statistic == "mean":
+            result[valid] = accumulator["sum"][valid] / count[valid]
+            return result
+        if statistic == "max":
+            result[valid] = accumulator["max"][valid]
+            return result
+        if statistic == "std":
+            mean = np.zeros(count.shape, dtype=float)
+            mean[valid] = accumulator["sum"][valid] / count[valid]
+            variance = np.zeros(count.shape, dtype=float)
+            variance[valid] = accumulator["sum_sq"][valid] / count[valid] - mean[valid] ** 2
+            result[valid] = np.sqrt(np.maximum(variance[valid], 0.0))
+            return result
+
+        raise ValueError(f"Unsupported reuse statistic: {statistic}")
 
     def get_histogram_definition(
         self,
@@ -472,6 +706,8 @@ class EventDataHistograms:
                 getattr(data["event_data"], data["event_data_column"]), bins=data["bin_edges"]
             )
         else:
+            if data["event_data"] is None:
+                return
             if any(event_data is None for event_data in data["event_data"]):
                 return
             values = [
@@ -662,7 +898,11 @@ class EventDataHistograms:
 
         # 2D histograms vs energy
         for name, hist in self.histograms.items():
-            if name.endswith("_vs_energy") and not name.endswith("_mc"):
+            if (
+                name.endswith("_vs_energy")
+                and not name.endswith("_mc")
+                and not name.startswith("reuse_")
+            ):
                 add_cumulative(name, hist, axis=0, normalize=True)
 
         # 1D histograms

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -566,10 +566,10 @@ class EventDataHistograms:
                 np.asarray(triggered_data.shower_id, dtype=np.int64),
             )
         )
-        counts = {}
-        for key in map(tuple, triggered_keys):
-            counts[key] = counts.get(key, 0) + 1
-        return np.array([counts[tuple(key)] for key in triggered_keys], dtype=float)
+        _, inverse, counts = np.unique(
+            triggered_keys, axis=0, return_inverse=True, return_counts=True
+        )
+        return counts[inverse].astype(float)
 
     def _create_reuse_stat_accumulator(self, bin_edges):
         """Return empty accumulation arrays for one reuse-statistic histogram."""

--- a/src/simtools/sim_events/histograms.py
+++ b/src/simtools/sim_events/histograms.py
@@ -620,29 +620,29 @@ class EventDataHistograms:
     @staticmethod
     def _accumulate_reuse_bin_values(accumulator, indices, reuse_counts):
         """Update count, sum, sum-of-squares, and max for addressed bins."""
-        grouped_values = {}
-        if np.ndim(indices) == 1:
-            for index, reuse_count in zip(indices, reuse_counts, strict=False):
-                grouped_values.setdefault(int(index), []).append(float(reuse_count))
-        else:
-            for index_pair, reuse_count in zip(indices, reuse_counts, strict=False):
-                grouped_values.setdefault(tuple(map(int, index_pair)), []).append(
-                    float(reuse_count)
-                )
+        reuse_counts = np.asarray(reuse_counts, dtype=float)
+        positive = reuse_counts > 0.0
+        if not np.any(positive):
+            return
 
-        for index, bin_values in grouped_values.items():
-            values = np.asarray(bin_values, dtype=float)
-            values = values[values > 0.0]
-            if values.size == 0:
-                continue
-            accumulator["count"][index] += len(values)
-            accumulator["sum"][index] += float(np.sum(values))
-            accumulator["sum_sq"][index] += float(np.sum(values**2))
-            current_max = accumulator["max"][index]
-            value_max = float(np.max(values))
-            accumulator["max"][index] = (
-                value_max if np.isnan(current_max) else max(current_max, value_max)
-            )
+        indices = np.asarray(indices, dtype=np.int64)
+        shape = accumulator["count"].shape
+        if indices.ndim == 1:
+            flat_indices = indices[positive]
+        else:
+            flat_indices = np.ravel_multi_index(indices[positive].T, shape)
+
+        values = reuse_counts[positive]
+        flat_size = int(np.prod(shape, dtype=np.int64))
+
+        count = np.bincount(flat_indices, minlength=flat_size).reshape(shape)
+        sum_ = np.bincount(flat_indices, weights=values, minlength=flat_size).reshape(shape)
+        sum_sq = np.bincount(flat_indices, weights=values**2, minlength=flat_size).reshape(shape)
+
+        accumulator["count"] += count
+        accumulator["sum"] += sum_
+        accumulator["sum_sq"] += sum_sq
+        np.fmax.at(accumulator["max"].reshape(-1), flat_indices, values)
 
     @staticmethod
     def _finalize_reuse_statistic(accumulator, statistic):

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -36,6 +36,11 @@ _BROAD_RANGE_KEY_GROUPS = (
 )
 
 
+def _is_reuse_histogram(name):
+    """Return whether the histogram contains reuse summary statistics."""
+    return str(name).startswith("reuse_")
+
+
 def plot(
     histograms,
     output_path=None,
@@ -321,6 +326,8 @@ def _build_plot_configuration(
 def _get_2d_plot_params(name, hist_2d_params, hist_2d_normalized_params):
     """Select the plotting style for a 2D histogram."""
     histogram_name = name.lower()
+    if _is_reuse_histogram(histogram_name):
+        return hist_2d_normalized_params
     if (
         "cumulative" in histogram_name
         or "efficiency" in histogram_name
@@ -831,13 +838,18 @@ def _create_2d_histogram_plot(data, bins, plot_params, ax=None):
 
     plotter = ax if ax is not None else plt
     if plot_params.get("norm") == "linear":
-        masked_data = np.ma.masked_equal(data.T, 0)
+        finite_values = np.asarray(data, dtype=float)[np.isfinite(data)]
+        masked_data = np.ma.masked_invalid(data.T)
+        data_min = float(np.min(finite_values)) if finite_values.size else 0.0
+        data_max = float(np.max(finite_values)) if finite_values.size else 1.0
+        if data_max <= data_min:
+            data_max = data_min + 1.0
         pcm = plotter.pcolormesh(
             bins[0],
             bins[1],
             masked_data,
-            vmin=0,
-            vmax=1,
+            vmin=data_min,
+            vmax=data_max,
             cmap=cmap,
         )
     else:

--- a/tests/unit_tests/production_configuration/test_trigger_histograms.py
+++ b/tests/unit_tests/production_configuration/test_trigger_histograms.py
@@ -203,6 +203,11 @@ def test_event_data_histograms_round_trip_via_hdf5(tmp_path):
     )
     assert "angular_distance_vs_energy_vs_core_distance_eff" in loaded_histograms.histograms
     assert "energy_cumulative" in loaded_histograms.histograms
+    assert "reuse_mean_vs_energy" in loaded_histograms.histograms
+    np.testing.assert_allclose(
+        loaded_histograms.histograms["reuse_mean_vs_energy"]["histogram"],
+        histograms.histograms["reuse_mean_vs_energy"]["histogram"],
+    )
 
     with h5py.File(output_file, "r") as hdf5_file:
         assert TRIGGER_HISTOGRAM_DENSE_GROUP in hdf5_file

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -216,6 +216,39 @@ def test_fill_histogram_and_bin_edges_2d_existing(mock_reader, hdf5_file_name):
     assert np.array_equal(data["histogram"], expected_total_hist)
 
 
+def test_fill_histogram_and_bin_edges_2d_event_data_none(mock_reader, hdf5_file_name):
+    histograms = EventDataHistograms(hdf5_file_name)
+    data = {
+        "1d": False,
+        "event_data": None,
+        "event_data_column": ("simulated_energy", "core_distance_shower"),
+        "bin_edges": [np.array([0, 2, 4]), np.array([3, 5, 7])],
+        "histogram": None,
+    }
+
+    histograms._fill_histogram_and_bin_edges(data)
+
+    assert data["histogram"] is None
+
+
+def test_release_event_data_handles_non_1d_none_event_data(mock_reader, hdf5_file_name):
+    histograms = EventDataHistograms(hdf5_file_name)
+    histograms.histograms = {
+        "energy": {"1d": True, "event_data": mock_reader.return_value},
+        "reuse_mean_vs_core_distance_vs_energy": {"1d": False, "event_data": None},
+        "core_distance_vs_energy": {
+            "1d": False,
+            "event_data": (mock_reader.return_value, mock_reader.return_value),
+        },
+    }
+
+    histograms._release_event_data()
+
+    assert histograms.histograms["energy"]["event_data"] is None
+    assert histograms.histograms["reuse_mean_vs_core_distance_vs_energy"]["event_data"] is None
+    assert histograms.histograms["core_distance_vs_energy"]["event_data"] == (None, None)
+
+
 def test_fill(mock_reader, hdf5_file_name, mocker):
     histograms = EventDataHistograms(hdf5_file_name)
 
@@ -458,6 +491,104 @@ def test_fill_coerces_unitless_file_info_values(mock_reader, hdf5_file_name, moc
     assert_quantity_allclose(histograms.file_info["viewcone_max"], 2.0 * u.deg)
     assert_quantity_allclose(histograms.file_info["solid_angle"], 1.0 * u.sr)
     assert_quantity_allclose(histograms.file_info["scatter_area"], 1.0 * (u.cm**2))
+
+
+def test_triggered_reuse_counts_repeat_per_triggered_event(mock_reader, hdf5_file_name, mocker):
+    histograms = EventDataHistograms(hdf5_file_name)
+    triggered_data = mocker.Mock(
+        file_id=np.array([0, 0, 0]),
+        shower_id=np.array([1, 1, 2]),
+    )
+
+    reuse_counts = histograms._triggered_reuse_counts(triggered_data)
+
+    np.testing.assert_array_equal(reuse_counts, np.array([2.0, 2.0, 1.0]))
+
+
+def test_accumulate_reuse_histograms_match_triggered_event_phase_space(
+    mock_reader, hdf5_file_name, mocker
+):
+    histograms = EventDataHistograms.create_accumulator(
+        energy_bins_per_decade=1,
+        angular_distance_bin_count=3,
+        core_distance_bin_count=3,
+    )
+    histograms.file_info = {
+        "energy_min": 0.1 * u.TeV,
+        "energy_max": 100.0 * u.TeV,
+        "core_scatter_min": 0.0 * u.m,
+        "core_scatter_max": 60.0 * u.m,
+        "viewcone_min": 0.0 * u.deg,
+        "viewcone_max": 0.6 * u.deg,
+    }
+    histograms.histograms = histograms._define_histograms(None, None, None)
+
+    event_data = mocker.Mock(
+        file_id=np.array([0, 0, 0]),
+        shower_id=np.array([1, 1, 2]),
+        simulated_energy=np.array([0.2, 0.2, 2.0]),
+        core_distance_shower=np.array([10.0, 20.0, 10.0]),
+    )
+    triggered_data = mocker.Mock(
+        file_id=np.array([0, 0, 0]),
+        shower_id=np.array([1, 1, 2]),
+        angular_distance=np.array([0.1, 0.2, 0.1]),
+    )
+
+    histograms._accumulate_reuse_histograms(event_data, triggered_data)
+
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_mean_vs_energy"]["histogram"],
+        np.array([2.0, 1.0, np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_max_vs_energy"]["histogram"],
+        np.array([2.0, 1.0, np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_std_vs_energy"]["histogram"],
+        np.array([0.0, 0.0, np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_mean_vs_core_distance"]["histogram"],
+        np.array([5.0 / 3.0, np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_max_vs_core_distance"]["histogram"],
+        np.array([2.0, np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_std_vs_core_distance"]["histogram"],
+        np.array([np.sqrt(2.0 / 9.0), np.nan]),
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_mean_vs_angular_distance"]["histogram"],
+        np.array([5.0 / 3.0, np.nan]),
+        equal_nan=True,
+    )
+    expected_2d_mean = np.array([[2.0, 1.0, np.nan], [np.nan, np.nan, np.nan]])
+    expected_2d_std = np.array([[0.0, 0.0, np.nan], [np.nan, np.nan, np.nan]])
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_mean_vs_core_distance_vs_energy"]["histogram"],
+        expected_2d_mean,
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_std_vs_core_distance_vs_energy"]["histogram"],
+        expected_2d_std,
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        histograms.histograms["reuse_max_vs_angular_distance_vs_energy"]["histogram"],
+        np.array([[2.0, 1.0, np.nan], [np.nan, np.nan, np.nan]]),
+        equal_nan=True,
+    )
 
 
 def test_calculate_cumulative_histogram(mock_reader, hdf5_file_name):

--- a/tests/unit_tests/sim_events/test_histograms.py
+++ b/tests/unit_tests/sim_events/test_histograms.py
@@ -505,6 +505,46 @@ def test_triggered_reuse_counts_repeat_per_triggered_event(mock_reader, hdf5_fil
     np.testing.assert_array_equal(reuse_counts, np.array([2.0, 2.0, 1.0]))
 
 
+def test_accumulate_reuse_bin_values_vectorized_1d_and_2d():
+    accumulator_1d = {
+        "count": np.zeros(3, dtype=int),
+        "sum": np.zeros(3, dtype=float),
+        "sum_sq": np.zeros(3, dtype=float),
+        "max": np.full(3, np.nan, dtype=float),
+    }
+    EventDataHistograms._accumulate_reuse_bin_values(
+        accumulator_1d,
+        np.array([0, 0, 1, 2, 2]),
+        np.array([2.0, 0.0, -1.0, 1.0, 3.0]),
+    )
+    np.testing.assert_array_equal(accumulator_1d["count"], np.array([1, 0, 2]))
+    np.testing.assert_allclose(accumulator_1d["sum"], np.array([2.0, 0.0, 4.0]))
+    np.testing.assert_allclose(accumulator_1d["sum_sq"], np.array([4.0, 0.0, 10.0]))
+    np.testing.assert_allclose(accumulator_1d["max"], np.array([2.0, np.nan, 3.0]), equal_nan=True)
+
+    accumulator_2d = {
+        "count": np.zeros((2, 3), dtype=int),
+        "sum": np.zeros((2, 3), dtype=float),
+        "sum_sq": np.zeros((2, 3), dtype=float),
+        "max": np.full((2, 3), np.nan, dtype=float),
+    }
+    EventDataHistograms._accumulate_reuse_bin_values(
+        accumulator_2d,
+        np.array([[0, 0], [0, 0], [0, 1], [1, 2], [1, 2], [1, 0]]),
+        np.array([1.0, 4.0, 0.0, -2.0, 5.0, 3.0]),
+    )
+    np.testing.assert_array_equal(accumulator_2d["count"], np.array([[2, 0, 0], [1, 0, 1]]))
+    np.testing.assert_allclose(accumulator_2d["sum"], np.array([[5.0, 0.0, 0.0], [3.0, 0.0, 5.0]]))
+    np.testing.assert_allclose(
+        accumulator_2d["sum_sq"], np.array([[17.0, 0.0, 0.0], [9.0, 0.0, 25.0]])
+    )
+    np.testing.assert_allclose(
+        accumulator_2d["max"],
+        np.array([[4.0, np.nan, np.nan], [3.0, np.nan, 5.0]]),
+        equal_nan=True,
+    )
+
+
 def test_accumulate_reuse_histograms_match_triggered_event_phase_space(
     mock_reader, hdf5_file_name, mocker
 ):

--- a/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
+++ b/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
@@ -65,6 +65,7 @@ def test_create_2d_histogram_plot_linear(sample_data):
 
     assert pcm is not None
     assert pcm.get_cmap().name == "viridis"
+    assert pcm.get_clim() == pytest.approx((1.0, 9.0))
     plt.close(fig)
 
 
@@ -212,8 +213,25 @@ def test_create_2d_histogram_plot_masks_zero_bins():
 
     plotted_array = pcm.get_array()
     assert np.ma.isMaskedArray(plotted_array)
-    assert np.any(np.ma.getmaskarray(plotted_array))
+    assert not np.any(np.ma.getmaskarray(plotted_array))
     assert pcm.cmap.get_bad()[-1] == pytest.approx(0.0)
+    assert pcm.get_clim() == pytest.approx((0.0, 3.0))
+    plt.close(fig)
+
+
+def test_create_2d_histogram_plot_masks_nan_bins_but_keeps_zero_values():
+    data = np.array([[0.0, np.nan], [3.0, 1.0]])
+    bins = (np.array([0, 1, 2]), np.array([0, 1, 2]))
+    plot_params = {"norm": "linear", "cmap": "viridis"}
+
+    fig, _ = plt.subplots()
+    pcm = _create_2d_histogram_plot(data, bins, plot_params)
+
+    plotted_array = pcm.get_array()
+    assert np.ma.isMaskedArray(plotted_array)
+    mask = np.ma.getmaskarray(plotted_array)
+    assert np.count_nonzero(mask) == 1
+    assert pcm.get_clim() == pytest.approx((0.0, 3.0))
     plt.close(fig)
 
 
@@ -930,6 +948,25 @@ def test_generate_plot_configurations():
         _, kwargs = mock_create_2d.call_args
         assert "plot_params" in kwargs
         assert kwargs["plot_params"]["norm"] == "linear"
+
+    histos = {"reuse_mean_vs_core_distance_vs_energy": {"histogram": "abc", "1d": False}}
+    with patch(f"{MOD}._create_2d_plot_config") as mock_create_2d:
+        plot_simtel_event_histograms._generate_plot_configurations(histos, None)
+        _, kwargs = mock_create_2d.call_args
+        assert kwargs["plot_params"]["norm"] == "linear"
+
+    histos = {
+        "reuse_mean_vs_energy": {
+            "histogram": "abc",
+            "1d": True,
+            "axis_titles": ["Energy [TeV]", "Mean Reuse"],
+            "title": "Triggered reuse mean",
+            "bin_edges": np.array([0.1, 1.0, 10.0]),
+            "plot_scales": {"x": "log", "y": "linear"},
+        }
+    }
+    result = plot_simtel_event_histograms._generate_plot_configurations(histos, None)
+    assert result["reuse_mean_vs_energy"]["scales"]["y"] == "linear"
 
 
 def test_broad_range_axis_limits_are_used_for_distance_histograms():

--- a/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
+++ b/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
@@ -203,7 +203,7 @@ def test_create_2d_histogram_plot_log(sample_data):
     plt.close(fig)
 
 
-def test_create_2d_histogram_plot_masks_zero_bins():
+def test_create_2d_histogram_plot_keeps_zero_bins_visible():
     data = np.array([[0, 2], [3, 0]])
     bins = (np.array([0, 1, 2]), np.array([0, 1, 2]))
     plot_params = {"norm": "linear", "cmap": "viridis", "show_contour": False}


### PR DESCRIPTION
Calculate per triggered event mean+std and max of shower re-use and fill into histograms as function of energy, core distance, angular distance.

Closes #2205

(low-statistics) example:

<img width="2050" height="1638" alt="reuse_max_vs_core_distance_vs_energy" src="https://github.com/user-attachments/assets/ce15c78e-1a11-4378-aa65-9c1f25df88bf" />
<img width="2050" height="1638" alt="reuse_mean_vs_core_distance_vs_energy" src="https://github.com/user-attachments/assets/ebf6508d-1cc1-4f5e-8875-e206521396c3" />
