### PR TITLE
Improve efficiency of schema file reading

### DIFF
--- a/docs/changes/2362.maintenance.md
+++ b/docs/changes/2362.maintenance.md
@@ -1,0 +1,1 @@
+Improve efficiency for reading model schema files (avoid multiple reading of the same files).

--- a/docs/source/api-reference/data_model.md
+++ b/docs/source/api-reference/data_model.md
@@ -66,6 +66,13 @@ Data products ingested or produced by simtools generally follows the CTAO data m
    :members:
 ```
 
+## schema_loader
+
+```{eval-rst}
+.. automodule:: data_model.schema_loader
+   :members:
+```
+
 (datamodelvalidatedata)=
 
 ## validate_data

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -1,8 +1,7 @@
 """Module providing functionality to read and validate dictionaries using schema."""
 
 import logging
-from copy import deepcopy
-from functools import cache, lru_cache
+from functools import lru_cache
 from pathlib import Path
 
 import jsonschema
@@ -75,11 +74,7 @@ def get_model_parameter_schema(parameter, schema_version=None):
     Returns
     -------
     dict
-        Shared, immutable schema dictionary.
-
-    Notes
-    -----
-    Returned schema dictionaries are cached and must not be modified.
+        Independent schema dictionary.
     """
     schema_file = get_model_parameter_schema_file(parameter)
     return load_schema(schema_file, schema_version or "latest")
@@ -212,7 +207,6 @@ def get_schema_version_from_data(data, observatory="cta"):
     return "latest"
 
 
-@cache
 def load_schema(schema_file=None, schema_version="latest"):
     """
     Load parameter schema from file.
@@ -227,20 +221,16 @@ def load_schema(schema_file=None, schema_version="latest"):
     Returns
     -------
     schema: dict
-        Shared, immutable schema dictionary.
+        Independent schema dictionary.
 
     Raises
     ------
     FileNotFoundError
         if schema file is not found
 
-    Notes
-    -----
-    Returned schema dictionaries are cached and must not be modified.
-
     """
     schema_file = schema_file or METADATA_JSON_SCHEMA
-    schema = deepcopy(schema_loader.load_schema(schema_file, schema_version))
+    schema = schema_loader.load_schema(schema_file, schema_version)
     _add_array_elements("InstrumentTypeElement", schema)
 
     return schema

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -1,7 +1,8 @@
 """Module providing functionality to read and validate dictionaries using schema."""
 
 import logging
-from functools import lru_cache
+from copy import deepcopy
+from functools import cache, lru_cache
 from pathlib import Path
 
 import jsonschema
@@ -15,7 +16,7 @@ from simtools.constants import (
     MODEL_PARAMETER_SCHEMA_PATH,
     SCHEMA_PATH,
 )
-from simtools.data_model import format_checkers
+from simtools.data_model import format_checkers, schema_loader
 from simtools.dependencies import get_software_version
 from simtools.io import ascii_handler
 from simtools.utils import names, value_conversion
@@ -36,15 +37,7 @@ def get_model_parameter_schema_files(schema_directory=MODEL_PARAMETER_SCHEMA_PAT
         List of schema files found in schema file directory.
 
     """
-    schema_files = sorted(Path(schema_directory).rglob("*.schema.yml"))
-    if not schema_files:
-        raise FileNotFoundError(f"No schema files found in {schema_directory}")
-    parameters = []
-    for schema_file in schema_files:
-        # reading parameter 'name' only - first document in schema file should be ok
-        schema_dict = ascii_handler.collect_data_from_file(file_name=schema_file, yaml_document=0)
-        parameters.append(schema_dict.get("name"))
-    return parameters, schema_files
+    return schema_loader.get_model_parameter_schema_files(schema_directory)
 
 
 def get_model_parameter_schema_file(parameter):
@@ -82,10 +75,14 @@ def get_model_parameter_schema(parameter, schema_version=None):
     Returns
     -------
     dict
-        Schema dictionary.
+        Shared, immutable schema dictionary.
+
+    Notes
+    -----
+    Returned schema dictionaries are cached and must not be modified.
     """
     schema_file = get_model_parameter_schema_file(parameter)
-    return load_schema(schema_file, schema_version=schema_version or "latest")
+    return load_schema(schema_file, schema_version or "latest")
 
 
 def get_model_parameter_schema_version(schema_version=None):
@@ -215,6 +212,7 @@ def get_schema_version_from_data(data, observatory="cta"):
     return "latest"
 
 
+@cache
 def load_schema(schema_file=None, schema_version="latest"):
     """
     Load parameter schema from file.
@@ -229,90 +227,22 @@ def load_schema(schema_file=None, schema_version="latest"):
     Returns
     -------
     schema: dict
-        Schema dictionary.
+        Shared, immutable schema dictionary.
 
     Raises
     ------
     FileNotFoundError
         if schema file is not found
 
+    Notes
+    -----
+    Returned schema dictionaries are cached and must not be modified.
+
     """
     schema_file = schema_file or METADATA_JSON_SCHEMA
-
-    schema = None
-    for path in _get_local_schema_candidates(schema_file):
-        try:
-            schema = ascii_handler.collect_data_from_file(file_name=path)
-            break
-        except FileNotFoundError:
-            continue
-
-    # Fall back to remote retrieval only if local resolution fails.
-    if schema is None and gen.is_url(str(schema_file)):
-        try:
-            schema = ascii_handler.collect_data_from_file(file_name=schema_file)
-        except FileNotFoundError as exc:
-            raise FileNotFoundError(f"Schema file not found: {schema_file}") from exc
-
-    if schema is None:
-        raise FileNotFoundError(f"Schema file not found: {schema_file}")
-
-    _logger.debug(f"Loading schema from {schema_file} for schema version {schema_version}")
-    schema = _get_schema_for_version(schema, schema_file, schema_version)
+    schema = deepcopy(schema_loader.load_schema(schema_file, schema_version))
     _add_array_elements("InstrumentTypeElement", schema)
 
-    return schema
-
-
-def _get_local_schema_candidates(schema_file):
-    """Build local candidate paths for a schema file reference."""
-    schema_path = Path(str(schema_file))
-    candidates = [schema_path, SCHEMA_PATH / schema_path]
-
-    if gen.is_url(str(schema_file)):
-        schema_name = Path(str(schema_file)).name
-        if schema_name:
-            candidates.extend([SCHEMA_PATH / schema_name, Path(schema_name)])
-
-    # Keep order stable while removing duplicates.
-    return list(dict.fromkeys(candidates))
-
-
-def _get_schema_for_version(schema, schema_file, schema_version):
-    """
-    Get schema for a specific version.
-
-    Allow for 'latest' version to return the most recent schema.
-
-    Parameters
-    ----------
-    schema: dict or list
-        Schema dictionary or list of dictionaries.
-    schema_file: str
-        Path to schema file.
-    schema_version: str or None
-        Schema version to retrieve. If 'latest', the most recent version is returned.
-
-    Returns
-    -------
-    dict
-        Schema dictionary for the specified version.
-    """
-    if schema_version is None:
-        raise ValueError(f"Schema version not given in {schema_file}.")
-
-    if isinstance(schema, list):  # schema file with several schemas defined
-        if len(schema) == 0:
-            raise ValueError(f"No schemas found in {schema_file}.")
-        if schema_version == "latest":
-            schema_version = schema[0].get("schema_version")
-        schema = next((doc for doc in schema if doc.get("schema_version") == schema_version), None)
-    if schema is None:
-        raise ValueError(f"Schema version {schema_version} not found in {schema_file}.")
-    if schema_version not in (None, "latest") and schema_version != schema.get("schema_version"):
-        _logger.warning(
-            f"Schema version {schema_version} does not match {schema.get('schema_version')}"
-        )
     return schema
 
 

--- a/src/simtools/data_model/schema_loader.py
+++ b/src/simtools/data_model/schema_loader.py
@@ -1,0 +1,137 @@
+"""Cached, dependency-neutral loading of schema definitions."""
+
+import logging
+from functools import cache
+from pathlib import Path
+
+import simtools.utils.general as gen
+from simtools.constants import SCHEMA_PATH
+from simtools.io import ascii_handler
+
+_logger = logging.getLogger(__name__)
+
+
+def get_model_parameter_schema_files(schema_directory):
+    """
+    Return model-parameter names and schema files from a directory.
+
+    Parameters
+    ----------
+    schema_directory : str or Path
+        Directory containing model-parameter schema files.
+
+    Returns
+    -------
+    list
+        Model-parameter names.
+    list
+        Corresponding schema file paths.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the directory contains no model-parameter schema files.
+    """
+    schema_files = sorted(Path(schema_directory).rglob("*.schema.yml"))
+    if not schema_files:
+        raise FileNotFoundError(f"No schema files found in {schema_directory}")
+    parameters = [load_schema(schema_file, "latest").get("name") for schema_file in schema_files]
+    return parameters, schema_files
+
+
+@cache
+def load_schema(schema_file, schema_version="latest"):
+    """
+    Load and cache an immutable schema definition by source and version.
+
+    Parameters
+    ----------
+    schema_file : str or Path
+        Local path or URL of the schema file.
+    schema_version : str
+        Schema version to return, or ``latest`` for the first document.
+
+    Returns
+    -------
+    dict
+        Shared, immutable schema definition.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the schema cannot be loaded locally or from its URL.
+    ValueError
+        If the requested schema version is unavailable.
+    """
+    schema = None
+    for path in _get_local_schema_candidates(schema_file):
+        try:
+            schema = ascii_handler.collect_data_from_file(file_name=path)
+            break
+        except FileNotFoundError:
+            continue
+
+    if schema is None and gen.is_url(str(schema_file)):
+        try:
+            schema = ascii_handler.collect_data_from_file(file_name=schema_file)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Schema file not found: {schema_file}") from exc
+
+    if schema is None:
+        raise FileNotFoundError(f"Schema file not found: {schema_file}")
+
+    return get_schema_for_version(schema, schema_file, schema_version)
+
+
+def _get_local_schema_candidates(schema_file):
+    """Build local candidate paths for a schema file reference."""
+    schema_path = Path(str(schema_file))
+    candidates = [schema_path, SCHEMA_PATH / schema_path]
+
+    if gen.is_url(str(schema_file)):
+        schema_name = Path(str(schema_file)).name
+        if schema_name:
+            candidates.extend([SCHEMA_PATH / schema_name, Path(schema_name)])
+
+    return list(dict.fromkeys(candidates))
+
+
+def get_schema_for_version(schema, schema_file, schema_version):
+    """
+    Return a requested version from a parsed schema definition.
+
+    Parameters
+    ----------
+    schema : dict or list
+        Parsed schema definition or versioned schema documents.
+    schema_file : str or Path
+        Schema source used in error and warning messages.
+    schema_version : str
+        Requested schema version, or ``latest`` for the first document.
+
+    Returns
+    -------
+    dict
+        Selected schema definition.
+
+    Raises
+    ------
+    ValueError
+        If no version is requested, the schema list is empty, or the requested version is absent.
+    """
+    if schema_version is None:
+        raise ValueError(f"Schema version not given in {schema_file}.")
+
+    if isinstance(schema, list):
+        if len(schema) == 0:
+            raise ValueError(f"No schemas found in {schema_file}.")
+        if schema_version == "latest":
+            schema_version = schema[0].get("schema_version")
+        schema = next((doc for doc in schema if doc.get("schema_version") == schema_version), None)
+    if schema is None:
+        raise ValueError(f"Schema version {schema_version} not found in {schema_file}.")
+    if schema_version not in (None, "latest") and schema_version != schema.get("schema_version"):
+        _logger.warning(
+            f"Schema version {schema_version} does not match {schema.get('schema_version')}"
+        )
+    return schema

--- a/src/simtools/data_model/schema_loader.py
+++ b/src/simtools/data_model/schema_loader.py
@@ -1,6 +1,7 @@
 """Cached, dependency-neutral loading of schema definitions."""
 
 import logging
+from copy import deepcopy
 from functools import cache
 from pathlib import Path
 
@@ -35,14 +36,16 @@ def get_model_parameter_schema_files(schema_directory):
     schema_files = sorted(Path(schema_directory).rglob("*.schema.yml"))
     if not schema_files:
         raise FileNotFoundError(f"No schema files found in {schema_directory}")
-    parameters = [load_schema(schema_file, "latest").get("name") for schema_file in schema_files]
+    parameters = [
+        get_schema_for_version(_load_schema_source(schema_file), schema_file, "latest").get("name")
+        for schema_file in schema_files
+    ]
     return parameters, schema_files
 
 
-@cache
 def load_schema(schema_file, schema_version="latest"):
     """
-    Load and cache an immutable schema definition by source and version.
+    Load a schema definition from a cached parsed source.
 
     Parameters
     ----------
@@ -54,7 +57,7 @@ def load_schema(schema_file, schema_version="latest"):
     Returns
     -------
     dict
-        Shared, immutable schema definition.
+        Independent schema definition selected from the cached parsed source.
 
     Raises
     ------
@@ -63,6 +66,13 @@ def load_schema(schema_file, schema_version="latest"):
     ValueError
         If the requested schema version is unavailable.
     """
+    schema = get_schema_for_version(_load_schema_source(schema_file), schema_file, schema_version)
+    return deepcopy(schema)
+
+
+@cache
+def _load_schema_source(schema_file):
+    """Resolve, parse, and cache all schema definitions from one source."""
     schema = None
     for path in _get_local_schema_candidates(schema_file):
         try:
@@ -80,7 +90,12 @@ def load_schema(schema_file, schema_version="latest"):
     if schema is None:
         raise FileNotFoundError(f"Schema file not found: {schema_file}")
 
-    return get_schema_for_version(schema, schema_file, schema_version)
+    return schema
+
+
+def clear_cache():
+    """Clear cached parsed schema sources."""
+    _load_schema_source.cache_clear()
 
 
 def _get_local_schema_candidates(schema_file):

--- a/src/simtools/simtel/simtel_config_reader.py
+++ b/src/simtools/simtel/simtel_config_reader.py
@@ -254,7 +254,6 @@ class SimtelConfigReader:
         if not any(isinstance(item, str) and item.startswith("all") for item in column):
             return column, {}
 
-        self._logger.debug(f"Resolving 'all' entries in column: {column}")
         # remove 'all:' entries
         column = [item for item in column if item not in ("all:", "all")]
         # resolve 'all:5' type entries

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -26,6 +26,7 @@ from simtools.constants import (
     RESOURCE_PATH,
     SIM_TELARRAY_INCLUDE_FILENAME_MAX_LENGTH,
 )
+from simtools.data_model import schema_loader
 
 _logger = logging.getLogger(__name__)
 
@@ -203,12 +204,13 @@ def _load_model_parameters():
     dict
         Model parameters definitions for all model parameters.
     """
-    _parameters = {}
-    for schema_file in Path(MODEL_PARAMETER_SCHEMA_PATH).rglob("*.yml"):
-        with open(schema_file, encoding="utf-8") as f:
-            data = next(yaml.safe_load_all(f))
-            _parameters[data["name"]] = data
-    return _parameters
+    parameters, schema_files = schema_loader.get_model_parameter_schema_files(
+        MODEL_PARAMETER_SCHEMA_PATH
+    )
+    return {
+        parameter: schema_loader.load_schema(schema_file, "latest")
+        for parameter, schema_file in zip(parameters, schema_files)
+    }
 
 
 def model_parameters(class_key_list=None):
@@ -225,7 +227,7 @@ def model_parameters(class_key_list=None):
     Returns
     -------
     dict
-        Model parameters definitions.
+        Model parameters definitions. Schema values are shared and must not be modified.
     """
     if class_key_list is None:
         return _load_model_parameters()

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -46,32 +46,32 @@ def test_get_model_parameter_schema_file():
         schema.get_model_parameter_schema_file("not_a_parameter")
 
 
-def test_get_model_parameter_schema_returns_cached_schema():
-    schema.load_schema.cache_clear()
-    schema_loader.load_schema.cache_clear()
+def test_get_model_parameter_schema_returns_independent_copies():
+    schema_loader.clear_cache()
     schema_1 = schema.get_model_parameter_schema("mirror_focal_length", "0.1.0")
     schema_2 = schema.get_model_parameter_schema("mirror_focal_length", "0.1.0")
 
-    assert schema_1 is schema_2
+    schema_1["data"][0]["unit"] = "m"
+
+    assert schema_2["data"][0]["unit"] == "cm"
 
 
-def test_load_schema_cache_separates_versions(mocker):
-    schema.load_schema.cache_clear()
-    schema_loader.load_schema.cache_clear()
+def test_load_schema_uses_cached_source_for_different_versions(mocker):
+    schema_loader.clear_cache()
     collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
 
     schema_1 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
     schema_2 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2.0")
     schema_1_cached = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
 
-    assert schema_1 is schema_1_cached
+    assert schema_1 == schema_1_cached
+    assert schema_1 is not schema_1_cached
     assert schema_1 is not schema_2
-    assert collect_data.call_count == 2
+    assert collect_data.call_count == 1
 
 
 def test_model_parameter_cache_is_shared_with_names(mocker):
-    schema.load_schema.cache_clear()
-    schema_loader.load_schema.cache_clear()
+    schema_loader.clear_cache()
     names._load_model_parameters.cache_clear()
     collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
 

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -17,10 +17,9 @@ from simtools.constants import (
     SIM_TELARRAY_META_PARAMETER_METASCHEMA,
     SIM_TELARRAY_META_PARAMETER_REGISTRY,
 )
-from simtools.data_model import schema
+from simtools.data_model import schema, schema_loader
 from simtools.io import ascii_handler
-
-DUMMY_FILE = "dummy_file.yml"
+from simtools.utils import names
 
 
 def test_get_model_parameter_schema_files(tmp_test_directory):
@@ -47,13 +46,48 @@ def test_get_model_parameter_schema_file():
         schema.get_model_parameter_schema_file("not_a_parameter")
 
 
-def test_get_model_parameter_schema_returns_independent_copies():
+def test_get_model_parameter_schema_returns_cached_schema():
+    schema.load_schema.cache_clear()
+    schema_loader.load_schema.cache_clear()
     schema_1 = schema.get_model_parameter_schema("mirror_focal_length", "0.1.0")
     schema_2 = schema.get_model_parameter_schema("mirror_focal_length", "0.1.0")
 
-    schema_1["data"][0]["unit"] = "m"
+    assert schema_1 is schema_2
 
-    assert schema_2["data"][0]["unit"] == "cm"
+
+def test_load_schema_cache_separates_versions(mocker):
+    schema.load_schema.cache_clear()
+    schema_loader.load_schema.cache_clear()
+    collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
+
+    schema_1 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
+    schema_2 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2.0")
+    schema_1_cached = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
+
+    assert schema_1 is schema_1_cached
+    assert schema_1 is not schema_2
+    assert collect_data.call_count == 2
+
+
+def test_model_parameter_cache_is_shared_with_names(mocker):
+    schema.load_schema.cache_clear()
+    schema_loader.load_schema.cache_clear()
+    names._load_model_parameters.cache_clear()
+    collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
+
+    model_parameters = names.model_parameters()
+    schema_file = schema.get_model_parameter_schema_file("mirror_focal_length")
+    reads_before = sum(
+        call.kwargs.get("file_name") == schema_file for call in collect_data.call_args_list
+    )
+    loaded_schema = schema.get_model_parameter_schema("mirror_focal_length")
+    reads_after = sum(
+        call.kwargs.get("file_name") == schema_file for call in collect_data.call_args_list
+    )
+
+    assert loaded_schema == model_parameters["mirror_focal_length"]
+    assert loaded_schema is not model_parameters["mirror_focal_length"]
+    assert reads_before == reads_after == 1
 
 
 def test_validate_sim_telarray_meta_parameter_registry_schema():
@@ -466,56 +500,6 @@ def test_load_schema(caplog, tmp_test_directory):
     assert "Schema version 0.3.0 does not match 0.2.0" in caplog.text
 
 
-def test_load_schema_prefers_local_before_remote(monkeypatch, tmp_path):
-    """Test URL-based schema loading checks local schema files before remote access."""
-    monkeypatch.setattr(schema, "SCHEMA_PATH", tmp_path)
-    schema._retrieve_yaml_schema_from_uri.cache_clear()
-
-    remote_url = "https://example.com/schemas/simulation_models_info.schema.yml"
-    local_schema_path = tmp_path / "simulation_models_info.schema.yml"
-    expected_schema = {"schema_version": "0.2.0", "definitions": {}}
-
-    calls = []
-
-    def _mock_collect_data_from_file(file_name, yaml_document=None):
-        calls.append(str(file_name))
-        if Path(str(file_name)) == local_schema_path:
-            return expected_schema
-        raise FileNotFoundError(f"Missing schema: {file_name}")
-
-    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _mock_collect_data_from_file)
-
-    result = schema.load_schema(schema_file=remote_url, schema_version="0.2.0")
-
-    assert result == expected_schema
-    assert str(local_schema_path) in calls
-    assert remote_url not in calls
-
-
-def test_load_schema_falls_back_to_remote_when_local_missing(monkeypatch, tmp_path):
-    """Test URL-based schema loading falls back to remote retrieval if local lookup fails."""
-    monkeypatch.setattr(schema, "SCHEMA_PATH", tmp_path)
-    schema._retrieve_yaml_schema_from_uri.cache_clear()
-
-    remote_url = "https://example.com/schemas/simulation_models_info.schema.yml"
-    expected_schema = {"schema_version": "0.2.0", "definitions": {}}
-
-    calls = []
-
-    def _mock_collect_data_from_file(file_name, yaml_document=None):
-        calls.append(str(file_name))
-        if str(file_name) == remote_url:
-            return expected_schema
-        raise FileNotFoundError(f"Missing schema: {file_name}")
-
-    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _mock_collect_data_from_file)
-
-    result = schema.load_schema(schema_file=remote_url, schema_version="0.2.0")
-
-    assert result == expected_schema
-    assert str(remote_url) in calls
-
-
 def test_add_array_elements():
     test_dict_1 = {"data": {"InstrumentTypeElement": {"enum": ["LSTN", "MSTN"]}}}
     test_dict_added = schema._add_array_elements("InstrumentTypeElement", test_dict_1)
@@ -587,59 +571,6 @@ def test_get_schema_version_from_data_with_custom_observatory_lowercase():
     data = {"veritas": {"reference": {"version": "0.9.9"}}}
     result = schema.get_schema_version_from_data(data, observatory="veritas")
     assert result == "0.9.9"
-
-
-def test_get_schema_for_version_with_dict():
-    test_schema = {"schema_version": "1.0.0", "name": "test"}
-    result = schema._get_schema_for_version(test_schema, DUMMY_FILE, "1.0.0")
-    assert result == test_schema
-
-
-def test_get_schema_for_version_with_list_and_latest():
-    schema_list = [
-        {"schema_version": "2.0.0", "name": "latest"},
-        {"schema_version": "1.0.0", "name": "old"},
-    ]
-    result = schema._get_schema_for_version(schema_list, DUMMY_FILE, "latest")
-    assert result["schema_version"] == "2.0.0"
-
-
-def test_get_schema_for_version_with_list_and_specific_version():
-    schema_list = [
-        {"schema_version": "2.0.0", "name": "latest"},
-        {"schema_version": "1.0.0", "name": "old"},
-    ]
-    result = schema._get_schema_for_version(schema_list, DUMMY_FILE, "1.0.0")
-    assert result["schema_version"] == "1.0.0"
-
-
-def test_get_schema_for_version_with_list_and_missing_version():
-    schema_list = [
-        {"schema_version": "2.0.0", "name": "latest"},
-        {"schema_version": "1.0.0", "name": "old"},
-    ]
-    with pytest.raises(ValueError, match=r"Schema version 3\.0\.0 not found in dummy_file\.yml\."):
-        schema._get_schema_for_version(schema_list, DUMMY_FILE, "3.0.0")
-
-
-def test_get_schema_for_version_with_none_version():
-    test_schema = {"schema_version": "1.0.0", "name": "test"}
-    with pytest.raises(ValueError, match=r"Schema version not given in dummy_file\.yml\."):
-        schema._get_schema_for_version(test_schema, DUMMY_FILE, None)
-
-
-def test_get_schema_for_version_with_empty_list():
-    schema_list = []
-    with pytest.raises(ValueError, match=r"No schemas found in dummy_file.yml."):
-        schema._get_schema_for_version(schema_list, DUMMY_FILE, "latest")
-
-
-def test_get_schema_for_version_warns_on_version_mismatch(caplog):
-    test_schema = {"schema_version": "1.0.0", "name": "test"}
-    with caplog.at_level("WARNING"):
-        result = schema._get_schema_for_version(test_schema, DUMMY_FILE, "2.0.0")
-    assert result == test_schema
-    assert "Schema version 2.0.0 does not match 1.0.0" in caplog.text
 
 
 def test_validate_deprecation_and_version(caplog, monkeypatch):

--- a/tests/unit_tests/data_model/test_schema_loader.py
+++ b/tests/unit_tests/data_model/test_schema_loader.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python3
-
 import logging
 from pathlib import Path
 
@@ -16,9 +14,9 @@ DUMMY_FILE = "dummy_file.yml"
 @pytest.fixture(autouse=True)
 def clear_schema_loader_cache():
     """Clear shared schema state around every test."""
-    schema_loader.load_schema.cache_clear()
+    schema_loader.clear_cache()
     yield
-    schema_loader.load_schema.cache_clear()
+    schema_loader.clear_cache()
 
 
 def test_get_model_parameter_schema_files(tmp_test_directory):
@@ -49,16 +47,18 @@ def test_get_model_parameter_schema_files_raises_for_missing_schemas(
         schema_loader.get_model_parameter_schema_files(directory)
 
 
-def test_load_schema_caches_by_source_and_version(mocker):
+def test_load_schema_caches_parsed_source_across_versions(mocker):
     collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
 
     schema_1 = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
     schema_2 = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2.0")
+    schema_1["schema_version"] = "changed"
     schema_1_cached = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
 
-    assert schema_1 is schema_1_cached
+    assert schema_1_cached["schema_version"] == "0.1.0"
+    assert schema_1 is not schema_1_cached
     assert schema_1 is not schema_2
-    assert collect_data.call_count == 2
+    assert collect_data.call_count == 1
 
 
 def test_load_schema_prefers_local_before_remote(monkeypatch, tmp_test_directory):
@@ -76,7 +76,7 @@ def test_load_schema_prefers_local_before_remote(monkeypatch, tmp_test_directory
 
     monkeypatch.setattr(ascii_handler, "collect_data_from_file", _collect_data)
 
-    assert schema_loader.load_schema(remote_url, "1.0.0") is expected_schema
+    assert schema_loader.load_schema(remote_url, "1.0.0") == expected_schema
     assert str(local_schema) in calls
     assert remote_url not in calls
 
@@ -93,7 +93,7 @@ def test_load_schema_falls_back_to_remote(monkeypatch, tmp_test_directory):
 
     monkeypatch.setattr(ascii_handler, "collect_data_from_file", _collect_data)
 
-    assert schema_loader.load_schema(remote_url, "1.0.0") is expected_schema
+    assert schema_loader.load_schema(remote_url, "1.0.0") == expected_schema
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/data_model/test_schema_loader.py
+++ b/tests/unit_tests/data_model/test_schema_loader.py
@@ -121,7 +121,7 @@ def test_load_schema_reports_missing_source(schema_file, error, monkeypatch, tmp
 def test_get_schema_for_version_with_dict():
     schema = {"schema_version": "1.0.0", "name": "test"}
 
-    assert schema_loader.get_schema_for_version(schema, DUMMY_FILE, "1.0.0") is schema
+    assert schema_loader.get_schema_for_version(schema, DUMMY_FILE, "1.0.0") == schema
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/data_model/test_schema_loader.py
+++ b/tests/unit_tests/data_model/test_schema_loader.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python3
+
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+from simtools.constants import MODEL_PARAMETER_METASCHEMA
+from simtools.data_model import schema_loader
+from simtools.io import ascii_handler
+
+DUMMY_FILE = "dummy_file.yml"
+
+
+@pytest.fixture(autouse=True)
+def clear_schema_loader_cache():
+    """Clear shared schema state around every test."""
+    schema_loader.load_schema.cache_clear()
+    yield
+    schema_loader.load_schema.cache_clear()
+
+
+def test_get_model_parameter_schema_files(tmp_test_directory):
+    tmp_test_directory = Path(tmp_test_directory)
+    schema_files = [
+        tmp_test_directory / "second.schema.yml",
+        tmp_test_directory / "first.schema.yml",
+    ]
+    for schema_file in schema_files:
+        schema_file.write_text(
+            yaml.safe_dump({"name": schema_file.stem, "schema_version": "1.0.0"}),
+            encoding="utf-8",
+        )
+
+    parameters, files = schema_loader.get_model_parameter_schema_files(tmp_test_directory)
+
+    assert parameters == ["first.schema", "second.schema"]
+    assert files == sorted(schema_files)
+
+
+@pytest.mark.parametrize("schema_directory", ["missing", None])
+def test_get_model_parameter_schema_files_raises_for_missing_schemas(
+    schema_directory, tmp_test_directory
+):
+    directory = tmp_test_directory / schema_directory if schema_directory else tmp_test_directory
+
+    with pytest.raises(FileNotFoundError, match=r"^No schema files found"):
+        schema_loader.get_model_parameter_schema_files(directory)
+
+
+def test_load_schema_caches_by_source_and_version(mocker):
+    collect_data = mocker.spy(ascii_handler, "collect_data_from_file")
+
+    schema_1 = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
+    schema_2 = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2.0")
+    schema_1_cached = schema_loader.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
+
+    assert schema_1 is schema_1_cached
+    assert schema_1 is not schema_2
+    assert collect_data.call_count == 2
+
+
+def test_load_schema_prefers_local_before_remote(monkeypatch, tmp_test_directory):
+    monkeypatch.setattr(schema_loader, "SCHEMA_PATH", tmp_test_directory)
+    remote_url = "https://example.com/schemas/example.schema.yml"
+    local_schema = tmp_test_directory / "example.schema.yml"
+    expected_schema = {"schema_version": "1.0.0"}
+    calls = []
+
+    def _collect_data(file_name):
+        calls.append(str(file_name))
+        if Path(str(file_name)) == local_schema:
+            return expected_schema
+        raise FileNotFoundError(file_name)
+
+    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _collect_data)
+
+    assert schema_loader.load_schema(remote_url, "1.0.0") is expected_schema
+    assert str(local_schema) in calls
+    assert remote_url not in calls
+
+
+def test_load_schema_falls_back_to_remote(monkeypatch, tmp_test_directory):
+    monkeypatch.setattr(schema_loader, "SCHEMA_PATH", tmp_test_directory)
+    remote_url = "https://example.com/schemas/example.schema.yml"
+    expected_schema = {"schema_version": "1.0.0"}
+
+    def _collect_data(file_name):
+        if str(file_name) == remote_url:
+            return expected_schema
+        raise FileNotFoundError(file_name)
+
+    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _collect_data)
+
+    assert schema_loader.load_schema(remote_url, "1.0.0") is expected_schema
+
+
+@pytest.mark.parametrize(
+    ("schema_file", "error"),
+    [
+        ("missing.schema.yml", "Schema file not found: missing.schema.yml"),
+        (
+            "https://example.com/schemas/missing.schema.yml",
+            "Schema file not found: https://example.com/schemas/missing.schema.yml",
+        ),
+    ],
+)
+def test_load_schema_reports_missing_source(schema_file, error, monkeypatch, tmp_test_directory):
+    monkeypatch.setattr(schema_loader, "SCHEMA_PATH", tmp_test_directory)
+
+    def _raise_file_not_found(file_name):
+        raise FileNotFoundError(file_name)
+
+    monkeypatch.setattr(ascii_handler, "collect_data_from_file", _raise_file_not_found)
+
+    with pytest.raises(FileNotFoundError, match=error):
+        schema_loader.load_schema(schema_file)
+
+
+def test_get_schema_for_version_with_dict():
+    schema = {"schema_version": "1.0.0", "name": "test"}
+
+    assert schema_loader.get_schema_for_version(schema, DUMMY_FILE, "1.0.0") is schema
+
+
+@pytest.mark.parametrize(
+    ("schema_version", "expected_version"),
+    [("latest", "2.0.0"), ("1.0.0", "1.0.0")],
+)
+def test_get_schema_for_version_with_list(schema_version, expected_version):
+    schemas = [
+        {"schema_version": "2.0.0", "name": "latest"},
+        {"schema_version": "1.0.0", "name": "old"},
+    ]
+
+    result = schema_loader.get_schema_for_version(schemas, DUMMY_FILE, schema_version)
+
+    assert result["schema_version"] == expected_version
+
+
+@pytest.mark.parametrize(
+    ("schemas", "schema_version", "error"),
+    [
+        ([], "latest", "No schemas found"),
+        ([{"schema_version": "1.0.0"}], "2.0.0", "Schema version 2.0.0 not found"),
+        ({"schema_version": "1.0.0"}, None, "Schema version not given"),
+    ],
+)
+def test_get_schema_for_version_raises(schemas, schema_version, error):
+    with pytest.raises(ValueError, match=error):
+        schema_loader.get_schema_for_version(schemas, DUMMY_FILE, schema_version)
+
+
+def test_get_schema_for_version_warns_on_mismatch(caplog):
+    schema = {"schema_version": "1.0.0", "name": "test"}
+
+    with caplog.at_level(logging.WARNING):
+        result = schema_loader.get_schema_for_version(schema, DUMMY_FILE, "2.0.0")
+
+    assert result is schema
+    assert "Schema version 2.0.0 does not match 1.0.0" in caplog.text


### PR DESCRIPTION
Improve efficiency of schema file reading by avoiding reading the same file multiple (4-5 times typically when running simulate_prod) times and cache the contents.

Closes #2355