### PR TITLE
Change trigger for simtools-prod and simtools-dev container push

### DIFF
--- a/.github/workflows/build-simtools-dev.yml
+++ b/.github/workflows/build-simtools-dev.yml
@@ -80,7 +80,7 @@ jobs:
             CORSIKA_IMAGE_VERSION=${{ env.CORSIKA_IMAGE_VERSION }}
             SIMTEL_IMAGE_VERSION=${{ env.SIMTEL_IMAGE_VERSION }}
             AVX_FLAG=${{ env.AVX_FLAG }}
-          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+          push: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
           file: ./docker/Dockerfile-simtools-dev
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-simtools-dev.yml
+++ b/.github/workflows/build-simtools-dev.yml
@@ -4,6 +4,9 @@ name: build-simtools-dev
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*-rc*'
   pull_request:
     paths:
       - docker/Dockerfile-simtools-dev
@@ -60,11 +63,12 @@ jobs:
         with:
           tags: |
             type=ref,event=pr
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{version}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD'}}
           images: ${{ env.REGISTRY }}/gammasim/${{ env.BASE_LABEL }}
-          flavor: latest=true
+          flavor: |
+            latest=${{ !(startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -76,7 +80,7 @@ jobs:
             CORSIKA_IMAGE_VERSION=${{ env.CORSIKA_IMAGE_VERSION }}
             SIMTEL_IMAGE_VERSION=${{ env.SIMTEL_IMAGE_VERSION }}
             AVX_FLAG=${{ env.AVX_FLAG }}
-          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
           file: ./docker/Dockerfile-simtools-dev
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -4,6 +4,9 @@ name: build-simtools-prod
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*-rc*'
   pull_request:
     paths:
       - docker/Dockerfile-simtools-prod
@@ -67,7 +70,7 @@ jobs:
             suffix=-${{ matrix.corsika }}-${{ matrix.sim_telarray }}-${{ matrix.avx_flag }}
           tags: |
             type=ref,event=pr
-            type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
+            type=semver,pattern=v{{version}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD'}}
 
@@ -90,13 +93,13 @@ jobs:
             SIMTEL_IMAGE_VERSION=${{ matrix.sim_telarray }}
             AVX_FLAG=${{ matrix.avx_flag }}
             SIMTOOLS_BRANCH=${{ env.SIMTOOLS_BRANCH }}
-          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
           file: ./docker/Dockerfile-simtools-prod
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Install Apptainer
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
         env:
           APPTAINER_VERSION: v1.5.0
           GH_TOKEN: ${{ github.token }}
@@ -108,7 +111,7 @@ jobs:
           apptainer --version
 
       - name: Generate and push Apptainer images
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
         env:
           APPTAINER_DOCKER_USERNAME: ${{ github.actor }}
           APPTAINER_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -135,7 +138,7 @@ jobs:
     permissions:
       contents: read
     needs: build-simtools-prod
-    if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
     uses: ./.github/workflows/CI-integrationtests.yml
     secrets: inherit
     with:

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -93,13 +93,13 @@ jobs:
             SIMTEL_IMAGE_VERSION=${{ matrix.sim_telarray }}
             AVX_FLAG=${{ matrix.avx_flag }}
             SIMTOOLS_BRANCH=${{ env.SIMTOOLS_BRANCH }}
-          push: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+          push: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
           file: ./docker/Dockerfile-simtools-prod
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Install Apptainer
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
         env:
           APPTAINER_VERSION: v1.5.0
           GH_TOKEN: ${{ github.token }}
@@ -111,7 +111,7 @@ jobs:
           apptainer --version
 
       - name: Generate and push Apptainer images
-        if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
         env:
           APPTAINER_DOCKER_USERNAME: ${{ github.actor }}
           APPTAINER_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
     permissions:
       contents: read
     needs: build-simtools-prod
-    if: ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+    if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
     uses: ./.github/workflows/CI-integrationtests.yml
     secrets: inherit
     with:

--- a/docs/changes/2339.maintenance.md
+++ b/docs/changes/2339.maintenance.md
@@ -1,0 +1,1 @@
+Change trigger for simtools-prod and simtools-dev container generation. Don't push when running on main. Push for tags of type `vXX.YY.ZZ-rc` (release candidates).


### PR DESCRIPTION
Change trigger for simtools-prod and simtools-dev container push. 

Don't push when running on main. Push for tags of type `vXX.YY.ZZ-rc` (release candidates).
