### PR TITLE
Preserve integer job-grid dtypes in validation

### DIFF
--- a/docs/changes/2343.bugfix.md
+++ b/docs/changes/2343.bugfix.md
@@ -1,0 +1,1 @@
+Fixed schema validation so dimensionless integer columns in generated job grids stay integer-typed instead of being written to ECSV as floats.

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -484,8 +484,18 @@ class DataValidator:
                 col_name=col_name,
             )
             self.data_table[col_name] = converted_col
-            self._check_range(col_name, np.nanmin(col.data), np.nanmax(col.data), "allowed_range")
-            self._check_range(col_name, np.nanmin(col.data), np.nanmax(col.data), "required_range")
+            self._check_range(
+                col_name,
+                np.nanmin(converted_col.data),
+                np.nanmax(converted_col.data),
+                "allowed_range",
+            )
+            self._check_range(
+                col_name,
+                np.nanmin(converted_col.data),
+                np.nanmax(converted_col.data),
+                "required_range",
+            )
 
     def _check_required_columns(self):
         """

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -478,7 +478,12 @@ class DataValidator:
                 continue
             self._check_for_not_a_number(col.data, col_name)
             self._check_data_type(col.dtype, col_name)
-            self.data_table[col_name] = col.to(u.Unit(self._get_reference_unit(col_name)))
+            converted_col, _ = self._check_and_convert_units(
+                col,
+                unit=getattr(col, "unit", None),
+                col_name=col_name,
+            )
+            self.data_table[col_name] = converted_col
             self._check_range(col_name, np.nanmin(col.data), np.nanmax(col.data), "allowed_range")
             self._check_range(col_name, np.nanmin(col.data), np.nanmax(col.data), "required_range")
 
@@ -770,7 +775,7 @@ class DataValidator:
                 f"Invalid unit in data column '{col_name}'. "
                 f"Expected type '{reference_unit}', found '{column_unit}'"
             )
-            raise u.core.UnitConversionError from exc
+            raise u.core.UnitConversionError(str(exc)) from exc
 
     def _check_and_convert_units_for_list(self, data, column_unit, reference_unit):
         """

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -246,6 +246,34 @@ def test_validate_data_columns(tmp_test_directory, caplog):
     assert "Error reading validation schema from" in caplog.text
 
 
+def test_validate_data_columns_preserves_dimensionless_integer_dtype():
+    data_validator = validate_data.DataValidator()
+    data_validator._data_description = [
+        {
+            "name": "run_number",
+            "required": True,
+            "type": "int64",
+        },
+        {
+            "name": "showers_per_run",
+            "required": True,
+            "unit": "dimensionless",
+            "type": "int64",
+        },
+    ]
+    data_validator.data_table = Table(
+        {
+            "run_number": np.array([1, 2], dtype=np.int64),
+            "showers_per_run": Column([10, 20], dtype=np.int64, unit="dimensionless"),
+        }
+    )
+
+    data_validator._validate_data_columns()
+
+    assert data_validator.data_table["run_number"].dtype == np.dtype("int64")
+    assert data_validator.data_table["showers_per_run"].dtype == np.dtype("int64")
+
+
 def test_sort_data(reference_columns, caplog):
     data_validator = validate_data.DataValidator()
     data_validator._data_description = reference_columns

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -274,6 +274,20 @@ def test_validate_data_columns_preserves_dimensionless_integer_dtype():
     assert data_validator.data_table["showers_per_run"].dtype == np.dtype("int64")
 
 
+def test_validate_data_columns_checks_range_after_unit_conversion(reference_columns):
+    data_validator = validate_data.DataValidator()
+    data_validator._data_description = reference_columns
+    data_validator.data_table = Table()
+    data_validator.data_table["wavelength"] = Column([300.0, 700.0], unit="nm", dtype="float64")
+    data_validator.data_table["qe"] = Column([0.1, 0.5], dtype="float64")
+    data_validator.data_table["position_x"] = Column([0.0004, 0.0006], unit="km", dtype="float64")
+
+    data_validator._validate_data_columns()
+
+    assert data_validator.data_table["position_x"].unit == u.m
+    assert data_validator.data_table["position_x"].value[0] == pytest.approx(0.4)
+
+
 def test_sort_data(reference_columns, caplog):
     data_validator = validate_data.DataValidator()
     data_validator._data_description = reference_columns

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import astropy.units as u
+import numpy as np
 import pytest
 from astropy.table import Table
 
@@ -67,6 +68,17 @@ def test_serialize_and_read_job_grid_ecsv(tmp_test_directory):
     assert metadata["job_grid_summary"]["simulation_rows"] == 1
     assert metadata["job_grid_summary"]["total_showers"] == 1000
     assert metadata["job_grid_summary"]["energy_min_used"] == "30 GeV"
+
+
+def test_serialize_job_grid_preserves_integer_dtypes_on_disk(tmp_test_directory):
+    output_file = Path(tmp_test_directory) / "job_grid.ecsv"
+
+    job_grid_io.serialize_job_grid(_job_rows(), output_file, metadata=_metadata())
+    output_table = Table.read(output_file, format="ascii.ecsv")
+
+    assert np.issubdtype(output_table["run_number"].dtype, np.integer)
+    assert np.issubdtype(output_table["cores_per_shower"].dtype, np.integer)
+    assert np.issubdtype(output_table["showers_per_run"].dtype, np.integer)
 
 
 def test_serialize_job_grid_and_read_multiple_rows(tmp_test_directory):


### PR DESCRIPTION
Problem: job-grid validation converted dimensionless integer columns like run_number through unit conversion, so generated ECSV files were written with float dtypes.

Solution: route table-column conversion through the dimensionless-aware validator path, preserve integer dtypes, and add regression tests plus a bugfix changelog fragment.