### PR TITLE
Improve integration testing and validation of output 

### DIFF
--- a/docs/changes/2356.feature.md
+++ b/docs/changes/2356.feature.md
@@ -1,0 +1,1 @@
+Expand integration testing of generated ECSV tables with schema, content, and metadata validation.

--- a/docs/source/developer-guide/testing_integration.md
+++ b/docs/source/developer-guide/testing_integration.md
@@ -110,3 +110,96 @@ Prefer explicit validation blocks over exit-code-only tests. Common patterns:
 
 Keep generated outputs deterministic by fixing seeds, labels, event counts,
 worker counts, and version-specific expectations.
+
+## Declarative output validation
+
+An integration test may include an optional `output_validation` list. Each file
+rule declares `kind`, `path_descriptor`, and `file`. Supported kinds are
+`file`, `table`, `mapping`, `group`, and `event_stream`.
+
+```yaml
+output_validation:
+- name: job_grid_content
+  kind: table
+  path_descriptor: output_path
+  file: job_grid.ecsv
+  format: ecsv
+  non_empty: true
+  count:
+    minimum: 1
+  required_columns: [run_number, model_version]
+  columns:
+    run_number:
+      type: int64
+      finite: true
+      unique: true
+    energy_min:
+      type: float64
+      range:
+        minimum: 30.0
+        maximum: 300.0
+        unit: GeV
+  metadata:
+    required_keys: [job_grid_summary]
+  consistency:
+  - left:
+      source: metadata
+      path: job_grid_summary.simulation_rows
+    operator: equals
+    right:
+      source: content
+      metric: row_count
+  data_product_schema: src/simtools/schemas/job_grid_density.schema.yml
+```
+
+`non_empty` checks bytes for a generic file, rows for a table, keys for a
+mapping or HDF5 group, and events for an event stream. `count` supports
+`exact`, `minimum`, and `maximum`. Column rules support declared data types,
+units, finite values, uniqueness, allowed values, and inclusive numerical
+ranges. Required and forbidden keys or columns are checked before field rules.
+
+When `data_product_schema` is provided, schema-owned constraints such as
+required columns, column types, and units can be omitted from the validation
+rule. Keep the rule focused on content invariants and workflow-specific domains
+that are not part of the general product schema.
+
+Consistency operands use only structured references: metadata paths such as
+`job_grid_summary.total_showers`, content metrics such as `row_count`, and
+column aggregates (`sum`, `minimum`, `maximum`, `count`, or `unique_count`).
+Supported operators are `equals`, `greater_than`, `greater_equal`,
+`less_than`, `less_equal`, and `in`.
+
+Use a `kind: relationship` rule only when the values being compared are in
+different output files. Each entry in `outputs` gives a generated file a local
+name. A check operand selects that name with `output`, then reads either a
+dotted mapping or metadata `path`, or a content `metric` such as `row_count`.
+For example, if an application writes `jobs.ecsv` and a separate
+`summary.yml`, this checks that the summary reports the actual number of rows:
+
+```yaml
+output_validation:
+- name: summary_matches_jobs
+  kind: relationship
+  outputs:
+  - name: jobs
+    kind: table
+    path_descriptor: output_path
+    file: jobs.ecsv
+    format: ecsv
+  - name: summary
+    kind: mapping
+    path_descriptor: output_path
+    file: summary.yml
+  checks:
+  - left:
+      output: summary
+      path: simulation_rows
+    operator: equals
+    right:
+      output: jobs
+      metric: row_count
+```
+
+If `summary.yml` reports `3` while `jobs.ecsv` has `2` rows, the relationship
+fails. If the summary is metadata inside `jobs.ecsv`, use a `consistency` rule
+instead; that compares metadata and content within one output.

--- a/docs/source/developer-guide/testing_integration.md
+++ b/docs/source/developer-guide/testing_integration.md
@@ -12,9 +12,13 @@ Integration tests should cover:
 - internal interfaces where one `simtools` output becomes another input
 - selected compatibility checks for generated products
 
-Keep pull-request integration tests within typical GitHub CI runtime. Prefer
-cheap checks first and stronger numerical or file-based validation where it
-adds signal.
+The tests follow the following levels of assertion, from weakest to strongest:
+
+- execution only;
+- file presence;
+- parse or schema validation;
+- semantic invariants;
+- deterministic reference comparison.
 
 ## Workflow Files
 
@@ -113,93 +117,40 @@ worker counts, and version-specific expectations.
 
 ## Declarative output validation
 
-An integration test may include an optional `output_validation` list. Each file
-rule declares `kind`, `path_descriptor`, and `file`. Supported kinds are
-`file`, `table`, `mapping`, `group`, and `event_stream`.
+An integration test may include an optional `output_validation` list for
+generated ECSV tables. Each rule declares the output location and its
+data-product schema. The schema validates required columns, types, units, and
+finite numerical values; keep the workflow rule focused on invariants specific
+to the integration-test configuration.
 
 ```yaml
 output_validation:
 - name: job_grid_content
-  kind: table
   path_descriptor: output_path
   file: job_grid.ecsv
-  format: ecsv
-  non_empty: true
-  count:
-    minimum: 1
-  required_columns: [run_number, model_version]
+  data_product_schema: src/simtools/schemas/job_grid_density.schema.yml
+  minimum_rows: 1
+  unique_columns: [run_number]
   columns:
-    run_number:
-      type: int64
-      finite: true
-      unique: true
+    primary:
+      allowed_values: [gamma, proton]
     energy_min:
-      type: float64
       range:
         minimum: 30.0
         maximum: 300.0
         unit: GeV
   metadata:
     required_keys: [job_grid_summary]
-  consistency:
-  - left:
-      source: metadata
-      path: job_grid_summary.simulation_rows
-    operator: equals
-    right:
-      source: content
-      metric: row_count
-  data_product_schema: src/simtools/schemas/job_grid_density.schema.yml
+    row_count: job_grid_summary.simulation_rows
+    column_sums:
+      showers_per_run: job_grid_summary.total_showers
 ```
 
-`non_empty` checks bytes for a generic file, rows for a table, keys for a
-mapping or HDF5 group, and events for an event stream. `count` supports
-`exact`, `minimum`, and `maximum`. Column rules support declared data types,
-units, finite values, uniqueness, allowed values, and inclusive numerical
-ranges. Required and forbidden keys or columns are checked before field rules.
+`minimum_rows` rejects empty or unexpectedly short tables. `unique_columns`
+checks complete columns for duplicate values. Column rules support
+`allowed_values` and inclusive or exclusive numerical `range` bounds, with an
+optional unit. Metadata paths use dotted mapping notation.
 
-When `data_product_schema` is provided, schema-owned constraints such as
-required columns, column types, and units can be omitted from the validation
-rule. Keep the rule focused on content invariants and workflow-specific domains
-that are not part of the general product schema.
-
-Consistency operands use only structured references: metadata paths such as
-`job_grid_summary.total_showers`, content metrics such as `row_count`, and
-column aggregates (`sum`, `minimum`, `maximum`, `count`, or `unique_count`).
-Supported operators are `equals`, `greater_than`, `greater_equal`,
-`less_than`, `less_equal`, and `in`.
-
-Use a `kind: relationship` rule only when the values being compared are in
-different output files. Each entry in `outputs` gives a generated file a local
-name. A check operand selects that name with `output`, then reads either a
-dotted mapping or metadata `path`, or a content `metric` such as `row_count`.
-For example, if an application writes `jobs.ecsv` and a separate
-`summary.yml`, this checks that the summary reports the actual number of rows:
-
-```yaml
-output_validation:
-- name: summary_matches_jobs
-  kind: relationship
-  outputs:
-  - name: jobs
-    kind: table
-    path_descriptor: output_path
-    file: jobs.ecsv
-    format: ecsv
-  - name: summary
-    kind: mapping
-    path_descriptor: output_path
-    file: summary.yml
-  checks:
-  - left:
-      output: summary
-      path: simulation_rows
-    operator: equals
-    right:
-      output: jobs
-      metric: row_count
-```
-
-If `summary.yml` reports `3` while `jobs.ecsv` has `2` rows, the relationship
-fails. If the summary is metadata inside `jobs.ecsv`, use a `consistency` rule
-instead; that compares metadata and content within one output.
+`metadata.row_count` names a metadata value that must equal the number of table
+rows. Each `metadata.column_sums` entry maps a table column to metadata that
+must equal that column's sum.

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -113,6 +113,9 @@ definitions:
         xfail_network_error:
           type: boolean
           description: "Mark test as xfail if application exits with a network error."
+        xfail:
+          type: string
+          description: "Expected failure reason for this workflow."
       required:
         - application
         - configuration

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -208,25 +208,20 @@ definitions:
               description: "Condition to apply to the cut column."
               type: string
       output_validation:
-        description: "Declarative semantic validation rules for generated outputs."
+        description: "Declarative validation rules for generated ECSV tables."
         type: array
         minItems: 1
         items:
-          oneOf:
-            - "$ref": "#/definitions/output_validation_file_rule"
-            - "$ref": "#/definitions/output_validation_relationship_rule"
+          "$ref": "#/definitions/output_validation_table_rule"
     title: ApplicationWorkflow
-  output_validation_file_rule:
-    description: "Semantic validation rules for one output file or data product."
+  output_validation_table_rule:
+    description: "Content validation rules for one generated ECSV table."
     type: object
     additionalProperties: false
     properties:
       name:
         type: string
         minLength: 1
-      kind:
-        type: string
-        enum: [file, table, mapping, group, event_stream]
       path_descriptor:
         type: string
         minLength: 1
@@ -235,36 +230,13 @@ definitions:
       file:
         type: string
         minLength: 1
-      format:
+      data_product_schema:
         type: string
-        enum: [ecsv, fits, json, yaml, yml, hdf5, simtel]
-      object_path:
-        type: string
-      event_type:
-        type: string
-      non_empty:
-        type: boolean
-      count:
-        "$ref": "#/definitions/output_validation_count"
-      required_keys:
-        type: array
-        uniqueItems: true
-        items:
-          type: string
-          minLength: 1
-      forbidden_keys:
-        type: array
-        uniqueItems: true
-        items:
-          type: string
-          minLength: 1
-      required_columns:
-        type: array
-        uniqueItems: true
-        items:
-          type: string
-          minLength: 1
-      forbidden_columns:
+        minLength: 1
+      minimum_rows:
+        type: integer
+        minimum: 0
+      unique_columns:
         type: array
         uniqueItems: true
         items:
@@ -273,79 +245,10 @@ definitions:
       columns:
         type: object
         additionalProperties:
-          "$ref": "#/definitions/output_validation_field_rule"
+          "$ref": "#/definitions/output_validation_column_rule"
       metadata:
         "$ref": "#/definitions/output_validation_metadata_rule"
-      consistency:
-        type: array
-        items:
-          "$ref": "#/definitions/output_validation_consistency_rule"
-      data_product_schema:
-        type: string
-        minLength: 1
-    required: [kind, path_descriptor, file]
-  output_validation_relationship_rule:
-    description: "Semantic relationship checks between multiple output files."
-    type: object
-    additionalProperties: false
-    properties:
-      name:
-        type: string
-        minLength: 1
-      kind:
-        type: string
-        enum: [relationship]
-      outputs:
-        type: array
-        minItems: 2
-        items:
-          "$ref": "#/definitions/output_validation_output_reference"
-      checks:
-        type: array
-        minItems: 1
-        items:
-          "$ref": "#/definitions/output_validation_relationship_check"
-    required: [kind, outputs, checks]
-  output_validation_output_reference:
-    type: object
-    additionalProperties: false
-    properties:
-      name:
-        type: string
-        minLength: 1
-      path_descriptor:
-        type: string
-        minLength: 1
-      output_sub_path:
-        type: string
-      file:
-        type: string
-        minLength: 1
-      kind:
-        type: string
-        enum: [file, table, mapping, group, event_stream]
-      format:
-        type: string
-        enum: [ecsv, fits, json, yaml, yml, hdf5, simtel]
-      object_path:
-        type: string
-      event_type:
-        type: string
-    required: [name, path_descriptor, file, kind]
-  output_validation_count:
-    type: object
-    additionalProperties: false
-    properties:
-      exact:
-        type: integer
-        minimum: 0
-      minimum:
-        type: integer
-        minimum: 0
-      maximum:
-        type: integer
-        minimum: 0
-    minProperties: 1
+    required: [path_descriptor, file, data_product_schema]
   output_validation_range:
     type: object
     additionalProperties: false
@@ -363,38 +266,17 @@ definitions:
     anyOf:
       - required: [minimum]
       - required: [maximum]
-  output_validation_field_rule:
+  output_validation_column_rule:
     type: object
     additionalProperties: false
     properties:
-      type:
-        type: string
-        enum:
-          - bool
-          - string
-          - int8
-          - int16
-          - int32
-          - int64
-          - uint8
-          - uint16
-          - uint32
-          - uint64
-          - float32
-          - float64
-          - number
-      unit:
-        type: string
-      finite:
-        type: boolean
-      unique:
-        type: boolean
       allowed_values:
         type: array
         minItems: 1
         items: {}
       range:
         "$ref": "#/definitions/output_validation_range"
+    minProperties: 1
   output_validation_metadata_rule:
     type: object
     additionalProperties: false
@@ -405,89 +287,13 @@ definitions:
         items:
           type: string
           minLength: 1
-      forbidden_keys:
-        type: array
-        uniqueItems: true
-        items:
+      row_count:
+        type: string
+        minLength: 1
+      column_sums:
+        type: object
+        minProperties: 1
+        additionalProperties:
           type: string
           minLength: 1
     minProperties: 1
-  output_validation_operand:
-    oneOf:
-      - type: [string, number, boolean, 'null']
-      - type: object
-        additionalProperties: false
-        properties:
-          source:
-            type: string
-            enum: [metadata, content]
-          path:
-            type: string
-            minLength: 1
-          metric:
-            type: string
-            enum: [row_count, event_count, member_count, key_count]
-          aggregate:
-            "$ref": "#/definitions/output_validation_aggregate"
-        required: [source]
-        oneOf:
-          - required: [path]
-          - required: [metric]
-          - required: [aggregate]
-  output_validation_aggregate:
-    type: object
-    additionalProperties: false
-    properties:
-      function:
-        type: string
-        enum: [sum, minimum, maximum, count, unique_count]
-      column:
-        type: string
-        minLength: 1
-    required: [function, column]
-  output_validation_consistency_rule:
-    type: object
-    additionalProperties: false
-    properties:
-      left:
-        "$ref": "#/definitions/output_validation_operand"
-      operator:
-        type: string
-        enum: [equals, greater_than, greater_equal, less_than, less_equal, in]
-      right:
-        "$ref": "#/definitions/output_validation_operand"
-    required: [left, operator, right]
-  output_validation_relationship_operand:
-    oneOf:
-      - type: [string, number, boolean, 'null']
-      - type: object
-        additionalProperties: false
-        properties:
-          output:
-            type: string
-            minLength: 1
-          path:
-            type: string
-            minLength: 1
-          metric:
-            type: string
-            enum: [row_count, event_count, member_count, key_count]
-          aggregate:
-            "$ref": "#/definitions/output_validation_aggregate"
-        required: [output]
-        oneOf:
-          - required: [path]
-          - required: [metric]
-          - required: [aggregate]
-  output_validation_relationship_check:
-    type: object
-    additionalProperties: false
-    properties:
-      left:
-        "$ref": "#/definitions/output_validation_relationship_operand"
-      operator:
-        type: string
-        enum: [equals, greater_than, greater_equal, less_than, less_equal, in]
-      right:
-        "$ref": "#/definitions/output_validation_relationship_operand"
-    required: [left, operator, right]

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -207,4 +207,287 @@ definitions:
             cut_condition:
               description: "Condition to apply to the cut column."
               type: string
+      output_validation:
+        description: "Declarative semantic validation rules for generated outputs."
+        type: array
+        minItems: 1
+        items:
+          oneOf:
+            - "$ref": "#/definitions/output_validation_file_rule"
+            - "$ref": "#/definitions/output_validation_relationship_rule"
     title: ApplicationWorkflow
+  output_validation_file_rule:
+    description: "Semantic validation rules for one output file or data product."
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        minLength: 1
+      kind:
+        type: string
+        enum: [file, table, mapping, group, event_stream]
+      path_descriptor:
+        type: string
+        minLength: 1
+      output_sub_path:
+        type: string
+      file:
+        type: string
+        minLength: 1
+      format:
+        type: string
+        enum: [ecsv, fits, json, yaml, yml, hdf5, simtel]
+      object_path:
+        type: string
+      event_type:
+        type: string
+      non_empty:
+        type: boolean
+      count:
+        "$ref": "#/definitions/output_validation_count"
+      required_keys:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+      forbidden_keys:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+      required_columns:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+      forbidden_columns:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+      columns:
+        type: object
+        additionalProperties:
+          "$ref": "#/definitions/output_validation_field_rule"
+      metadata:
+        "$ref": "#/definitions/output_validation_metadata_rule"
+      consistency:
+        type: array
+        items:
+          "$ref": "#/definitions/output_validation_consistency_rule"
+      data_product_schema:
+        type: string
+        minLength: 1
+    required: [kind, path_descriptor, file]
+  output_validation_relationship_rule:
+    description: "Semantic relationship checks between multiple output files."
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        minLength: 1
+      kind:
+        type: string
+        enum: [relationship]
+      outputs:
+        type: array
+        minItems: 2
+        items:
+          "$ref": "#/definitions/output_validation_output_reference"
+      checks:
+        type: array
+        minItems: 1
+        items:
+          "$ref": "#/definitions/output_validation_relationship_check"
+    required: [kind, outputs, checks]
+  output_validation_output_reference:
+    type: object
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        minLength: 1
+      path_descriptor:
+        type: string
+        minLength: 1
+      output_sub_path:
+        type: string
+      file:
+        type: string
+        minLength: 1
+      kind:
+        type: string
+        enum: [file, table, mapping, group, event_stream]
+      format:
+        type: string
+        enum: [ecsv, fits, json, yaml, yml, hdf5, simtel]
+      object_path:
+        type: string
+      event_type:
+        type: string
+    required: [name, path_descriptor, file, kind]
+  output_validation_count:
+    type: object
+    additionalProperties: false
+    properties:
+      exact:
+        type: integer
+        minimum: 0
+      minimum:
+        type: integer
+        minimum: 0
+      maximum:
+        type: integer
+        minimum: 0
+    minProperties: 1
+  output_validation_range:
+    type: object
+    additionalProperties: false
+    properties:
+      minimum:
+        type: number
+      maximum:
+        type: number
+      unit:
+        type: string
+        minLength: 1
+      inclusive:
+        type: boolean
+    minProperties: 1
+    anyOf:
+      - required: [minimum]
+      - required: [maximum]
+  output_validation_field_rule:
+    type: object
+    additionalProperties: false
+    properties:
+      type:
+        type: string
+        enum:
+          - bool
+          - string
+          - int8
+          - int16
+          - int32
+          - int64
+          - uint8
+          - uint16
+          - uint32
+          - uint64
+          - float32
+          - float64
+          - number
+      unit:
+        type: string
+      finite:
+        type: boolean
+      unique:
+        type: boolean
+      allowed_values:
+        type: array
+        minItems: 1
+        items: {}
+      range:
+        "$ref": "#/definitions/output_validation_range"
+  output_validation_metadata_rule:
+    type: object
+    additionalProperties: false
+    properties:
+      required_keys:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+      forbidden_keys:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
+          minLength: 1
+    minProperties: 1
+  output_validation_operand:
+    oneOf:
+      - type: [string, number, boolean, 'null']
+      - type: object
+        additionalProperties: false
+        properties:
+          source:
+            type: string
+            enum: [metadata, content]
+          path:
+            type: string
+            minLength: 1
+          metric:
+            type: string
+            enum: [row_count, event_count, member_count, key_count]
+          aggregate:
+            "$ref": "#/definitions/output_validation_aggregate"
+        required: [source]
+        oneOf:
+          - required: [path]
+          - required: [metric]
+          - required: [aggregate]
+  output_validation_aggregate:
+    type: object
+    additionalProperties: false
+    properties:
+      function:
+        type: string
+        enum: [sum, minimum, maximum, count, unique_count]
+      column:
+        type: string
+        minLength: 1
+    required: [function, column]
+  output_validation_consistency_rule:
+    type: object
+    additionalProperties: false
+    properties:
+      left:
+        "$ref": "#/definitions/output_validation_operand"
+      operator:
+        type: string
+        enum: [equals, greater_than, greater_equal, less_than, less_equal, in]
+      right:
+        "$ref": "#/definitions/output_validation_operand"
+    required: [left, operator, right]
+  output_validation_relationship_operand:
+    oneOf:
+      - type: [string, number, boolean, 'null']
+      - type: object
+        additionalProperties: false
+        properties:
+          output:
+            type: string
+            minLength: 1
+          path:
+            type: string
+            minLength: 1
+          metric:
+            type: string
+            enum: [row_count, event_count, member_count, key_count]
+          aggregate:
+            "$ref": "#/definitions/output_validation_aggregate"
+        required: [output]
+        oneOf:
+          - required: [path]
+          - required: [metric]
+          - required: [aggregate]
+  output_validation_relationship_check:
+    type: object
+    additionalProperties: false
+    properties:
+      left:
+        "$ref": "#/definitions/output_validation_relationship_operand"
+      operator:
+        type: string
+        enum: [equals, greater_than, greater_equal, less_than, less_equal, in]
+      right:
+        "$ref": "#/definitions/output_validation_relationship_operand"
+    required: [left, operator, right]

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from collections.abc import Mapping
 from pathlib import Path
 
 import numpy as np
@@ -17,6 +18,8 @@ from simtools.simtel import simtel_validate_metadata
 from simtools.testing import assertions
 
 _logger = logging.getLogger(__name__)
+
+_ECSV_FORMAT = "ascii.ecsv"
 
 
 def _find_repo_root():
@@ -156,7 +159,7 @@ def _has_path(value, dotted_path):
     """Return whether a dotted path exists in nested mappings."""
     current = value
     for part in dotted_path.split("."):
-        if not isinstance(current, dict) or part not in current:
+        if not isinstance(current, Mapping) or part not in current:
             return False
         current = current[part]
     return True
@@ -221,8 +224,11 @@ def _validate_data_product_schema(path, rule, table):
             data_table=table.copy(copy_data=True),
         ).validate_and_transform()
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        _validation_failure(path, rule, f"data-product schema {schema_file}", str(exc))
-        return None
+        rule_name = rule.get("name", "output_validation")
+        raise AssertionError(
+            f"Output '{path}' failed rule '{rule_name}': "
+            f"expected 'data-product schema {schema_file}', actual {str(exc)!r}."
+        ) from exc
 
 
 def _validate_unique_columns(path, rule, table):
@@ -247,7 +253,7 @@ def _validate_metadata(path, rule, table):
     for metadata_path in metadata_rule.get("required_keys", []):
         if not _has_path(table.meta, metadata_path):
             _validation_failure(
-                path, rule, f"required metadata key {metadata_path}", sorted(table.meta)
+                path, rule, f"required metadata key {metadata_path}", list(table.meta)
             )
 
     row_count_path = metadata_rule.get("row_count")
@@ -279,7 +285,7 @@ def _validate_table_output(config, rule):
     if not path.exists():
         _validation_failure(path, rule, "an existing output", "missing")
     try:
-        table = Table.read(path, format="ascii.ecsv")
+        table = Table.read(path, format=_ECSV_FORMAT)
     except Exception as exc:  # pylint: disable=broad-exception-caught
         _validation_failure(path, rule, "a parseable ECSV table", str(exc))
 
@@ -623,8 +629,8 @@ def compare_ecsv_files(file1, file2, tolerance=1.0e-5, test_columns=None):
 
     """
     _logger.info(f"Comparing files: {file1} and {file2}")
-    table1 = Table.read(file1, format="ascii.ecsv")
-    table2 = Table.read(file2, format="ascii.ecsv")
+    table1 = Table.read(file1, format=_ECSV_FORMAT)
+    table2 = Table.read(file2, format=_ECSV_FORMAT)
 
     if test_columns is None:
         test_columns = [{"test_column_name": col} for col in table1.colnames]

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -4,10 +4,14 @@ import logging
 import re
 from pathlib import Path
 
+import h5py
 import numpy as np
+from astropy import units as u
 from astropy.table import Table
+from eventio.simtel.simtelfile import SimTelFile
 
 import simtools.utils.general as gen
+from simtools.data_model import validate_data
 from simtools.db import db_handler
 from simtools.io import ascii_handler
 from simtools.sim_events import file_info
@@ -101,6 +105,7 @@ def validate_application_output(config, from_command_line=None, from_config_file
 
         if _versions_match(from_command_line, from_config_file):
             _validate_output_files(config, integration_test)
+            _validate_declarative_output(config, integration_test)
 
             if "file_type" in integration_test:
                 assert assertions.assert_file_type(
@@ -127,6 +132,438 @@ def _validate_output_files(config, integration_test):
         )
     if "model_parameter_validation" in integration_test:
         _validate_model_parameter_json_file(config, integration_test["model_parameter_validation"])
+
+
+def _validation_failure(output_path, rule, expected, actual):
+    """Raise a consistently formatted semantic output validation failure."""
+    rule_name = rule.get("name", rule.get("kind", "output_validation"))
+    raise AssertionError(
+        f"Output '{output_path}' failed rule '{rule_name}': "
+        f"expected {expected!r}, actual {actual!r}."
+    )
+
+
+def _output_validation_path(config, descriptor):
+    """Resolve an output descriptor to an absolute or configured output path."""
+    try:
+        base_path = config["configuration"][descriptor["path_descriptor"]]
+    except KeyError as exc:
+        raise KeyError(
+            f"Path {descriptor.get('path_descriptor')} not found in integration test configuration."
+        ) from exc
+    return Path(base_path) / descriptor.get("output_sub_path", "") / descriptor["file"]
+
+
+def _read_hdf5_object(path, object_path, kind):
+    """Read an HDF5 group or dataset into a validation context."""
+    with h5py.File(path, "r") as hdf5_file:
+        selected_path = object_path or "/"
+        selected = hdf5_file[selected_path]
+        metadata = dict(selected.attrs.items())
+        if kind == "group":
+            return {
+                "data": None,
+                "metadata": metadata,
+                "keys": list(selected.keys()),
+                "count": len(selected.keys()),
+            }
+        data = selected[:]
+        return {
+            "data": data,
+            "metadata": metadata,
+            "keys": list(selected.dtype.names or []),
+            "count": len(data),
+        }
+
+
+def _read_event_stream(path, descriptor):
+    """Read an event stream and return its event count and first event fields."""
+    event_type = descriptor.get("event_type")
+    event_type = {
+        "shower": "data",
+        "pedestal": "calibration",
+        "direct_injection": "calibration",
+    }.get(event_type, event_type)
+    file_format = descriptor.get("format", "simtel")
+    if file_format == "hdf5":
+        return _read_hdf5_object(path, descriptor.get("object_path"), "event_stream")
+    if file_format in ("ecsv", "fits"):
+        table = _read_table(path, file_format)
+        return {
+            "data": table,
+            "metadata": dict(table.meta),
+            "keys": table.colnames,
+            "count": len(table),
+        }
+
+    count = 0
+    first_event = None
+    with SimTelFile(path) as event_file:
+        for event in event_file:
+            if event_type and event.get("type") != event_type:
+                continue
+            count += 1
+            if first_event is None:
+                first_event = event
+    return {
+        "data": None,
+        "metadata": {},
+        "keys": list(first_event.keys()) if isinstance(first_event, dict) else [],
+        "count": count,
+    }
+
+
+def _read_table(path, file_format):
+    """Read a supported table format."""
+    if file_format == "ecsv":
+        return Table.read(path, format="ascii.ecsv")
+    return Table.read(path, format="fits")
+
+
+def _load_output_context(path, descriptor):
+    """Load one output and return the normalized semantic validation context."""
+    kind = descriptor["kind"]
+    if not path.exists():
+        _validation_failure(path, descriptor, "an existing output", "missing")
+    if kind == "file":
+        return {"data": None, "metadata": {}, "keys": [], "count": path.stat().st_size}
+    if kind == "table":
+        table = _read_table(path, descriptor.get("format", "ecsv"))
+        return {
+            "data": table,
+            "metadata": dict(table.meta),
+            "keys": table.colnames,
+            "count": len(table),
+        }
+    if kind == "mapping":
+        mapping = ascii_handler.collect_data_from_file(path)
+        if not isinstance(mapping, dict):
+            _validation_failure(path, descriptor, "a mapping", type(mapping).__name__)
+        return {"data": mapping, "metadata": mapping, "keys": list(mapping), "count": len(mapping)}
+    if kind == "group":
+        return _read_hdf5_object(path, descriptor.get("object_path"), kind)
+    if kind == "event_stream":
+        return _read_event_stream(path, descriptor)
+    _validation_failure(path, descriptor, "a supported output kind", kind)
+    return None
+
+
+def _has_path(value, dotted_path):
+    """Return whether a dotted path exists in nested mappings."""
+    current = value
+    for part in dotted_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+def _get_path(value, dotted_path):
+    """Read a dotted path from a nested mapping."""
+    current = value
+    for part in dotted_path.split("."):
+        current = current[part]
+    return current
+
+
+def _validate_count(path, rule, actual):
+    """Validate exact, minimum, and maximum content counts."""
+    count_rule = rule.get("count", {})
+    if "exact" in count_rule and actual != count_rule["exact"]:
+        _validation_failure(path, rule, count_rule["exact"], actual)
+    if "minimum" in count_rule and actual < count_rule["minimum"]:
+        _validation_failure(path, rule, f">={count_rule['minimum']}", actual)
+    if "maximum" in count_rule and actual > count_rule["maximum"]:
+        _validation_failure(path, rule, f"<={count_rule['maximum']}", actual)
+
+
+def _validate_keys(path, rule, context):
+    """Validate required and forbidden mapping or group keys."""
+    keys = set(context["keys"])
+    for key in rule.get("required_keys", []) + rule.get("metadata", {}).get("required_keys", []):
+        if key not in keys and not _has_path(context["metadata"], key):
+            _validation_failure(path, rule, f"required key {key}", sorted(keys))
+    for key in rule.get("forbidden_keys", []) + rule.get("metadata", {}).get("forbidden_keys", []):
+        if key in keys or _has_path(context["metadata"], key):
+            _validation_failure(path, rule, f"forbidden key {key} absent", sorted(keys))
+
+
+def _validate_columns(path, rule, context):
+    """Validate required/forbidden columns and per-column semantic constraints."""
+    data = context["data"]
+    if not isinstance(data, Table):
+        if rule.get("required_columns") or rule.get("forbidden_columns") or rule.get("columns"):
+            _validation_failure(
+                path, rule, "a tabular or structured event output", type(data).__name__
+            )
+        return
+
+    columns = set(data.colnames)
+    _validate_required_columns(path, rule, columns)
+    _validate_forbidden_columns(path, rule, columns)
+
+    for column_name, column_rule in rule.get("columns", {}).items():
+        _validate_column(path, rule, data, columns, column_name, column_rule)
+
+
+def _validate_required_columns(path, rule, columns):
+    """Validate required table columns."""
+    for column in rule.get("required_columns", []):
+        if column not in columns:
+            _validation_failure(path, rule, f"required column {column}", sorted(columns))
+
+
+def _validate_forbidden_columns(path, rule, columns):
+    """Validate forbidden table columns."""
+    for column in rule.get("forbidden_columns", []):
+        if column in columns:
+            _validation_failure(path, rule, f"forbidden column {column} absent", sorted(columns))
+
+
+def _validate_column(path, rule, data, columns, column_name, column_rule):
+    """Validate one table column against its declarative constraints."""
+    if column_name not in columns:
+        _validation_failure(path, rule, f"column {column_name}", sorted(columns))
+    column = data[column_name]
+    values = np.asarray(column)
+    if column_rule.get("type") and not _matches_dtype(values, column_rule["type"]):
+        _validation_failure(
+            path, rule, f"{column_name} type {column_rule['type']}", str(values.dtype)
+        )
+    if column_rule.get("unit") is not None:
+        _validate_unit(path, rule, column_name, column, column_rule["unit"])
+    if column_rule.get("finite"):
+        if not np.issubdtype(values.dtype, np.number) or not np.all(np.isfinite(values)):
+            _validation_failure(path, rule, f"finite values in {column_name}", values.tolist())
+    if column_rule.get("unique") and len(np.unique(values)) != len(values):
+        _validation_failure(path, rule, f"unique values in {column_name}", values.tolist())
+    _validate_allowed_values(path, rule, column_name, column, column_rule)
+    _validate_range(path, rule, column_name, column, column_rule)
+
+
+def _matches_dtype(values, expected_type):
+    """Return whether an array matches a declarative field type."""
+    if expected_type == "string":
+        return values.dtype.kind in "OUS"
+    if expected_type == "bool":
+        return values.dtype.kind == "b"
+    if expected_type == "number":
+        return np.issubdtype(values.dtype, np.number)
+    expected = np.dtype(expected_type)
+    return values.dtype == expected
+
+
+def _validate_unit(path, rule, column_name, column, expected_unit):
+    """Validate that a column has the declared physical unit."""
+    actual_unit = getattr(column, "unit", None) or u.dimensionless_unscaled
+    try:
+        if not actual_unit.is_equivalent(u.Unit(expected_unit)):
+            _validation_failure(
+                path, rule, f"unit {expected_unit} for {column_name}", str(actual_unit)
+            )
+    except ValueError as exc:
+        _validation_failure(path, rule, f"valid unit {expected_unit} for {column_name}", str(exc))
+
+
+def _validate_allowed_values(path, rule, column_name, column, column_rule):
+    """Validate a column against an allowed-value domain."""
+    allowed = column_rule.get("allowed_values")
+    if allowed is None:
+        return
+    values = np.asarray(column)
+    if not np.all(np.isin(values, allowed)):
+        _validation_failure(
+            path, rule, f"allowed values {allowed} for {column_name}", values.tolist()
+        )
+
+
+def _validate_range(path, rule, column_name, column, column_rule):
+    """Validate a numerical column against a unit-aware range."""
+    range_rule = column_rule.get("range")
+    if range_rule is None:
+        return
+    values = np.asarray(column)
+    if not np.issubdtype(values.dtype, np.number):
+        _validation_failure(path, rule, f"numerical range for {column_name}", str(values.dtype))
+    actual_unit = getattr(column, "unit", None) or u.dimensionless_unscaled
+    values = values * actual_unit
+    if range_rule.get("unit"):
+        values = values.to(range_rule["unit"])
+    numeric_values = np.asarray(values.value)
+    inclusive = range_rule.get("inclusive", True)
+    minimum = range_rule.get("minimum")
+    maximum = range_rule.get("maximum")
+    if minimum is not None:
+        valid = numeric_values >= minimum if inclusive else numeric_values > minimum
+        if not np.all(valid):
+            _validation_failure(
+                path, rule, f"minimum {minimum} for {column_name}", numeric_values.tolist()
+            )
+    if maximum is not None:
+        valid = numeric_values <= maximum if inclusive else numeric_values < maximum
+        if not np.all(valid):
+            _validation_failure(
+                path, rule, f"maximum {maximum} for {column_name}", numeric_values.tolist()
+            )
+
+
+def _content_operand(context, operand):
+    """Resolve a content metric or aggregate operand."""
+    if "path" in operand:
+        if isinstance(context["data"], Table) and operand["path"] in context["data"].colnames:
+            return np.asarray(context["data"][operand["path"]])
+        return _get_path(context["data"], operand["path"])
+    if "metric" in operand:
+        return context["count"]
+    aggregate = operand["aggregate"]
+    values = np.asarray(context["data"][aggregate["column"]])
+    aggregate_functions = {
+        "sum": np.sum,
+        "minimum": np.min,
+        "maximum": np.max,
+        "count": len,
+        "unique_count": lambda array: len(np.unique(array)),
+    }
+    return aggregate_functions[aggregate["function"]](values)
+
+
+def _resolve_operand(context, operand):
+    """Resolve a structured consistency operand."""
+    if not isinstance(operand, dict):
+        return operand
+    if operand["source"] == "metadata":
+        return _get_path(context["metadata"], operand["path"])
+    return _content_operand(context, operand)
+
+
+def _apply_operator(left, operator_name, right):
+    """Apply one supported declarative comparison operator."""
+    if operator_name == "equals":
+        if isinstance(left, (float, np.ndarray)):
+            try:
+                return bool(np.allclose(left, right))
+            except TypeError:
+                return bool(np.array_equal(left, right))
+        return left == right
+    operators = {
+        "greater_than": lambda left_value, right_value: left_value > right_value,
+        "greater_equal": lambda left_value, right_value: left_value >= right_value,
+        "less_than": lambda left_value, right_value: left_value < right_value,
+        "less_equal": lambda left_value, right_value: left_value <= right_value,
+        "in": lambda left_value, right_value: left_value in right_value,
+    }
+    return operators[operator_name](left, right)
+
+
+def _validate_consistency(path, rule, context):
+    """Validate metadata-to-content consistency rules."""
+    for consistency_rule in rule.get("consistency", []):
+        try:
+            left = _resolve_operand(context, consistency_rule["left"])
+            right = _resolve_operand(context, consistency_rule["right"])
+            valid = _apply_operator(left, consistency_rule["operator"], right)
+        except (KeyError, TypeError, ValueError) as exc:
+            _validation_failure(path, rule, consistency_rule, str(exc))
+        if not valid:
+            _validation_failure(path, rule, consistency_rule["operator"], f"{left!r} vs {right!r}")
+
+
+def _validate_data_product_schema(path, rule, context):
+    """Validate a table or mapping against an explicit simtools data schema."""
+    schema_file = rule.get("data_product_schema")
+    if not schema_file:
+        return
+    try:
+        if isinstance(context["data"], Table):
+            context["data"] = validate_data.DataValidator(
+                schema_file=_resolve_path(schema_file),
+                data_table=context["data"].copy(copy_data=True),
+            ).validate_and_transform()
+        elif isinstance(context["data"], dict):
+            context["data"] = validate_data.DataValidator(
+                schema_file=_resolve_path(schema_file),
+                data_dict=context["data"].copy(),
+            ).validate_and_transform()
+        else:
+            _validation_failure(
+                path, rule, "schema-validatable table or mapping", type(context["data"]).__name__
+            )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _validation_failure(path, rule, f"data-product schema {schema_file}", str(exc))
+
+
+def _validate_file_rule(config, rule):
+    """Validate one declarative output rule."""
+    path = _output_validation_path(config, rule)
+    try:
+        context = _load_output_context(path, rule)
+    except AssertionError:
+        raise
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _validation_failure(path, rule, "a parseable output", str(exc))
+    if rule.get("non_empty") and context["count"] == 0:
+        _validation_failure(path, rule, "non-empty content", context["count"])
+    _validate_count(path, rule, context["count"])
+    _validate_keys(path, rule, context)
+    _validate_columns(path, rule, context)
+    _validate_data_product_schema(path, rule, context)
+    _validate_consistency(path, rule, context)
+    return context
+
+
+def _resolve_relationship_operand(operand, contexts):
+    """Resolve an operand by selecting a named output and reading its value.
+
+    Relationship operands use ``output`` to select one loaded output, then
+    address either a dotted metadata/content path or a content count metric.
+    """
+    if not isinstance(operand, dict):
+        return operand
+    context = contexts[operand["output"]]
+    if "metric" in operand:
+        return context["count"]
+    if "aggregate" in operand:
+        return _content_operand(context, {"aggregate": operand["aggregate"]})
+    if _has_path(context["metadata"], operand["path"]):
+        return _get_path(context["metadata"], operand["path"])
+    return _content_operand(context, {"path": operand["path"]})
+
+
+def _validate_relationship_rule(config, rule):
+    """Validate comparisons between separate generated output files.
+
+    Each output descriptor is loaded independently and stored under its local
+    ``name``. Checks then compare values selected with relationship operands,
+    for example a summary mapping's ``simulation_rows`` with a table's
+    ``row_count``. Comparisons within one file use ``consistency`` instead.
+    """
+    contexts = {}
+    for descriptor in rule["outputs"]:
+        if descriptor["name"] in contexts:
+            _validation_failure(descriptor["name"], rule, "unique output names", descriptor["name"])
+        contexts[descriptor["name"]] = _validate_file_rule(
+            config, descriptor | {"non_empty": False}
+        )
+    for check in rule["checks"]:
+        try:
+            left = _resolve_relationship_operand(check["left"], contexts)
+            right = _resolve_relationship_operand(check["right"], contexts)
+            valid = _apply_operator(left, check["operator"], right)
+        except (KeyError, TypeError, ValueError) as exc:
+            _validation_failure(rule.get("name", "relationship"), rule, check, str(exc))
+        if not valid:
+            _validation_failure(
+                rule.get("name", "relationship"), rule, check["operator"], f"{left!r} vs {right!r}"
+            )
+
+
+def _validate_declarative_output(config, integration_test):
+    """Run optional declarative semantic output validation rules."""
+    for rule in integration_test.get("output_validation", []):
+        if rule["kind"] == "relationship":
+            _validate_relationship_rule(config, rule)
+        else:
+            _validate_file_rule(config, rule)
 
 
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -4,11 +4,9 @@ import logging
 import re
 from pathlib import Path
 
-import h5py
 import numpy as np
 from astropy import units as u
 from astropy.table import Table
-from eventio.simtel.simtelfile import SimTelFile
 
 import simtools.utils.general as gen
 from simtools.data_model import validate_data
@@ -136,7 +134,7 @@ def _validate_output_files(config, integration_test):
 
 def _validation_failure(output_path, rule, expected, actual):
     """Raise a consistently formatted semantic output validation failure."""
-    rule_name = rule.get("name", rule.get("kind", "output_validation"))
+    rule_name = rule.get("name", "output_validation")
     raise AssertionError(
         f"Output '{output_path}' failed rule '{rule_name}': "
         f"expected {expected!r}, actual {actual!r}."
@@ -152,100 +150,6 @@ def _output_validation_path(config, descriptor):
             f"Path {descriptor.get('path_descriptor')} not found in integration test configuration."
         ) from exc
     return Path(base_path) / descriptor.get("output_sub_path", "") / descriptor["file"]
-
-
-def _read_hdf5_object(path, object_path, kind):
-    """Read an HDF5 group or dataset into a validation context."""
-    with h5py.File(path, "r") as hdf5_file:
-        selected_path = object_path or "/"
-        selected = hdf5_file[selected_path]
-        metadata = dict(selected.attrs.items())
-        if kind == "group":
-            return {
-                "data": None,
-                "metadata": metadata,
-                "keys": list(selected.keys()),
-                "count": len(selected.keys()),
-            }
-        data = selected[:]
-        return {
-            "data": data,
-            "metadata": metadata,
-            "keys": list(selected.dtype.names or []),
-            "count": len(data),
-        }
-
-
-def _read_event_stream(path, descriptor):
-    """Read an event stream and return its event count and first event fields."""
-    event_type = descriptor.get("event_type")
-    event_type = {
-        "shower": "data",
-        "pedestal": "calibration",
-        "direct_injection": "calibration",
-    }.get(event_type, event_type)
-    file_format = descriptor.get("format", "simtel")
-    if file_format == "hdf5":
-        return _read_hdf5_object(path, descriptor.get("object_path"), "event_stream")
-    if file_format in ("ecsv", "fits"):
-        table = _read_table(path, file_format)
-        return {
-            "data": table,
-            "metadata": dict(table.meta),
-            "keys": table.colnames,
-            "count": len(table),
-        }
-
-    count = 0
-    first_event = None
-    with SimTelFile(path) as event_file:
-        for event in event_file:
-            if event_type and event.get("type") != event_type:
-                continue
-            count += 1
-            if first_event is None:
-                first_event = event
-    return {
-        "data": None,
-        "metadata": {},
-        "keys": list(first_event.keys()) if isinstance(first_event, dict) else [],
-        "count": count,
-    }
-
-
-def _read_table(path, file_format):
-    """Read a supported table format."""
-    if file_format == "ecsv":
-        return Table.read(path, format="ascii.ecsv")
-    return Table.read(path, format="fits")
-
-
-def _load_output_context(path, descriptor):
-    """Load one output and return the normalized semantic validation context."""
-    kind = descriptor["kind"]
-    if not path.exists():
-        _validation_failure(path, descriptor, "an existing output", "missing")
-    if kind == "file":
-        return {"data": None, "metadata": {}, "keys": [], "count": path.stat().st_size}
-    if kind == "table":
-        table = _read_table(path, descriptor.get("format", "ecsv"))
-        return {
-            "data": table,
-            "metadata": dict(table.meta),
-            "keys": table.colnames,
-            "count": len(table),
-        }
-    if kind == "mapping":
-        mapping = ascii_handler.collect_data_from_file(path)
-        if not isinstance(mapping, dict):
-            _validation_failure(path, descriptor, "a mapping", type(mapping).__name__)
-        return {"data": mapping, "metadata": mapping, "keys": list(mapping), "count": len(mapping)}
-    if kind == "group":
-        return _read_hdf5_object(path, descriptor.get("object_path"), kind)
-    if kind == "event_stream":
-        return _read_event_stream(path, descriptor)
-    _validation_failure(path, descriptor, "a supported output kind", kind)
-    return None
 
 
 def _has_path(value, dotted_path):
@@ -264,105 +168,6 @@ def _get_path(value, dotted_path):
     for part in dotted_path.split("."):
         current = current[part]
     return current
-
-
-def _validate_count(path, rule, actual):
-    """Validate exact, minimum, and maximum content counts."""
-    count_rule = rule.get("count", {})
-    if "exact" in count_rule and actual != count_rule["exact"]:
-        _validation_failure(path, rule, count_rule["exact"], actual)
-    if "minimum" in count_rule and actual < count_rule["minimum"]:
-        _validation_failure(path, rule, f">={count_rule['minimum']}", actual)
-    if "maximum" in count_rule and actual > count_rule["maximum"]:
-        _validation_failure(path, rule, f"<={count_rule['maximum']}", actual)
-
-
-def _validate_keys(path, rule, context):
-    """Validate required and forbidden mapping or group keys."""
-    keys = set(context["keys"])
-    for key in rule.get("required_keys", []) + rule.get("metadata", {}).get("required_keys", []):
-        if key not in keys and not _has_path(context["metadata"], key):
-            _validation_failure(path, rule, f"required key {key}", sorted(keys))
-    for key in rule.get("forbidden_keys", []) + rule.get("metadata", {}).get("forbidden_keys", []):
-        if key in keys or _has_path(context["metadata"], key):
-            _validation_failure(path, rule, f"forbidden key {key} absent", sorted(keys))
-
-
-def _validate_columns(path, rule, context):
-    """Validate required/forbidden columns and per-column semantic constraints."""
-    data = context["data"]
-    if not isinstance(data, Table):
-        if rule.get("required_columns") or rule.get("forbidden_columns") or rule.get("columns"):
-            _validation_failure(
-                path, rule, "a tabular or structured event output", type(data).__name__
-            )
-        return
-
-    columns = set(data.colnames)
-    _validate_required_columns(path, rule, columns)
-    _validate_forbidden_columns(path, rule, columns)
-
-    for column_name, column_rule in rule.get("columns", {}).items():
-        _validate_column(path, rule, data, columns, column_name, column_rule)
-
-
-def _validate_required_columns(path, rule, columns):
-    """Validate required table columns."""
-    for column in rule.get("required_columns", []):
-        if column not in columns:
-            _validation_failure(path, rule, f"required column {column}", sorted(columns))
-
-
-def _validate_forbidden_columns(path, rule, columns):
-    """Validate forbidden table columns."""
-    for column in rule.get("forbidden_columns", []):
-        if column in columns:
-            _validation_failure(path, rule, f"forbidden column {column} absent", sorted(columns))
-
-
-def _validate_column(path, rule, data, columns, column_name, column_rule):
-    """Validate one table column against its declarative constraints."""
-    if column_name not in columns:
-        _validation_failure(path, rule, f"column {column_name}", sorted(columns))
-    column = data[column_name]
-    values = np.asarray(column)
-    if column_rule.get("type") and not _matches_dtype(values, column_rule["type"]):
-        _validation_failure(
-            path, rule, f"{column_name} type {column_rule['type']}", str(values.dtype)
-        )
-    if column_rule.get("unit") is not None:
-        _validate_unit(path, rule, column_name, column, column_rule["unit"])
-    if column_rule.get("finite"):
-        if not np.issubdtype(values.dtype, np.number) or not np.all(np.isfinite(values)):
-            _validation_failure(path, rule, f"finite values in {column_name}", values.tolist())
-    if column_rule.get("unique") and len(np.unique(values)) != len(values):
-        _validation_failure(path, rule, f"unique values in {column_name}", values.tolist())
-    _validate_allowed_values(path, rule, column_name, column, column_rule)
-    _validate_range(path, rule, column_name, column, column_rule)
-
-
-def _matches_dtype(values, expected_type):
-    """Return whether an array matches a declarative field type."""
-    if expected_type == "string":
-        return values.dtype.kind in "OUS"
-    if expected_type == "bool":
-        return values.dtype.kind == "b"
-    if expected_type == "number":
-        return np.issubdtype(values.dtype, np.number)
-    expected = np.dtype(expected_type)
-    return values.dtype == expected
-
-
-def _validate_unit(path, rule, column_name, column, expected_unit):
-    """Validate that a column has the declared physical unit."""
-    actual_unit = getattr(column, "unit", None) or u.dimensionless_unscaled
-    try:
-        if not actual_unit.is_equivalent(u.Unit(expected_unit)):
-            _validation_failure(
-                path, rule, f"unit {expected_unit} for {column_name}", str(actual_unit)
-            )
-    except ValueError as exc:
-        _validation_failure(path, rule, f"valid unit {expected_unit} for {column_name}", str(exc))
 
 
 def _validate_allowed_values(path, rule, column_name, column, column_rule):
@@ -407,163 +212,94 @@ def _validate_range(path, rule, column_name, column, column_rule):
             )
 
 
-def _content_operand(context, operand):
-    """Resolve a content metric or aggregate operand."""
-    if "path" in operand:
-        if isinstance(context["data"], Table) and operand["path"] in context["data"].colnames:
-            return np.asarray(context["data"][operand["path"]])
-        return _get_path(context["data"], operand["path"])
-    if "metric" in operand:
-        return context["count"]
-    aggregate = operand["aggregate"]
-    values = np.asarray(context["data"][aggregate["column"]])
-    aggregate_functions = {
-        "sum": np.sum,
-        "minimum": np.min,
-        "maximum": np.max,
-        "count": len,
-        "unique_count": lambda array: len(np.unique(array)),
-    }
-    return aggregate_functions[aggregate["function"]](values)
-
-
-def _resolve_operand(context, operand):
-    """Resolve a structured consistency operand."""
-    if not isinstance(operand, dict):
-        return operand
-    if operand["source"] == "metadata":
-        return _get_path(context["metadata"], operand["path"])
-    return _content_operand(context, operand)
-
-
-def _apply_operator(left, operator_name, right):
-    """Apply one supported declarative comparison operator."""
-    if operator_name == "equals":
-        if isinstance(left, (float, np.ndarray)):
-            try:
-                return bool(np.allclose(left, right))
-            except TypeError:
-                return bool(np.array_equal(left, right))
-        return left == right
-    operators = {
-        "greater_than": lambda left_value, right_value: left_value > right_value,
-        "greater_equal": lambda left_value, right_value: left_value >= right_value,
-        "less_than": lambda left_value, right_value: left_value < right_value,
-        "less_equal": lambda left_value, right_value: left_value <= right_value,
-        "in": lambda left_value, right_value: left_value in right_value,
-    }
-    return operators[operator_name](left, right)
-
-
-def _validate_consistency(path, rule, context):
-    """Validate metadata-to-content consistency rules."""
-    for consistency_rule in rule.get("consistency", []):
-        try:
-            left = _resolve_operand(context, consistency_rule["left"])
-            right = _resolve_operand(context, consistency_rule["right"])
-            valid = _apply_operator(left, consistency_rule["operator"], right)
-        except (KeyError, TypeError, ValueError) as exc:
-            _validation_failure(path, rule, consistency_rule, str(exc))
-        if not valid:
-            _validation_failure(path, rule, consistency_rule["operator"], f"{left!r} vs {right!r}")
-
-
-def _validate_data_product_schema(path, rule, context):
-    """Validate a table or mapping against an explicit simtools data schema."""
-    schema_file = rule.get("data_product_schema")
-    if not schema_file:
-        return
+def _validate_data_product_schema(path, rule, table):
+    """Validate a table against its simtools data schema."""
+    schema_file = rule["data_product_schema"]
     try:
-        if isinstance(context["data"], Table):
-            context["data"] = validate_data.DataValidator(
-                schema_file=_resolve_path(schema_file),
-                data_table=context["data"].copy(copy_data=True),
-            ).validate_and_transform()
-        elif isinstance(context["data"], dict):
-            context["data"] = validate_data.DataValidator(
-                schema_file=_resolve_path(schema_file),
-                data_dict=context["data"].copy(),
-            ).validate_and_transform()
-        else:
-            _validation_failure(
-                path, rule, "schema-validatable table or mapping", type(context["data"]).__name__
-            )
+        return validate_data.DataValidator(
+            schema_file=_resolve_path(schema_file),
+            data_table=table.copy(copy_data=True),
+        ).validate_and_transform()
     except Exception as exc:  # pylint: disable=broad-exception-caught
         _validation_failure(path, rule, f"data-product schema {schema_file}", str(exc))
+        return None
 
 
-def _validate_file_rule(config, rule):
-    """Validate one declarative output rule."""
-    path = _output_validation_path(config, rule)
-    try:
-        context = _load_output_context(path, rule)
-    except AssertionError:
-        raise
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        _validation_failure(path, rule, "a parseable output", str(exc))
-    if rule.get("non_empty") and context["count"] == 0:
-        _validation_failure(path, rule, "non-empty content", context["count"])
-    _validate_count(path, rule, context["count"])
-    _validate_keys(path, rule, context)
-    _validate_columns(path, rule, context)
-    _validate_data_product_schema(path, rule, context)
-    _validate_consistency(path, rule, context)
-    return context
+def _validate_unique_columns(path, rule, table):
+    """Validate uniqueness for selected table columns."""
+    for column_name in rule.get("unique_columns", []):
+        values = np.asarray(table[column_name])
+        if len(np.unique(values)) != len(values):
+            _validation_failure(path, rule, f"unique values in {column_name}", values.tolist())
 
 
-def _resolve_relationship_operand(operand, contexts):
-    """Resolve an operand by selecting a named output and reading its value.
-
-    Relationship operands use ``output`` to select one loaded output, then
-    address either a dotted metadata/content path or a content count metric.
-    """
-    if not isinstance(operand, dict):
-        return operand
-    context = contexts[operand["output"]]
-    if "metric" in operand:
-        return context["count"]
-    if "aggregate" in operand:
-        return _content_operand(context, {"aggregate": operand["aggregate"]})
-    if _has_path(context["metadata"], operand["path"]):
-        return _get_path(context["metadata"], operand["path"])
-    return _content_operand(context, {"path": operand["path"]})
+def _validate_columns(path, rule, table):
+    """Validate workflow-specific table column domains and ranges."""
+    for column_name, column_rule in rule.get("columns", {}).items():
+        column = table[column_name]
+        _validate_allowed_values(path, rule, column_name, column, column_rule)
+        _validate_range(path, rule, column_name, column, column_rule)
 
 
-def _validate_relationship_rule(config, rule):
-    """Validate comparisons between separate generated output files.
-
-    Each output descriptor is loaded independently and stored under its local
-    ``name``. Checks then compare values selected with relationship operands,
-    for example a summary mapping's ``simulation_rows`` with a table's
-    ``row_count``. Comparisons within one file use ``consistency`` instead.
-    """
-    contexts = {}
-    for descriptor in rule["outputs"]:
-        if descriptor["name"] in contexts:
-            _validation_failure(descriptor["name"], rule, "unique output names", descriptor["name"])
-        contexts[descriptor["name"]] = _validate_file_rule(
-            config, descriptor | {"non_empty": False}
-        )
-    for check in rule["checks"]:
-        try:
-            left = _resolve_relationship_operand(check["left"], contexts)
-            right = _resolve_relationship_operand(check["right"], contexts)
-            valid = _apply_operator(left, check["operator"], right)
-        except (KeyError, TypeError, ValueError) as exc:
-            _validation_failure(rule.get("name", "relationship"), rule, check, str(exc))
-        if not valid:
+def _validate_metadata(path, rule, table):
+    """Validate required metadata and selected metadata-to-content summaries."""
+    metadata_rule = rule.get("metadata", {})
+    for metadata_path in metadata_rule.get("required_keys", []):
+        if not _has_path(table.meta, metadata_path):
             _validation_failure(
-                rule.get("name", "relationship"), rule, check["operator"], f"{left!r} vs {right!r}"
+                path, rule, f"required metadata key {metadata_path}", sorted(table.meta)
             )
+
+    row_count_path = metadata_rule.get("row_count")
+    if row_count_path:
+        metadata_row_count = _get_path(table.meta, row_count_path)
+        if metadata_row_count != len(table):
+            _validation_failure(
+                path,
+                rule,
+                f"{row_count_path} equals row count",
+                f"{metadata_row_count} vs {len(table)}",
+            )
+
+    for column_name, metadata_path in metadata_rule.get("column_sums", {}).items():
+        metadata_value = _get_path(table.meta, metadata_path)
+        column_sum = np.sum(np.asarray(table[column_name]))
+        if not np.isclose(metadata_value, column_sum):
+            _validation_failure(
+                path,
+                rule,
+                f"{metadata_path} equals sum of {column_name}",
+                f"{metadata_value!r} vs {column_sum!r}",
+            )
+
+
+def _validate_table_output(config, rule):
+    """Validate one ECSV table output."""
+    path = _output_validation_path(config, rule)
+    if not path.exists():
+        _validation_failure(path, rule, "an existing output", "missing")
+    try:
+        table = Table.read(path, format="ascii.ecsv")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        _validation_failure(path, rule, "a parseable ECSV table", str(exc))
+
+    minimum_rows = rule.get("minimum_rows", 0)
+    if len(table) < minimum_rows:
+        _validation_failure(path, rule, f"at least {minimum_rows} rows", len(table))
+
+    table = _validate_data_product_schema(path, rule, table)
+    try:
+        _validate_unique_columns(path, rule, table)
+        _validate_columns(path, rule, table)
+        _validate_metadata(path, rule, table)
+    except (KeyError, TypeError, ValueError) as exc:
+        _validation_failure(path, rule, "valid configured table content", str(exc))
 
 
 def _validate_declarative_output(config, integration_test):
-    """Run optional declarative semantic output validation rules."""
+    """Run optional declarative ECSV table validation rules."""
     for rule in integration_test.get("output_validation", []):
-        if rule["kind"] == "relationship":
-            _validate_relationship_rule(config, rule)
-        else:
-            _validate_file_rule(config, rule)
+        _validate_table_output(config, rule)
 
 
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):

--- a/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
+++ b/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
@@ -43,6 +43,103 @@ applications:
     - 40
   integration_tests:
   - output_file: job_grid_horizontal_explicit.ecsv
+    output_validation:
+    - name: job_grid_content
+      kind: table
+      path_descriptor: output_path
+      file: job_grid_horizontal_explicit.ecsv
+      format: ecsv
+      non_empty: true
+      count:
+        minimum: 1
+      columns:
+        run_number:
+          finite: true
+          unique: true
+        primary:
+          allowed_values: [gamma, proton]
+        azimuth_angle:
+          finite: true
+          allowed_values: [0.0, 180.0]
+        zenith_angle:
+          finite: true
+          range:
+            minimum: 20.0
+            maximum: 40.0
+            unit: deg
+        energy_min:
+          finite: true
+          range:
+            minimum: 30.0
+            maximum: 300.0
+            unit: GeV
+        energy_max:
+          finite: true
+          range:
+            minimum: 30.0
+            maximum: 300.0
+            unit: GeV
+        cores_per_shower:
+          finite: true
+        core_scatter_max:
+          finite: true
+          range:
+            minimum: 0.0
+            maximum: 500.0
+            unit: m
+        view_cone_min:
+          finite: true
+          range:
+            minimum: 0.0
+            maximum: 10.0
+            unit: deg
+        view_cone_max:
+          finite: true
+          range:
+            minimum: 0.0
+            maximum: 10.0
+            unit: deg
+        showers_per_run:
+          finite: true
+          range:
+            minimum: 1.0
+        nsb_rate:
+          finite: true
+        model_version:
+          allowed_values: ["6.3.0", "7.0.0"]
+        corsika_le_interaction:
+          allowed_values: [urqmd]
+        corsika_he_interaction:
+          allowed_values: [epos, qgs3]
+      metadata:
+        required_keys:
+        - job_grid_summary
+        - job_grid_format_version
+      consistency:
+      - left:
+          source: metadata
+          path: job_grid_summary.simulation_rows
+        operator: equals
+        right:
+          source: content
+          metric: row_count
+      - left:
+          source: metadata
+          path: job_grid_summary.total_showers
+        operator: equals
+        right:
+          source: content
+          aggregate:
+            function: sum
+            column: showers_per_run
+      - left:
+          source: content
+          aggregate:
+            function: sum
+            column: showers_per_run
+        operator: greater_than
+        right: 0
+      data_product_schema: src/simtools/schemas/job_grid_density.schema.yml
   test_name: production_generate_grid_horizontal_explicit
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
+++ b/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
@@ -45,66 +45,48 @@ applications:
   - output_file: job_grid_horizontal_explicit.ecsv
     output_validation:
     - name: job_grid_content
-      kind: table
       path_descriptor: output_path
       file: job_grid_horizontal_explicit.ecsv
-      format: ecsv
-      non_empty: true
-      count:
-        minimum: 1
+      minimum_rows: 1
+      unique_columns: [run_number]
       columns:
-        run_number:
-          finite: true
-          unique: true
         primary:
           allowed_values: [gamma, proton]
         azimuth_angle:
-          finite: true
           allowed_values: [0.0, 180.0]
         zenith_angle:
-          finite: true
           range:
             minimum: 20.0
             maximum: 40.0
             unit: deg
         energy_min:
-          finite: true
           range:
             minimum: 30.0
             maximum: 300.0
             unit: GeV
         energy_max:
-          finite: true
           range:
             minimum: 30.0
             maximum: 300.0
             unit: GeV
-        cores_per_shower:
-          finite: true
         core_scatter_max:
-          finite: true
           range:
             minimum: 0.0
             maximum: 500.0
             unit: m
         view_cone_min:
-          finite: true
           range:
             minimum: 0.0
             maximum: 10.0
             unit: deg
         view_cone_max:
-          finite: true
           range:
             minimum: 0.0
             maximum: 10.0
             unit: deg
         showers_per_run:
-          finite: true
           range:
             minimum: 1.0
-        nsb_rate:
-          finite: true
         model_version:
           allowed_values: ["6.3.0", "7.0.0"]
         corsika_le_interaction:
@@ -115,31 +97,11 @@ applications:
         required_keys:
         - job_grid_summary
         - job_grid_format_version
-      consistency:
-      - left:
-          source: metadata
-          path: job_grid_summary.simulation_rows
-        operator: equals
-        right:
-          source: content
-          metric: row_count
-      - left:
-          source: metadata
-          path: job_grid_summary.total_showers
-        operator: equals
-        right:
-          source: content
-          aggregate:
-            function: sum
-            column: showers_per_run
-      - left:
-          source: content
-          aggregate:
-            function: sum
-            column: showers_per_run
-        operator: greater_than
-        right: 0
+        row_count: job_grid_summary.simulation_rows
+        column_sums:
+          showers_per_run: job_grid_summary.total_showers
       data_product_schema: src/simtools/schemas/job_grid_density.schema.yml
   test_name: production_generate_grid_horizontal_explicit
+  xfail: "requires to address issue #2352"
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -220,66 +220,27 @@ def _valid_output_validation_rule():
     """Build a representative table rule for metaschema tests."""
     return {
         "name": "table",
-        "kind": "table",
         "path_descriptor": "output_path",
         "file": "output.ecsv",
-        "format": "ecsv",
-        "non_empty": True,
-        "count": {"minimum": 1},
-        "required_columns": ["id"],
+        "data_product_schema": "schema.yml",
+        "minimum_rows": 1,
+        "unique_columns": ["id"],
         "columns": {
-            "id": {"type": "int64", "finite": True, "unique": True},
             "energy": {
-                "type": "float64",
-                "unit": "GeV",
                 "range": {"minimum": 1.0, "unit": "GeV"},
             },
         },
-        "metadata": {"required_keys": ["summary"]},
-        "consistency": [
-            {
-                "left": {"source": "metadata", "path": "summary.rows"},
-                "operator": "equals",
-                "right": {"source": "content", "metric": "row_count"},
-            }
-        ],
-        "data_product_schema": "schema.yml",
-    }
-
-
-def _valid_relationship_rule():
-    """Build a representative cross-output relationship rule."""
-    return {
-        "kind": "relationship",
-        "outputs": [
-            {
-                "name": "summary",
-                "kind": "mapping",
-                "path_descriptor": "output_path",
-                "file": "summary.yml",
-            },
-            {
-                "name": "table",
-                "kind": "table",
-                "path_descriptor": "output_path",
-                "file": "output.ecsv",
-            },
-        ],
-        "checks": [
-            {
-                "left": {"output": "summary", "path": "rows"},
-                "operator": "equals",
-                "right": {"output": "table", "metric": "row_count"},
-            }
-        ],
+        "metadata": {
+            "required_keys": ["summary"],
+            "row_count": "summary.rows",
+            "column_sums": {"energy": "summary.total"},
+        },
     }
 
 
 def test_application_workflow_schema_accepts_output_validation_rules():
-    """Test the complete declarative output-validation configuration shape."""
-    workflow_config = _output_validation_workflow(
-        _valid_output_validation_rule(), _valid_relationship_rule()
-    )
+    """Test the table output-validation configuration shape."""
+    workflow_config = _output_validation_workflow(_valid_output_validation_rule())
 
     schema.validate_dict_using_schema(
         workflow_config,
@@ -291,11 +252,12 @@ def test_application_workflow_schema_accepts_output_validation_rules():
     "change",
     [
         lambda rule: rule.update({"unknown": True}),
-        lambda rule: rule.update({"kind": "unsupported"}),
-        lambda rule: rule["count"].update({"invalid": 1}),
-        lambda rule: rule["columns"]["id"].update({"range": {"minimum": "bad"}}),
-        lambda rule: rule["columns"]["id"].update({"range": {"unit": "GeV"}}),
-        lambda rule: rule["consistency"][0].update({"operator": "python"}),
+        lambda rule: rule.update({"minimum_rows": -1}),
+        lambda rule: rule.update({"unique_columns": ["id", "id"]}),
+        lambda rule: rule["columns"]["energy"].update({"range": {"minimum": "bad"}}),
+        lambda rule: rule["columns"]["energy"].update({"range": {"unit": "GeV"}}),
+        lambda rule: rule["columns"].update({"id": {}}),
+        lambda rule: rule["metadata"].update({"unknown": "value"}),
     ],
 )
 def test_application_workflow_schema_rejects_malformed_output_validation(change):

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -201,6 +201,26 @@ def test_application_workflow_schema_accepts_optional_docs_metadata():
     )
 
 
+def test_application_workflow_schema_accepts_expected_failure_reason():
+    """Allow workflows to document expected application failures."""
+    workflow_config = {
+        "schema_version": "0.4.0",
+        "schema_name": "application_workflow.metaschema",
+        "applications": [
+            {
+                "application": "simtools-test",
+                "configuration": {},
+                "xfail": "known issue",
+            }
+        ],
+    }
+
+    schema.validate_dict_using_schema(
+        workflow_config,
+        schema_file=SCHEMA_PATH / "application_workflow.metaschema.yml",
+    )
+
+
 def _output_validation_workflow(*rules):
     """Build a minimal workflow containing declarative output rules."""
     return {

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -201,6 +201,116 @@ def test_application_workflow_schema_accepts_optional_docs_metadata():
     )
 
 
+def _output_validation_workflow(*rules):
+    """Build a minimal workflow containing declarative output rules."""
+    return {
+        "schema_version": "0.4.0",
+        "schema_name": "application_workflow.metaschema",
+        "applications": [
+            {
+                "application": "simtools-test",
+                "configuration": {"output_path": "output"},
+                "integration_tests": [{"output_validation": list(rules)}],
+            }
+        ],
+    }
+
+
+def _valid_output_validation_rule():
+    """Build a representative table rule for metaschema tests."""
+    return {
+        "name": "table",
+        "kind": "table",
+        "path_descriptor": "output_path",
+        "file": "output.ecsv",
+        "format": "ecsv",
+        "non_empty": True,
+        "count": {"minimum": 1},
+        "required_columns": ["id"],
+        "columns": {
+            "id": {"type": "int64", "finite": True, "unique": True},
+            "energy": {
+                "type": "float64",
+                "unit": "GeV",
+                "range": {"minimum": 1.0, "unit": "GeV"},
+            },
+        },
+        "metadata": {"required_keys": ["summary"]},
+        "consistency": [
+            {
+                "left": {"source": "metadata", "path": "summary.rows"},
+                "operator": "equals",
+                "right": {"source": "content", "metric": "row_count"},
+            }
+        ],
+        "data_product_schema": "schema.yml",
+    }
+
+
+def _valid_relationship_rule():
+    """Build a representative cross-output relationship rule."""
+    return {
+        "kind": "relationship",
+        "outputs": [
+            {
+                "name": "summary",
+                "kind": "mapping",
+                "path_descriptor": "output_path",
+                "file": "summary.yml",
+            },
+            {
+                "name": "table",
+                "kind": "table",
+                "path_descriptor": "output_path",
+                "file": "output.ecsv",
+            },
+        ],
+        "checks": [
+            {
+                "left": {"output": "summary", "path": "rows"},
+                "operator": "equals",
+                "right": {"output": "table", "metric": "row_count"},
+            }
+        ],
+    }
+
+
+def test_application_workflow_schema_accepts_output_validation_rules():
+    """Test the complete declarative output-validation configuration shape."""
+    workflow_config = _output_validation_workflow(
+        _valid_output_validation_rule(), _valid_relationship_rule()
+    )
+
+    schema.validate_dict_using_schema(
+        workflow_config,
+        schema_file=SCHEMA_PATH / "application_workflow.metaschema.yml",
+    )
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        lambda rule: rule.update({"unknown": True}),
+        lambda rule: rule.update({"kind": "unsupported"}),
+        lambda rule: rule["count"].update({"invalid": 1}),
+        lambda rule: rule["columns"]["id"].update({"range": {"minimum": "bad"}}),
+        lambda rule: rule["columns"]["id"].update({"range": {"unit": "GeV"}}),
+        lambda rule: rule["consistency"][0].update({"operator": "python"}),
+    ],
+)
+def test_application_workflow_schema_rejects_malformed_output_validation(change):
+    """Reject unknown properties and malformed declarative validation rules."""
+    rule = _valid_output_validation_rule()
+    change(rule)
+    workflow_config = _output_validation_workflow(rule)
+
+    with pytest.raises(jsonschema.ValidationError):
+        schema.validate_dict_using_schema(
+            workflow_config,
+            schema_file=SCHEMA_PATH / "application_workflow.metaschema.yml",
+        )
+
+
 def test_validate_dict_using_schema_remote(tmp_test_directory, mocker):
     sample_schema = {
         "type": "object",

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -3,8 +3,11 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
+import h5py
+import numpy as np
 import pytest
 import yaml
+from astropy import units as u
 from astropy.table import Table
 
 from simtools.constants import TEST_RESOURCES_GENERATED
@@ -878,3 +881,354 @@ def test_compare_nested_dicts_with_tolerance(data1, data2, tolerance, is_value_f
         )
         == should_match
     )
+
+
+def _semantic_table(path, metadata=None):
+    """Write a small table used by declarative output-validation tests."""
+    table = Table(
+        {
+            "run_number": [1, 2],
+            "value": [1.0, 2.0],
+            "label": ["a", "b"],
+        }
+    )
+    table["value"].unit = u.m
+    table.meta = metadata or {"summary": {"rows": 2, "total": 3.0}}
+    table.write(path, format="ascii.ecsv", overwrite=True)
+
+
+def _semantic_config(output_path, rule):
+    """Build a configuration containing one semantic output rule."""
+    return {
+        "configuration": {"output_path": str(output_path)},
+        "integration_tests": [{"output_validation": [rule]}],
+    }
+
+
+def test_declarative_table_validation_passes(tmp_test_directory):
+    """Validate counts, fields, units, domains, uniqueness, and consistency."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    _semantic_table(output_file)
+    rule = {
+        "name": "semantic_table",
+        "kind": "table",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "format": "ecsv",
+        "non_empty": True,
+        "count": {"exact": 2},
+        "required_columns": ["run_number", "value"],
+        "forbidden_columns": ["forbidden"],
+        "columns": {
+            "run_number": {"type": "int64", "finite": True, "unique": True},
+            "value": {
+                "type": "float64",
+                "unit": "m",
+                "finite": True,
+                "range": {"minimum": 0.0, "maximum": 3.0, "unit": "m"},
+            },
+            "label": {"type": "string", "allowed_values": ["a", "b"]},
+        },
+        "metadata": {"required_keys": ["summary"]},
+        "consistency": [
+            {
+                "left": {"source": "metadata", "path": "summary.rows"},
+                "operator": "equals",
+                "right": {"source": "content", "metric": "row_count"},
+            },
+            {
+                "left": {"source": "metadata", "path": "summary.total"},
+                "operator": "equals",
+                "right": {
+                    "source": "content",
+                    "aggregate": {"function": "sum", "column": "value"},
+                },
+            },
+        ],
+    }
+
+    validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+
+def test_empty_parseable_job_grid_fails_minimum_row_validation(tmp_test_directory):
+    """Regression test for issue #2352: an empty ECSV must not pass presence checks."""
+    tmp_test_directory = Path(tmp_test_directory)
+    workflow = yaml.safe_load(
+        Path(
+            "tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml"
+        ).read_text(encoding="utf-8")
+    )
+    config = workflow["applications"][0]
+    config["configuration"]["output_path"] = str(tmp_test_directory)
+    output_file = tmp_test_directory / "job_grid_horizontal_explicit.ecsv"
+    columns = [
+        "run_number",
+        "primary",
+        "azimuth_angle",
+        "zenith_angle",
+        "energy_min",
+        "energy_max",
+        "cores_per_shower",
+        "core_scatter_max",
+        "view_cone_min",
+        "view_cone_max",
+        "showers_per_run",
+        "nsb_rate",
+        "model_version",
+        "array_layout_name",
+        "corsika_le_interaction",
+        "corsika_he_interaction",
+    ]
+    Table(names=columns, dtype=["int64", "str"] + ["float64"] * 10 + ["str"] * 4).write(
+        output_file, format="ascii.ecsv"
+    )
+    with pytest.raises(AssertionError, match=r"expected 'non-empty content', actual 0"):
+        validate_output.validate_application_output(config)
+
+
+@pytest.mark.parametrize(
+    ("change", "expected"),
+    [
+        (lambda rule: rule.update({"non_empty": True, "count": {"minimum": 3}}), ">=3"),
+        (lambda rule: rule.update({"count": {"maximum": 1}}), "<=1"),
+        (lambda rule: rule["required_columns"].append("missing"), "required column"),
+        (lambda rule: rule["columns"]["value"].update({"finite": True}), "finite"),
+        (lambda rule: rule["columns"]["run_number"].update({"unique": True}), "unique"),
+        (lambda rule: rule["columns"]["label"].update({"type": "int64"}), "type"),
+        (lambda rule: rule["columns"]["value"].update({"unit": "s"}), "unit"),
+        (lambda rule: rule.update({"forbidden_columns": ["value"]}), "forbidden column"),
+        (lambda rule: rule["columns"]["label"].update({"allowed_values": ["x"]}), "allowed"),
+        (
+            lambda rule: rule["columns"]["value"].update({"range": {"maximum": 1.0}}),
+            "maximum",
+        ),
+    ],
+)
+def test_declarative_table_validation_failures(tmp_test_directory, change, expected):
+    """Report the output, rule, expected condition, and actual value on failure."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    _semantic_table(output_file)
+    if expected == "finite":
+        table = Table.read(output_file, format="ascii.ecsv")
+        table["value"][0] = np.nan
+        table.write(output_file, format="ascii.ecsv", overwrite=True)
+    if expected == "unique":
+        table = Table.read(output_file, format="ascii.ecsv")
+        table["run_number"][1] = table["run_number"][0]
+        table.write(output_file, format="ascii.ecsv", overwrite=True)
+    rule = {
+        "name": "semantic_table",
+        "kind": "table",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "required_columns": ["run_number", "value", "label"],
+        "columns": {
+            "run_number": {"type": "int64"},
+            "value": {"type": "float64", "unit": "m"},
+            "label": {"type": "string"},
+        },
+    }
+    change(rule)
+
+    with pytest.raises(
+        AssertionError, match=r"Output .* failed rule 'semantic_table'.*"
+    ) as exc_info:
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+    assert expected in str(exc_info.value)
+    assert "expected" in str(exc_info.value)
+    assert "actual" in str(exc_info.value)
+
+
+def test_declarative_file_and_mapping_validation(tmp_test_directory):
+    """Validate generic files and mapping keys."""
+    tmp_test_directory = Path(tmp_test_directory)
+    empty_file = tmp_test_directory / "empty.txt"
+    empty_file.touch()
+    empty_rule = {
+        "name": "non_empty_file",
+        "kind": "file",
+        "path_descriptor": "output_path",
+        "file": empty_file.name,
+        "non_empty": True,
+    }
+    with pytest.raises(AssertionError, match="non-empty"):
+        validate_output.validate_application_output(
+            _semantic_config(tmp_test_directory, empty_rule)
+        )
+
+    mapping_file = tmp_test_directory / "mapping.yml"
+    mapping_file.write_text("required: true\n", encoding="utf-8")
+    mapping_rule = {
+        "name": "mapping_keys",
+        "kind": "mapping",
+        "path_descriptor": "output_path",
+        "file": mapping_file.name,
+        "non_empty": True,
+        "required_keys": ["required"],
+        "forbidden_keys": ["forbidden"],
+    }
+    validate_output.validate_application_output(_semantic_config(tmp_test_directory, mapping_rule))
+
+    missing_key_rule = dict(mapping_rule)
+    missing_key_rule["required_keys"] = ["missing"]
+    with pytest.raises(AssertionError, match="required key"):
+        validate_output.validate_application_output(
+            _semantic_config(tmp_test_directory, missing_key_rule)
+        )
+
+    forbidden_key_rule = dict(mapping_rule)
+    forbidden_key_rule["forbidden_keys"] = ["required"]
+    with pytest.raises(AssertionError, match="forbidden key"):
+        validate_output.validate_application_output(
+            _semantic_config(tmp_test_directory, forbidden_key_rule)
+        )
+
+
+def test_declarative_group_and_event_stream_counts(tmp_test_directory):
+    """Validate HDF5 groups and event-stream counts."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "structured.h5"
+    with h5py.File(output_file, "w") as hdf5_file:
+        group = hdf5_file.create_group("group")
+        group.create_dataset("member", data=[1, 2])
+        hdf5_file.create_dataset("events", data=[10, 20, 30])
+
+    group_rule = {
+        "name": "group",
+        "kind": "group",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "object_path": "group",
+        "non_empty": True,
+        "count": {"exact": 1},
+        "required_keys": ["member"],
+    }
+    event_rule = {
+        "name": "events",
+        "kind": "event_stream",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "format": "hdf5",
+        "object_path": "events",
+        "non_empty": True,
+        "count": {"minimum": 3},
+    }
+    config = {
+        "configuration": {"output_path": str(tmp_test_directory)},
+        "integration_tests": [{"output_validation": [group_rule, event_rule]}],
+    }
+    validate_output.validate_application_output(config)
+
+    group_rule["count"] = {"maximum": 0}
+    with pytest.raises(AssertionError, match="<=0"):
+        validate_output.validate_application_output(config)
+
+    group_rule["count"] = {"exact": 1}
+    event_rule["count"] = {"exact": 4}
+    with pytest.raises(AssertionError, match="expected 4"):
+        validate_output.validate_application_output(config)
+
+
+def test_declarative_relationship_validation(tmp_test_directory):
+    """Validate a relationship between mapping metadata and a table count."""
+    tmp_test_directory = Path(tmp_test_directory)
+    table_file = tmp_test_directory / "table.ecsv"
+    _semantic_table(table_file)
+    summary_file = tmp_test_directory / "summary.yml"
+    summary_file.write_text("rows: 2\n", encoding="utf-8")
+    rule = {
+        "name": "summary_relationship",
+        "kind": "relationship",
+        "outputs": [
+            {
+                "name": "summary",
+                "kind": "mapping",
+                "path_descriptor": "output_path",
+                "file": summary_file.name,
+            },
+            {
+                "name": "table",
+                "kind": "table",
+                "path_descriptor": "output_path",
+                "file": table_file.name,
+                "format": "ecsv",
+            },
+        ],
+        "checks": [
+            {
+                "left": {"output": "summary", "path": "rows"},
+                "operator": "equals",
+                "right": {"output": "table", "metric": "row_count"},
+            }
+        ],
+    }
+    config = {
+        "configuration": {"output_path": str(tmp_test_directory)},
+        "integration_tests": [{"output_validation": [rule]}],
+    }
+    validate_output.validate_application_output(config)
+
+    summary_file.write_text("rows: 3\n", encoding="utf-8")
+    with pytest.raises(AssertionError, match="summary_relationship"):
+        validate_output.validate_application_output(config)
+
+
+def test_declarative_data_product_schema_validation(tmp_test_directory):
+    """Validate a table against an explicit simtools data-product schema."""
+    tmp_test_directory = Path(tmp_test_directory)
+    schema_file = tmp_test_directory / "table.schema.yml"
+    schema_file.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "0.1.0",
+                "data": [
+                    {
+                        "type": "data_table",
+                        "table_columns": [
+                            {"name": "run_number", "required": True, "type": "int64"}
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_file = tmp_test_directory / "schema.ecsv"
+    Table({"run_number": [1, 2]}).write(output_file, format="ascii.ecsv")
+    rule = {
+        "name": "schema",
+        "kind": "table",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "data_product_schema": str(schema_file),
+    }
+    validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+    Table({"other": [1, 2]}).write(output_file, format="ascii.ecsv", overwrite=True)
+    with pytest.raises(AssertionError, match="data-product schema"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+
+def test_declarative_metadata_consistency_failure(tmp_test_directory):
+    """Reject metadata that disagrees with table content."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "inconsistent.ecsv"
+    _semantic_table(output_file, metadata={"summary": {"rows": 99, "total": 3.0}})
+    rule = {
+        "name": "metadata_consistency",
+        "kind": "table",
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "consistency": [
+            {
+                "left": {"source": "metadata", "path": "summary.rows"},
+                "operator": "equals",
+                "right": {"source": "content", "metric": "row_count"},
+            }
+        ],
+    }
+
+    with pytest.raises(AssertionError, match="metadata_consistency"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -3,8 +3,6 @@ import logging
 from pathlib import Path
 from unittest.mock import patch
 
-import h5py
-import numpy as np
 import pytest
 import yaml
 from astropy import units as u
@@ -884,7 +882,7 @@ def test_compare_nested_dicts_with_tolerance(data1, data2, tolerance, is_value_f
 
 
 def _semantic_table(path, metadata=None):
-    """Write a small table used by declarative output-validation tests."""
+    """Write a small ECSV table used by declarative output-validation tests."""
     table = Table(
         {
             "run_number": [1, 2],
@@ -893,8 +891,35 @@ def _semantic_table(path, metadata=None):
         }
     )
     table["value"].unit = u.m
-    table.meta = metadata or {"summary": {"rows": 2, "total": 3.0}}
+    table.meta = metadata if metadata is not None else {"summary": {"rows": 2, "total": 3.0}}
     table.write(path, format="ascii.ecsv", overwrite=True)
+
+
+def _semantic_schema(path):
+    """Write the data-product schema for the semantic table."""
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "0.1.0",
+                "data": [
+                    {
+                        "type": "data_table",
+                        "table_columns": [
+                            {"name": "run_number", "required": True, "type": "int64"},
+                            {
+                                "name": "value",
+                                "required": True,
+                                "type": "float64",
+                                "unit": "m",
+                            },
+                            {"name": "label", "required": True, "type": "string"},
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def _semantic_config(output_path, rule):
@@ -905,330 +930,148 @@ def _semantic_config(output_path, rule):
     }
 
 
-def test_declarative_table_validation_passes(tmp_test_directory):
-    """Validate counts, fields, units, domains, uniqueness, and consistency."""
-    tmp_test_directory = Path(tmp_test_directory)
-    output_file = tmp_test_directory / "table.ecsv"
-    _semantic_table(output_file)
-    rule = {
+def _semantic_rule(output_file, schema_file):
+    """Build the representative ECSV output-validation rule."""
+    return {
         "name": "semantic_table",
-        "kind": "table",
-        "path_descriptor": "output_path",
-        "file": output_file.name,
-        "format": "ecsv",
-        "non_empty": True,
-        "count": {"exact": 2},
-        "required_columns": ["run_number", "value"],
-        "forbidden_columns": ["forbidden"],
-        "columns": {
-            "run_number": {"type": "int64", "finite": True, "unique": True},
-            "value": {
-                "type": "float64",
-                "unit": "m",
-                "finite": True,
-                "range": {"minimum": 0.0, "maximum": 3.0, "unit": "m"},
-            },
-            "label": {"type": "string", "allowed_values": ["a", "b"]},
-        },
-        "metadata": {"required_keys": ["summary"]},
-        "consistency": [
-            {
-                "left": {"source": "metadata", "path": "summary.rows"},
-                "operator": "equals",
-                "right": {"source": "content", "metric": "row_count"},
-            },
-            {
-                "left": {"source": "metadata", "path": "summary.total"},
-                "operator": "equals",
-                "right": {
-                    "source": "content",
-                    "aggregate": {"function": "sum", "column": "value"},
-                },
-            },
-        ],
-    }
-
-    validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
-
-
-def test_empty_parseable_job_grid_fails_minimum_row_validation(tmp_test_directory):
-    """Regression test for issue #2352: an empty ECSV must not pass presence checks."""
-    tmp_test_directory = Path(tmp_test_directory)
-    workflow = yaml.safe_load(
-        Path(
-            "tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml"
-        ).read_text(encoding="utf-8")
-    )
-    config = workflow["applications"][0]
-    config["configuration"]["output_path"] = str(tmp_test_directory)
-    output_file = tmp_test_directory / "job_grid_horizontal_explicit.ecsv"
-    columns = [
-        "run_number",
-        "primary",
-        "azimuth_angle",
-        "zenith_angle",
-        "energy_min",
-        "energy_max",
-        "cores_per_shower",
-        "core_scatter_max",
-        "view_cone_min",
-        "view_cone_max",
-        "showers_per_run",
-        "nsb_rate",
-        "model_version",
-        "array_layout_name",
-        "corsika_le_interaction",
-        "corsika_he_interaction",
-    ]
-    Table(names=columns, dtype=["int64", "str"] + ["float64"] * 10 + ["str"] * 4).write(
-        output_file, format="ascii.ecsv"
-    )
-    with pytest.raises(AssertionError, match=r"expected 'non-empty content', actual 0"):
-        validate_output.validate_application_output(config)
-
-
-@pytest.mark.parametrize(
-    ("change", "expected"),
-    [
-        (lambda rule: rule.update({"non_empty": True, "count": {"minimum": 3}}), ">=3"),
-        (lambda rule: rule.update({"count": {"maximum": 1}}), "<=1"),
-        (lambda rule: rule["required_columns"].append("missing"), "required column"),
-        (lambda rule: rule["columns"]["value"].update({"finite": True}), "finite"),
-        (lambda rule: rule["columns"]["run_number"].update({"unique": True}), "unique"),
-        (lambda rule: rule["columns"]["label"].update({"type": "int64"}), "type"),
-        (lambda rule: rule["columns"]["value"].update({"unit": "s"}), "unit"),
-        (lambda rule: rule.update({"forbidden_columns": ["value"]}), "forbidden column"),
-        (lambda rule: rule["columns"]["label"].update({"allowed_values": ["x"]}), "allowed"),
-        (
-            lambda rule: rule["columns"]["value"].update({"range": {"maximum": 1.0}}),
-            "maximum",
-        ),
-    ],
-)
-def test_declarative_table_validation_failures(tmp_test_directory, change, expected):
-    """Report the output, rule, expected condition, and actual value on failure."""
-    tmp_test_directory = Path(tmp_test_directory)
-    output_file = tmp_test_directory / "table.ecsv"
-    _semantic_table(output_file)
-    if expected == "finite":
-        table = Table.read(output_file, format="ascii.ecsv")
-        table["value"][0] = np.nan
-        table.write(output_file, format="ascii.ecsv", overwrite=True)
-    if expected == "unique":
-        table = Table.read(output_file, format="ascii.ecsv")
-        table["run_number"][1] = table["run_number"][0]
-        table.write(output_file, format="ascii.ecsv", overwrite=True)
-    rule = {
-        "name": "semantic_table",
-        "kind": "table",
-        "path_descriptor": "output_path",
-        "file": output_file.name,
-        "required_columns": ["run_number", "value", "label"],
-        "columns": {
-            "run_number": {"type": "int64"},
-            "value": {"type": "float64", "unit": "m"},
-            "label": {"type": "string"},
-        },
-    }
-    change(rule)
-
-    with pytest.raises(
-        AssertionError, match=r"Output .* failed rule 'semantic_table'.*"
-    ) as exc_info:
-        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
-    assert expected in str(exc_info.value)
-    assert "expected" in str(exc_info.value)
-    assert "actual" in str(exc_info.value)
-
-
-def test_declarative_file_and_mapping_validation(tmp_test_directory):
-    """Validate generic files and mapping keys."""
-    tmp_test_directory = Path(tmp_test_directory)
-    empty_file = tmp_test_directory / "empty.txt"
-    empty_file.touch()
-    empty_rule = {
-        "name": "non_empty_file",
-        "kind": "file",
-        "path_descriptor": "output_path",
-        "file": empty_file.name,
-        "non_empty": True,
-    }
-    with pytest.raises(AssertionError, match="non-empty"):
-        validate_output.validate_application_output(
-            _semantic_config(tmp_test_directory, empty_rule)
-        )
-
-    mapping_file = tmp_test_directory / "mapping.yml"
-    mapping_file.write_text("required: true\n", encoding="utf-8")
-    mapping_rule = {
-        "name": "mapping_keys",
-        "kind": "mapping",
-        "path_descriptor": "output_path",
-        "file": mapping_file.name,
-        "non_empty": True,
-        "required_keys": ["required"],
-        "forbidden_keys": ["forbidden"],
-    }
-    validate_output.validate_application_output(_semantic_config(tmp_test_directory, mapping_rule))
-
-    missing_key_rule = dict(mapping_rule)
-    missing_key_rule["required_keys"] = ["missing"]
-    with pytest.raises(AssertionError, match="required key"):
-        validate_output.validate_application_output(
-            _semantic_config(tmp_test_directory, missing_key_rule)
-        )
-
-    forbidden_key_rule = dict(mapping_rule)
-    forbidden_key_rule["forbidden_keys"] = ["required"]
-    with pytest.raises(AssertionError, match="forbidden key"):
-        validate_output.validate_application_output(
-            _semantic_config(tmp_test_directory, forbidden_key_rule)
-        )
-
-
-def test_declarative_group_and_event_stream_counts(tmp_test_directory):
-    """Validate HDF5 groups and event-stream counts."""
-    tmp_test_directory = Path(tmp_test_directory)
-    output_file = tmp_test_directory / "structured.h5"
-    with h5py.File(output_file, "w") as hdf5_file:
-        group = hdf5_file.create_group("group")
-        group.create_dataset("member", data=[1, 2])
-        hdf5_file.create_dataset("events", data=[10, 20, 30])
-
-    group_rule = {
-        "name": "group",
-        "kind": "group",
-        "path_descriptor": "output_path",
-        "file": output_file.name,
-        "object_path": "group",
-        "non_empty": True,
-        "count": {"exact": 1},
-        "required_keys": ["member"],
-    }
-    event_rule = {
-        "name": "events",
-        "kind": "event_stream",
-        "path_descriptor": "output_path",
-        "file": output_file.name,
-        "format": "hdf5",
-        "object_path": "events",
-        "non_empty": True,
-        "count": {"minimum": 3},
-    }
-    config = {
-        "configuration": {"output_path": str(tmp_test_directory)},
-        "integration_tests": [{"output_validation": [group_rule, event_rule]}],
-    }
-    validate_output.validate_application_output(config)
-
-    group_rule["count"] = {"maximum": 0}
-    with pytest.raises(AssertionError, match="<=0"):
-        validate_output.validate_application_output(config)
-
-    group_rule["count"] = {"exact": 1}
-    event_rule["count"] = {"exact": 4}
-    with pytest.raises(AssertionError, match="expected 4"):
-        validate_output.validate_application_output(config)
-
-
-def test_declarative_relationship_validation(tmp_test_directory):
-    """Validate a relationship between mapping metadata and a table count."""
-    tmp_test_directory = Path(tmp_test_directory)
-    table_file = tmp_test_directory / "table.ecsv"
-    _semantic_table(table_file)
-    summary_file = tmp_test_directory / "summary.yml"
-    summary_file.write_text("rows: 2\n", encoding="utf-8")
-    rule = {
-        "name": "summary_relationship",
-        "kind": "relationship",
-        "outputs": [
-            {
-                "name": "summary",
-                "kind": "mapping",
-                "path_descriptor": "output_path",
-                "file": summary_file.name,
-            },
-            {
-                "name": "table",
-                "kind": "table",
-                "path_descriptor": "output_path",
-                "file": table_file.name,
-                "format": "ecsv",
-            },
-        ],
-        "checks": [
-            {
-                "left": {"output": "summary", "path": "rows"},
-                "operator": "equals",
-                "right": {"output": "table", "metric": "row_count"},
-            }
-        ],
-    }
-    config = {
-        "configuration": {"output_path": str(tmp_test_directory)},
-        "integration_tests": [{"output_validation": [rule]}],
-    }
-    validate_output.validate_application_output(config)
-
-    summary_file.write_text("rows: 3\n", encoding="utf-8")
-    with pytest.raises(AssertionError, match="summary_relationship"):
-        validate_output.validate_application_output(config)
-
-
-def test_declarative_data_product_schema_validation(tmp_test_directory):
-    """Validate a table against an explicit simtools data-product schema."""
-    tmp_test_directory = Path(tmp_test_directory)
-    schema_file = tmp_test_directory / "table.schema.yml"
-    schema_file.write_text(
-        yaml.safe_dump(
-            {
-                "schema_version": "0.1.0",
-                "data": [
-                    {
-                        "type": "data_table",
-                        "table_columns": [
-                            {"name": "run_number", "required": True, "type": "int64"}
-                        ],
-                    }
-                ],
-            }
-        ),
-        encoding="utf-8",
-    )
-    output_file = tmp_test_directory / "schema.ecsv"
-    Table({"run_number": [1, 2]}).write(output_file, format="ascii.ecsv")
-    rule = {
-        "name": "schema",
-        "kind": "table",
         "path_descriptor": "output_path",
         "file": output_file.name,
         "data_product_schema": str(schema_file),
+        "minimum_rows": 1,
+        "unique_columns": ["run_number"],
+        "columns": {
+            "value": {"range": {"minimum": 0.0, "maximum": 3.0, "unit": "m"}},
+            "label": {"allowed_values": ["a", "b"]},
+        },
+        "metadata": {
+            "required_keys": ["summary"],
+            "row_count": "summary.rows",
+            "column_sums": {"value": "summary.total"},
+        },
     }
-    validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
 
-    Table({"other": [1, 2]}).write(output_file, format="ascii.ecsv", overwrite=True)
-    with pytest.raises(AssertionError, match="data-product schema"):
+
+def test_declarative_table_validation_passes(tmp_test_directory):
+    """Validate schema, rows, domains, uniqueness, and metadata summaries."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_table(output_file)
+    _semantic_schema(schema_file)
+
+    validate_output.validate_application_output(
+        _semantic_config(tmp_test_directory, _semantic_rule(output_file, schema_file))
+    )
+
+
+def test_declarative_table_rejects_empty_and_duplicate_rows(tmp_test_directory):
+    """Reject an empty table and duplicate values in a unique column."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_schema(schema_file)
+    rule = _semantic_rule(output_file, schema_file)
+    Table(
+        names=["run_number", "value", "label"],
+        dtype=["int64", "float64", "str"],
+        meta={"summary": {"rows": 0, "total": 0.0}},
+    ).write(output_file, format="ascii.ecsv")
+    with pytest.raises(AssertionError, match="at least 1 rows"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+    _semantic_table(output_file)
+    table = Table.read(output_file, format="ascii.ecsv")
+    table["run_number"][1] = table["run_number"][0]
+    table.write(output_file, format="ascii.ecsv", overwrite=True)
+    with pytest.raises(AssertionError, match="unique values in run_number"):
         validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
 
 
-def test_declarative_metadata_consistency_failure(tmp_test_directory):
-    """Reject metadata that disagrees with table content."""
+@pytest.mark.parametrize(
+    ("column", "column_rule", "expected"),
+    [
+        ("label", {"allowed_values": ["x"]}, "allowed values"),
+        ("label", {"range": {"minimum": 0.0}}, "numerical range"),
+        ("value", {"range": {"minimum": 2.0, "unit": "m"}}, "minimum"),
+        ("value", {"range": {"maximum": 1.0, "unit": "m"}}, "maximum"),
+    ],
+)
+def test_declarative_column_validation_failures(tmp_test_directory, column, column_rule, expected):
+    """Reject workflow-specific column domains and ranges."""
     tmp_test_directory = Path(tmp_test_directory)
-    output_file = tmp_test_directory / "inconsistent.ecsv"
-    _semantic_table(output_file, metadata={"summary": {"rows": 99, "total": 3.0}})
-    rule = {
-        "name": "metadata_consistency",
-        "kind": "table",
-        "path_descriptor": "output_path",
-        "file": output_file.name,
-        "consistency": [
-            {
-                "left": {"source": "metadata", "path": "summary.rows"},
-                "operator": "equals",
-                "right": {"source": "content", "metric": "row_count"},
-            }
-        ],
-    }
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_table(output_file)
+    _semantic_schema(schema_file)
+    rule = _semantic_rule(output_file, schema_file)
+    rule["columns"] = {column: column_rule}
 
-    with pytest.raises(AssertionError, match="metadata_consistency"):
+    with pytest.raises(AssertionError, match=expected):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        ({}, "required metadata key summary"),
+        ({"summary": {"rows": 3, "total": 3.0}}, "equals row count"),
+        ({"summary": {"rows": 2, "total": 4.0}}, "equals sum of value"),
+    ],
+)
+def test_declarative_metadata_validation_failures(tmp_test_directory, metadata, expected):
+    """Reject missing or inconsistent table metadata."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_table(output_file, metadata=metadata)
+    _semantic_schema(schema_file)
+
+    with pytest.raises(AssertionError, match=expected):
+        validate_output.validate_application_output(
+            _semantic_config(
+                tmp_test_directory,
+                _semantic_rule(output_file, schema_file),
+            )
+        )
+
+
+def test_declarative_data_product_schema_validation(tmp_test_directory):
+    """Reject a table that does not satisfy its data-product schema."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_schema(schema_file)
+    Table({"other": [1, 2]}).write(output_file, format="ascii.ecsv")
+
+    with pytest.raises(AssertionError, match="data-product schema"):
+        validate_output.validate_application_output(
+            _semantic_config(
+                tmp_test_directory,
+                _semantic_rule(output_file, schema_file),
+            )
+        )
+
+
+def test_declarative_output_must_exist_and_be_ecsv(tmp_test_directory):
+    """Report missing and unparsable output tables consistently."""
+    tmp_test_directory = Path(tmp_test_directory)
+    output_file = tmp_test_directory / "table.ecsv"
+    schema_file = tmp_test_directory / "table.schema.yml"
+    _semantic_schema(schema_file)
+    rule = _semantic_rule(output_file, schema_file)
+
+    with pytest.raises(AssertionError, match="existing output"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+    output_file.write_text("not an ECSV table\n", encoding="utf-8")
+    with pytest.raises(AssertionError, match="parseable ECSV table"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+    _semantic_table(output_file)
+    rule["unique_columns"] = ["missing"]
+    with pytest.raises(AssertionError, match="valid configured table content"):
+        validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))
+
+    rule["path_descriptor"] = "missing"
+    with pytest.raises(KeyError, match="Path missing"):
         validate_output.validate_application_output(_semantic_config(tmp_test_directory, rule))

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from collections import UserDict
 from pathlib import Path
 from unittest.mock import patch
 
@@ -962,6 +963,13 @@ def test_declarative_table_validation_passes(tmp_test_directory):
     validate_output.validate_application_output(
         _semantic_config(tmp_test_directory, _semantic_rule(output_file, schema_file))
     )
+
+
+def test_has_path_supports_mapping_metadata():
+    """Accept mapping implementations used for ordered metadata."""
+    metadata = UserDict({"summary": UserDict({"rows": 2})})
+
+    assert validate_output._has_path(metadata, "summary.rows")
 
 
 def test_declarative_table_rejects_empty_and_duplicate_rows(tmp_test_directory):


### PR DESCRIPTION
production_generate_grid generates an empty ECSV table during the integration test - clearly something which should be caught (see issue #2352).

In general, integration test should follow the following steps of increasing test power:

- execution only;
- file presence;
- parse or schema validation;
- semantic invariants;
- deterministic reference comparison.

Improve the validation of output from integration tests such that we add tests:

- presence of columns in table
- presence of rows in table
- range of values columns
- required content ('keys') in metadata.
- schema

Implemented only as example in tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml (but needs to be extended to other tests generating tables).

Expect this to be the start of several similar extensions for output validation in integration tests. 