### PR TITLE
Bug fix in plotting for MC statistics calculation: don't overwrite existing plots.

### DIFF
--- a/src/simtools/production_configuration/monte_carlo_statistics_estimator.py
+++ b/src/simtools/production_configuration/monte_carlo_statistics_estimator.py
@@ -319,6 +319,15 @@ def _resolve_limiting_indices(energy_mask, limiting_index):
     return limiting_index[0], masked_energy_indices[limiting_index[1]]
 
 
+def _extract_diagnostic_file_info(metadata_row):
+    """Return observational metadata used to disambiguate diagnostic plot filenames."""
+    return {
+        "zenith": _get_metadata_quantity(metadata_row, "zenith", u.deg),
+        "azimuth": _get_metadata_quantity(metadata_row, "azimuth", u.deg),
+        "nsb_level": metadata_row["nsb_level"],
+    }
+
+
 def _build_result_metadata(
     metadata_row,
     spectral_index,
@@ -404,6 +413,7 @@ def _build_result_row(
         plot_monte_carlo_statistics_diagnostics(
             io_handler.IOHandler().get_output_directory(),
             metadata_row["array_name"],
+            _extract_diagnostic_file_info(metadata_row),
             energy_edges,
             angular_edges,
             expected_counts,

--- a/src/simtools/production_configuration/monte_carlo_statistics_estimator.py
+++ b/src/simtools/production_configuration/monte_carlo_statistics_estimator.py
@@ -462,6 +462,11 @@ def estimate_monte_carlo_statistics(args_dict=None):
         metadata_table,
         args_dict.get("array_layout_name") or args_dict.get("array_names"),
     )
+    if args_dict.get("plot_diagnostics") and len(selected_references) > 0:
+        _logger.info(
+            "Writing Monte Carlo statistics diagnostic plots to %s",
+            io_handler.IOHandler().get_output_directory(),
+        )
 
     output_rows = [
         _build_result_row(

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -138,6 +138,7 @@ def _plottable_histograms(histograms):
 def plot_monte_carlo_statistics_diagnostics(
     output_dir,
     array_name,
+    file_info,
     energy_edges,
     angular_edges,
     expected_counts,
@@ -152,6 +153,9 @@ def plot_monte_carlo_statistics_diagnostics(
         Directory to write plot files.
     array_name : str
         Array or telescope-selection name used in plot titles and filenames.
+    file_info : dict
+        Dictionary with simulation metadata (zenith, azimuth, nsb_level) used
+        to make filenames unique per observational setup.
     energy_edges : array-like
         Energy bin edges in TeV.
     angular_edges : array-like
@@ -165,6 +169,9 @@ def plot_monte_carlo_statistics_diagnostics(
     output_dir.mkdir(parents=True, exist_ok=True)
     _logger.info(f"Writing Monte Carlo statistics diagnostic plots to {output_dir}")
     file_prefix = _sanitize_filename_part(array_name)
+    file_info_suffix = _format_file_info_suffix(file_info or {})
+    if file_info_suffix:
+        file_prefix = f"{file_prefix}_{file_info_suffix}"
     plot_specs = (
         (
             expected_counts,

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -156,7 +156,7 @@ def plot_monte_carlo_statistics_diagnostics(
     file_info : dict, optional
         Dictionary with simulation metadata (zenith, azimuth, nsb_level) used
         to make filenames unique per observational setup. If omitted, filenames are based on
-        `array_name` only.
+        ``array_name`` only.
     energy_edges : array-like
         Energy bin edges in TeV.
     angular_edges : array-like

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -167,7 +167,6 @@ def plot_monte_carlo_statistics_diagnostics(
     """
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
-    _logger.info(f"Writing Monte Carlo statistics diagnostic plots to {output_dir}")
     file_prefix = _sanitize_filename_part(array_name)
     file_info_suffix = _format_file_info_suffix(file_info or {})
     if file_info_suffix:

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -153,9 +153,10 @@ def plot_monte_carlo_statistics_diagnostics(
         Directory to write plot files.
     array_name : str
         Array or telescope-selection name used in plot titles and filenames.
-    file_info : dict
+    file_info : dict, optional
         Dictionary with simulation metadata (zenith, azimuth, nsb_level) used
-        to make filenames unique per observational setup.
+        to make filenames unique per observational setup. If omitted, filenames are based on
+        `array_name` only.
     energy_edges : array-like
         Energy bin edges in TeV.
     angular_edges : array-like

--- a/tests/unit_tests/production_configuration/test_monte_carlo_statistics_estimator.py
+++ b/tests/unit_tests/production_configuration/test_monte_carlo_statistics_estimator.py
@@ -225,6 +225,11 @@ def test_estimator_writes_diagnostic_plots(mocker, tmp_path):
     )
 
     mock_plot.assert_called_once()
+    assert mock_plot.call_args.args[2] == {
+        "zenith": 20.0 * u.deg,
+        "azimuth": 180.0 * u.deg,
+        "nsb_level": 1.0,
+    }
 
 
 def test_estimator_reports_limiting_bin_and_positive_required_events(mocker, tmp_path):

--- a/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
+++ b/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
@@ -75,6 +75,7 @@ def test_plot_monte_carlo_statistics_diagnostics_writes_expected_plots(tmp_test_
     plot_monte_carlo_statistics_diagnostics(
         tmp_test_directory,
         "MSTS-01",
+        {"zenith": 20.0 * u.deg, "azimuth": 180.0 * u.deg, "nsb_level": 1.0},
         np.array([0.1, 1.0, 10.0]),
         np.array([0.0, 0.5]),
         np.array([[10.0, 20.0]]),
@@ -83,8 +84,8 @@ def test_plot_monte_carlo_statistics_diagnostics_writes_expected_plots(tmp_test_
 
     assert mock_plot.call_count == 2
     output_files = [call.args[3] for call in mock_plot.call_args_list]
-    assert tmp_test_directory / "MSTS-01_expected_events.png" in output_files
-    assert tmp_test_directory / "MSTS-01_relative_uncertainty.png" in output_files
+    assert tmp_test_directory / "MSTS-01_z20_az180_nsb1_expected_events.png" in output_files
+    assert tmp_test_directory / "MSTS-01_z20_az180_nsb1_relative_uncertainty.png" in output_files
 
 
 def test_plot_monte_carlo_statistics_matrix_can_mask_zero_bins(tmp_test_directory, mocker):


### PR DESCRIPTION
Plots are named now according to zenith/azimuth/nsb.