### PR TITLE
Use python time package for run-time determination of simulation jobs

### DIFF
--- a/docs/changes/2354.maintenance.md
+++ b/docs/changes/2354.maintenance.md
@@ -1,1 +1,1 @@
-Replace bash run-time determination of simulation jobs and use the python time package.
+Replace bash runtime determination of simulation jobs with Python's time module.

--- a/docs/changes/2354.maintenance.md
+++ b/docs/changes/2354.maintenance.md
@@ -1,0 +1,1 @@
+Replace bash run-time determination of simulation jobs and use the python time package.

--- a/src/simtools/job_execution/job_manager.py
+++ b/src/simtools/job_execution/job_manager.py
@@ -69,6 +69,7 @@ def submit(
     test=False,
     check=True,
     capture_output=True,
+    return_runtime=False,
 ):
     """
     Submit a job described by a command or a shell script.
@@ -102,6 +103,15 @@ def submit(
     capture_output: bool
         If True, capture stdout/stderr in pipes when no output files are provided.
         If False, inherit parent stdout/stderr when no output files are provided.
+    return_runtime: bool
+        If True, return a tuple containing the subprocess result and its wall-clock
+        runtime in seconds.
+
+    Returns
+    -------
+    subprocess.CompletedProcess or tuple
+        The subprocess result, or the result and wall-clock runtime when
+        ``return_runtime`` is True. Returns None in testing mode.
     """
     command = _build_command(command, configuration, runtime_environment)
 
@@ -115,6 +125,7 @@ def submit(
 
     sub_process_env = _build_environment(env)
     stdout, stderr = _prepare_streams(out_file, err_file, capture_output)
+    start_time = time.perf_counter()
 
     try:
         result = subprocess.run(
@@ -130,11 +141,14 @@ def submit(
     except subprocess.CalledProcessError as exc:
         _raise_job_execution_error(exc, out_file, err_file, application_log)
     finally:
+        runtime = time.perf_counter() - start_time
         if out_file:
             stdout.close()
         if err_file:
             stderr.close()
 
+    if return_runtime:
+        return result, runtime
     return result
 
 

--- a/src/simtools/job_execution/job_manager.py
+++ b/src/simtools/job_execution/job_manager.py
@@ -125,7 +125,7 @@ def submit(
 
     sub_process_env = _build_environment(env)
     stdout, stderr = _prepare_streams(out_file, err_file, capture_output)
-    start_time = time.perf_counter()
+    start_time = time.perf_counter() if return_runtime else None
 
     try:
         result = subprocess.run(
@@ -141,7 +141,8 @@ def submit(
     except subprocess.CalledProcessError as exc:
         _raise_job_execution_error(exc, out_file, err_file, application_log)
     finally:
-        runtime = time.perf_counter() - start_time
+        if return_runtime:
+            runtime = time.perf_counter() - start_time
         if out_file:
             stdout.close()
         if err_file:

--- a/src/simtools/runners/corsika_runner.py
+++ b/src/simtools/runners/corsika_runner.py
@@ -98,9 +98,6 @@ class CorsikaRunner:
             file.write("set -e\n")
             file.write("set -o pipefail\n")
 
-            # Setting SECONDS variable to measure runtime
-            file.write("\nSECONDS=0\n")
-
             if extra_commands is not None:
                 file.write("\n# Writing extras\n")
                 file.write(f"{extra_commands}\n")
@@ -117,8 +114,6 @@ class CorsikaRunner:
             file.write("\n# Cleanup\n")
             file.write(f"gzip {corsika_log_file}\n")
 
-            file.write('\necho "RUNTIME: $SECONDS"\n')
-
-    def get_resources(self, sub_out_file):
+    def get_resources(self, runtime=None):
         """Return computing resources used."""
-        return self.runner_service.get_resources(sub_out_file)
+        return self.runner_service.get_resources(runtime=runtime)

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -146,9 +146,9 @@ class CorsikaSimtelRunner:
 
         multipipe_script.chmod(multipipe_script.stat().st_mode | stat.S_IEXEC)
 
-    def get_resources(self, run_number=None):
+    def get_resources(self, runtime=None):
         """Return computing resources used."""
-        return self.corsika_runner.get_resources(run_number)
+        return self.corsika_runner.get_resources(runtime=runtime)
 
     def update_file_list_from_runners(self):
         """

--- a/src/simtools/runners/runner_services.py
+++ b/src/simtools/runners/runner_services.py
@@ -317,32 +317,20 @@ class RunnerServices:
             return ""
         return f"run{validate_corsika_run_number(run_number):06d}"
 
-    def get_resources(self, sub_out_file):
+    def get_resources(self, runtime=None):
         """
-        Read run time of job from last line of submission log file.
+        Return resources used by a simulation run.
 
         Parameters
         ----------
-        sub_out_file: str or Path
-            Path to the submission output file.
+        runtime: float, optional
+            Wall-clock runtime in seconds measured by the Python subprocess caller.
 
         Returns
         -------
         dict
             run time and number of simulated events
         """
-        _logger.debug(f"Reading resources from {sub_out_file}")
-
-        runtime = None
-        with open(sub_out_file, encoding="utf-8") as f:
-            for line in reversed(f.readlines()):
-                if "RUNTIME" in line:
-                    runtime = int(line.split()[1])
-                    break
-
-        if runtime is None:
-            _logger.debug("RUNTIME was not found in run log file")
-
         if isinstance(self.config, CorsikaConfig):
             return {
                 "runtime": runtime,

--- a/src/simtools/runners/simtel_runner.py
+++ b/src/simtools/runners/simtel_runner.py
@@ -75,6 +75,6 @@ class SimtelRunner:
         """Make the sim_telarray run command (to implemented in subclasses)."""
         raise NotImplementedError("Must be implemented in concrete subclass")
 
-    def get_resources(self, run_number=None):
+    def get_resources(self, runtime=None):
         """Return computing resources used."""
-        return self.runner_service.get_resources(run_number)
+        return self.runner_service.get_resources(runtime=runtime)

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -57,8 +57,6 @@ class SimulatorArray(SimtelRunner):
             file.write("#!/usr/bin/env bash\n\n")
             file.write("set -e\n")
             file.write("set -o pipefail\n")
-            file.write("\nSECONDS=0\n")
-
             if extra_commands:
                 file.write("# Writing extras\n")
                 for line in extra_commands:
@@ -71,8 +69,6 @@ class SimulatorArray(SimtelRunner):
                     + " ".join(command)
                     + f" 2>&1 | gzip > {log_file}\n"
                 )
-
-            file.write('\necho "RUNTIME: $SECONDS"\n')
 
     def make_run_command(self, run_number=None, input_file=None):
         """

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -65,6 +65,7 @@ class Simulator:
         self.io_handler = io_handler.IOHandler()
 
         self._extra_commands = extra_commands
+        self._runtime = None
         self.run_number = self._initialize_from_tool_configuration()
 
         self.array_models, self.corsika_configurations = self._initialize_array_models()
@@ -198,11 +199,12 @@ class Simulator:
         )
         self.update_file_lists()
 
-        job_manager.submit(
+        _, self._runtime = job_manager.submit(
             command=self.runner_service.get_file_name("sub_script", self.run_number),
             out_file=self.runner_service.get_file_name("sub_out", self.run_number),
             err_file=self.runner_service.get_file_name("sub_err", self.run_number),
             env=simtel_runner.SIM_TELARRAY_ENV,
+            return_runtime=True,
         )
 
     @classmethod
@@ -315,7 +317,7 @@ class Simulator:
 
         """
         runtime = []
-        _resources = self._simulation_runner.get_resources(self.get_files(file_type="sub_out"))
+        _resources = self._simulation_runner.get_resources(runtime=self._runtime)
         if _resources.get("runtime") is not None:
             runtime.append(_resources["runtime"])
 

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -67,6 +67,15 @@ def test_submit_with_pipes(mock_successful_run):
     assert call_args[1]["stderr"] == subprocess.PIPE
 
 
+def test_submit_returns_runtime(mock_successful_run, mocker):
+    mocker.patch("simtools.job_execution.job_manager.time.perf_counter", side_effect=[10.0, 12.5])
+
+    result, runtime = jm.submit("echo test", return_runtime=True)
+
+    assert result is not None
+    assert runtime == pytest.approx(2.5)
+
+
 def test_submit_without_capture_output_uses_inherited_streams(mock_successful_run):
     result = jm.submit("echo test", None, None, capture_output=False)
 

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -67,6 +67,14 @@ def test_submit_with_pipes(mock_successful_run):
     assert call_args[1]["stderr"] == subprocess.PIPE
 
 
+def test_submit_does_not_measure_runtime_by_default(mock_successful_run, mocker):
+    perf_counter = mocker.patch("simtools.job_execution.job_manager.time.perf_counter")
+
+    jm.submit("echo test")
+
+    perf_counter.assert_not_called()
+
+
 def test_submit_returns_runtime(mock_successful_run, mocker):
     mocker.patch("simtools.job_execution.job_manager.time.perf_counter", side_effect=[10.0, 12.5])
 

--- a/tests/unit_tests/runners/test_corsika_runner.py
+++ b/tests/unit_tests/runners/test_corsika_runner.py
@@ -65,11 +65,9 @@ def test_prepare_run_with_extra(corsika_runner_mock_array_model, file_has_text, 
         assert bin_bash in script_content
 
 
-def test_get_resources(corsika_runner_mock_array_model, tmp_path):
-    # get_resources now requires sub_out_file parameter
-    test_file = tmp_path / "nonexistent_file.log"
-    with pytest.raises(FileNotFoundError):
-        corsika_runner_mock_array_model.get_resources(test_file)
+def test_get_resources(corsika_runner_mock_array_model):
+    resources = corsika_runner_mock_array_model.get_resources(runtime=2.5)
+    assert resources["runtime"] == pytest.approx(2.5)
 
 
 def test_corsika_executable(corsika_runner_mock_array_model):

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -46,6 +46,19 @@ def test_corsika_simtel_runner(corsika_simtel_runner):
     assert isinstance(corsika_simtel_runner.simulator_array[0], SimulatorArray)
 
 
+def test_get_resources(corsika_simtel_runner, mocker):
+    get_resources = mocker.patch.object(
+        corsika_simtel_runner.corsika_runner,
+        "get_resources",
+        return_value={"runtime": 2.5, "n_events": 100},
+    )
+
+    result = corsika_simtel_runner.get_resources(runtime=2.5)
+
+    assert result == {"runtime": 2.5, "n_events": 100}
+    get_resources.assert_called_once_with(runtime=2.5)
+
+
 def test_prepare_run(corsika_simtel_runner, tmp_path):
     # prepare_run now requires sub_script parameter and doesn't return the script path
     script_path = tmp_path / "test_script.sh"

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -148,30 +148,17 @@ def test_get_run_number_string(runner_service_config_only):
     assert runner_service_config_only._get_run_number_string(None) == ""
 
 
-def test_get_resources(runner_service_mock_array_model, caplog):
-    sub_log_file = runner_service_mock_array_model.get_file_name(file_type="sub_log", run_number=5)
-    with open(sub_log_file, "w", encoding="utf-8") as file:
-        lines_to_write = ["RUNTIME 500\n"]
-        file.writelines(lines_to_write)
-    resources = runner_service_mock_array_model.get_resources(sub_log_file)
+def test_get_resources(runner_service_mock_array_model):
+    resources = runner_service_mock_array_model.get_resources(runtime=12.5)
     assert isinstance(resources, dict)
     assert "runtime" in resources
-    assert resources["runtime"] == 500
+    assert resources["runtime"] == pytest.approx(12.5)
     # NSHOW from corsika_config_data fixture
     assert resources["n_events"] == 100
 
-    with open(sub_log_file, "w", encoding="utf-8") as file:
-        lines_to_write = ["SOMETHING ELSE 500\n"]
-        file.writelines(lines_to_write)
-
-    with caplog.at_level(logging.DEBUG):
-        resources = runner_service_mock_array_model.get_resources(sub_log_file)
-    assert resources["runtime"] is None
-    assert "RUNTIME was not found in run log file" in caplog.text
-
     runner_service_mock_array_model.config = None
-    resources = runner_service_mock_array_model.get_resources(sub_log_file)
-    assert resources["runtime"] is None
+    resources = runner_service_mock_array_model.get_resources(runtime=12.5)
+    assert resources["runtime"] == pytest.approx(12.5)
 
 
 def test_validate_corsika_run_number():

--- a/tests/unit_tests/runners/test_simtel_runner.py
+++ b/tests/unit_tests/runners/test_simtel_runner.py
@@ -19,6 +19,19 @@ def test_run(simtel_runner, caplog, mocker):
         simtel_runner.run(test=True, input_file="test", run_number=5)
 
 
+def test_get_resources(simtel_runner, mocker):
+    get_resources = mocker.patch.object(
+        simtel_runner.runner_service,
+        "get_resources",
+        return_value={"runtime": 2.5, "n_events": None},
+    )
+
+    result = simtel_runner.get_resources(runtime=2.5)
+
+    assert result == {"runtime": 2.5, "n_events": None}
+    get_resources.assert_called_once_with(runtime=2.5)
+
+
 def test_run_with_runs_per_set(simtel_runner, mocker):
     mock_make_run_command = mocker.patch.object(
         simtel_runner, "make_run_command", return_value=("echo test", None, None)

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -56,8 +56,6 @@ def test_prepare_run(simtel_runner, tmp_path, mocker):
     assert "export TEST_VAR=1" in content
     assert "echo 'extra command'" in content
     assert "echo 'test command'" in content
-    assert "SECONDS=0" in content
-    assert 'echo "RUNTIME: $SECONDS"' in content
 
 
 def test_prepare_run_no_extra_commands(simtel_runner, tmp_path, mocker):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -1055,8 +1055,9 @@ def test_simulate(array_simulator, mocker):
 
     mocker.patch.object(array_simulator, "_get_corsika_file", return_value="/path/to/corsika.file")
     mocker.patch.object(array_simulator, "update_file_lists")
-
-    mock_submit = mocker.patch("simtools.job_execution.job_manager.submit")
+    mock_submit = mocker.patch(
+        "simtools.job_execution.job_manager.submit", return_value=(None, 2.5)
+    )
 
     array_simulator.simulate()
 
@@ -1074,7 +1075,9 @@ def test_simulate(array_simulator, mocker):
         out_file="output_42.out",
         err_file="output_42.err",
         env={"SIM_TELARRAY_CONFIG_PATH": ""},
+        return_runtime=True,
     )
+    assert array_simulator._runtime == pytest.approx(2.5)
 
 
 def test_save_file_lists(array_simulator, mocker, tmp_test_directory, caplog):


### PR DESCRIPTION
Definitely simpler to use the python time package before / after the subprocess call then writing a command to the bash scripts, and then retrieve the run time from the log file.

Closes #2299