### PR TITLE
Improve command line configuration for production-generate grid

### DIFF
--- a/src/simtools/application_control.py
+++ b/src/simtools/application_control.py
@@ -383,9 +383,6 @@ def build_application_parser(
         db_config=initialization_kwargs.get("db_config", False),
         common_arguments=initialization_kwargs.get("common_arguments"),
         argument_overrides=initialization_kwargs.get("argument_overrides"),
-        include_implicit_simulation_model_arguments=initialization_kwargs.get(
-            "include_implicit_simulation_model_arguments", True
-        ),
     )
     return config_builder.parser
 

--- a/src/simtools/application_control.py
+++ b/src/simtools/application_control.py
@@ -381,6 +381,11 @@ def build_application_parser(
         simulation_model=initialization_kwargs.get("simulation_model"),
         simulation_configuration=initialization_kwargs.get("simulation_configuration"),
         db_config=initialization_kwargs.get("db_config", False),
+        common_arguments=initialization_kwargs.get("common_arguments"),
+        argument_overrides=initialization_kwargs.get("argument_overrides"),
+        include_implicit_simulation_model_arguments=initialization_kwargs.get(
+            "include_implicit_simulation_model_arguments", True
+        ),
     )
     return config_builder.parser
 

--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -15,82 +15,72 @@ _APPLICATION_ARG_DEFINITIONS = {
         "action": "append",
         "nargs": "+",
         "help": (
-            "Compact axis definition: --axis <name> <min> <unit> <max> <unit> <binning> "
-            "[scaling]. May be repeated. Supported axes: azimuth, zenith, ha, dec, offset. "
-            "Options for scaling are: linear, log, 1/cos"
+            "Grid axis as NAME MIN UNIT MAX UNIT POINTS [SCALING]. Repeat for each axis. "
+            "Use azimuth/zenith or ha/dec, plus offset. SCALING is linear, log, or 1/cos."
         ),
+        "metavar": "AXIS",
     },
     "direction_grid_density": {
         "nargs": "+",
         "default": None,
-        "help": (
-            "Direction-grid density in 1/deg^2. If set, direction-axis binning is "
-            "derived from axis ranges and this density. With HA/Dec axes, use "
-            "local_zenith_range/local_azimuth_range to filter generated points."
-        ),
+        "help": "Direction-point density in deg^-2. Overrides POINTS for both direction axes.",
+        "metavar": "DENSITY",
     },
     "local_zenith_range": {
         "nargs": "+",
         "default": None,
-        "help": (
-            "Local zenith range (quantity pair) used to filter HA/Dec density points, "
-            "for example: --local_zenith_range 0 deg 70 deg"
-        ),
+        "help": "Accepted local zenith range for an HA/Dec density grid, e.g. 0 deg 70 deg.",
+        "metavar": "RANGE",
     },
     "local_azimuth_range": {
         "nargs": "+",
         "default": None,
         "help": (
-            "Local azimuth range (quantity pair) used to filter HA/Dec density points, "
-            "for example: --local_azimuth_range 300 deg 60 deg"
+            "Accepted local azimuth range for an HA/Dec density grid. Ranges may wrap through "
+            "0 deg."
         ),
-    },
-    "output_file": {
-        "type": str,
-        "default": "job_grid.ecsv",
-        "help": "Output file for the generated executable job grid.",
+        "metavar": "RANGE",
     },
     "corsika_limits": {
         "type": str,
-        "help": "Path to the lookup table for simulation limits.",
+        "metavar": "FILE",
+        "help": "ECSV lookup table of direction-dependent CORSIKA simulation limits.",
     },
     "number_of_runs": {
-        "help": "Number of runs to be simulated for each production grid point and energy range.",
+        "help": "Runs generated per grid point and energy interval.",
         "type": scientific_int,
         "default": None,
     },
     "total_showers": {
-        "help": "Total number of showers to simulate per production grid point and energy range.",
+        "help": (
+            "Target showers per grid point and energy interval; incompatible with --number_of_runs."
+        ),
         "type": scientific_int,
         "default": None,
     },
     "total_showers_scaling": {
-        "help": "Scaling mode for total showers.",
+        "help": (
+            "Total-shower zenith scaling. zenith_scaled applies "
+            "N * exp(factor * (cos(zenith) - 1))."
+        ),
         "type": str,
         "choices": ["fixed", "zenith_scaled"],
         "default": "fixed",
     },
     "zenith_angle_scaling_factor": {
-        "help": (
-            "Scaling factor for zenith-dependent total_showers scaling. "
-            "Used only when --total_showers_scaling is 'zenith_scaled'."
-        ),
+        "help": "Factor in the zenith_scaled total-showers expression.",
         "type": float,
         "default": defaults.ZENITH_ANGLE_SCALING_FACTOR_DEFAULT,
     },
     "max_total_showers_rounding_warnings": {
-        "help": (
-            "Maximum number of per-point warnings emitted when total_showers is "
-            "rounded up to keep equal showers per run."
-        ),
+        "help": "Maximum warnings emitted when total_showers is rounded up to complete runs.",
         "type": scientific_int,
         "default": TOTAL_SHOWERS_ROUNDING_WARNINGS_MAX_DEFAULT,
     },
     "showers_per_run_power_law": {
         "help": (
-            "Scale showers_per_run by (E_mid / E_ref) ** power_index using the bin midpoint: "
-            "<power_index> <reference_energy_value> <reference_energy_unit> "
-            "(for example: --showers_per_run_power_law -2.0 1 TeV)."
+            "Scale showers per run by (E_mid / E_ref)^INDEX. Provide INDEX VALUE UNIT; "
+            "E_mid is the logarithmic energy-interval midpoint."
         ),
         "nargs": 3,
         "type": str,
@@ -98,22 +88,15 @@ _APPLICATION_ARG_DEFINITIONS = {
         "default": None,
     },
     "showers_per_run_scaling": {
-        "help": (
-            "Zenith-angle scaling mode for showers_per_run: "
-            "'fixed' keeps the baseline value, "
-            "'cosine_zenith' applies showers_per_run * cos(zenith_angle)."
-        ),
+        "help": "Showers-per-run zenith scaling. cosine_zenith applies ceil(N * cos(zenith)).",
         "type": str,
         "choices": ["fixed", "cosine_zenith"],
         "default": "fixed",
     },
     "energy_max_scaling": {
         "help": (
-            "Scale max energy with zenith angle as "
-            "energy_max_scaling_reference * cos(zenith_angle) ** power_index. "
-            "Provide: <power_index> <reference_energy_value> <reference_energy_unit> "
-            "(for example: --energy_max_scaling -2.5 300 TeV). "
-            "Max energy is limited by the configured energy_range."
+            "Set the zenith-dependent maximum energy to VALUE * cos(zenith)^INDEX. "
+            "Provide INDEX VALUE UNIT; the configured energy-range maximum remains an upper bound."
         ),
         "nargs": 3,
         "type": str,
@@ -122,17 +105,74 @@ _APPLICATION_ARG_DEFINITIONS = {
     },
 }
 
+_INITIALIZATION_KWARGS = {
+    "argument_overrides": {
+        "model_version": {"required": True},
+        "output_file": {
+            "default": "job_grid.ecsv",
+            "help": "Output ECSV production job grid.",
+            "metavar": "FILE",
+        },
+        "run_number_offset": {
+            "help": "Offset for sequential run numbers; the first run is offset + 1."
+        },
+        "showers_per_run": {"required": True},
+        "site": {"required": True},
+    },
+    "common_arguments": {
+        "configuration": ["config", "env_file"],
+        "execution": [
+            "activity_id",
+            "label",
+            "log_level",
+            "log_file",
+            "log_file_path",
+            "disable_log_file",
+            "export_build_info",
+            "version",
+            "build_info",
+        ],
+    },
+    "db_config": True,
+    "include_implicit_simulation_model_arguments": False,
+    "output": ["output_file"],
+    "paths": ["output_path"],
+    "preserve_by_version_keys": ["array_layout_name"],
+    "simulation_model": ["site", "array_layout_name", "model_version"],
+    "simulation_configuration": {
+        "software": None,
+        "corsika_configuration": [
+            "primary",
+            "azimuth_angle",
+            "zenith_angle",
+            "showers_per_run",
+            "run_number_offset",
+            "energy_range",
+            "view_cone",
+            "core_scatter",
+            "corsika_he_interaction",
+            "corsika_le_interaction",
+        ],
+    },
+}
+
+
+def _add_arguments(parser):
+    """Add application arguments, including mutually exclusive shower-count modes."""
+    shower_count_group = parser.add_mutually_exclusive_group()
+    for parameter, definition in _APPLICATION_ARG_DEFINITIONS.items():
+        container = (
+            shower_count_group if parameter in {"number_of_runs", "total_showers"} else parser
+        )
+        parser.add_parameter_from_definition(container, parameter, definition)
+
 
 def main():
     """See CLI description."""
     app_context = build_application(
-        application_argument_definitions=_APPLICATION_ARG_DEFINITIONS,
-        initialization_kwargs={
-            "db_config": True,
-            "preserve_by_version_keys": ["array_layout_name"],
-            "simulation_model": ["site", "layout", "telescope", "model_version"],
-            "simulation_configuration": {"software": None, "corsika_configuration": ["all"]},
-        },
+        add_arguments_function=_add_arguments,
+        initialization_kwargs=_INITIALIZATION_KWARGS,
+        startup_kwargs={"resolve_sim_software_executables": False},
     )
 
     generate_job_grid(

--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -41,6 +41,11 @@ _APPLICATION_ARG_DEFINITIONS = {
         ),
         "metavar": "RANGE",
     },
+    "output_file": {
+        "type": str,
+        "default": "job_grid.ecsv",
+        "help": "Output ECSV production job grid.",
+    },
     "corsika_limits": {
         "type": str,
         "metavar": "FILE",
@@ -105,73 +110,37 @@ _APPLICATION_ARG_DEFINITIONS = {
     },
 }
 
-_INITIALIZATION_KWARGS = {
-    "argument_overrides": {
-        "model_version": {"required": True},
-        "output_file": {
-            "default": "job_grid.ecsv",
-            "help": "Output ECSV production job grid.",
-            "metavar": "FILE",
-        },
-        "run_number_offset": {
-            "help": "Offset for sequential run numbers; the first run is offset + 1."
-        },
-        "showers_per_run": {"required": True},
-        "site": {"required": True},
-    },
-    "common_arguments": {
-        "configuration": ["config", "env_file"],
-        "execution": [
-            "activity_id",
-            "label",
-            "log_level",
-            "log_file",
-            "log_file_path",
-            "disable_log_file",
-            "export_build_info",
-            "version",
-            "build_info",
-        ],
-    },
-    "db_config": True,
-    "include_implicit_simulation_model_arguments": False,
-    "output": ["output_file"],
-    "paths": ["output_path"],
-    "preserve_by_version_keys": ["array_layout_name"],
-    "simulation_model": ["site", "array_layout_name", "model_version"],
-    "simulation_configuration": {
-        "software": None,
-        "corsika_configuration": [
-            "primary",
-            "azimuth_angle",
-            "zenith_angle",
-            "showers_per_run",
-            "run_number_offset",
-            "energy_range",
-            "view_cone",
-            "core_scatter",
-            "corsika_he_interaction",
-            "corsika_le_interaction",
-        ],
-    },
-}
-
-
-def _add_arguments(parser):
-    """Add application arguments, including mutually exclusive shower-count modes."""
-    shower_count_group = parser.add_mutually_exclusive_group()
-    for parameter, definition in _APPLICATION_ARG_DEFINITIONS.items():
-        container = (
-            shower_count_group if parameter in {"number_of_runs", "total_showers"} else parser
-        )
-        parser.add_parameter_from_definition(container, parameter, definition)
-
 
 def main():
     """See CLI description."""
     app_context = build_application(
-        add_arguments_function=_add_arguments,
-        initialization_kwargs=_INITIALIZATION_KWARGS,
+        application_argument_definitions=_APPLICATION_ARG_DEFINITIONS,
+        initialization_kwargs={
+            "argument_overrides": {
+                "model_version": {"required": True},
+                "showers_per_run": {"required": True},
+                "site": {"required": True},
+            },
+            "db_config": True,
+            "paths": ["output_path"],
+            "simulation_model": ["site", "array_layout_name", "model_version"],
+            "simulation_configuration": {
+                "software": None,
+                "corsika_configuration": [
+                    "primary",
+                    "primary_id_type",
+                    "azimuth_angle",
+                    "zenith_angle",
+                    "showers_per_run",
+                    "run_number_offset",
+                    "energy_range",
+                    "view_cone",
+                    "core_scatter",
+                    "corsika_he_interaction",
+                    "corsika_le_interaction",
+                ],
+            },
+        },
         startup_kwargs={"resolve_sim_software_executables": False},
     )
 

--- a/src/simtools/configuration/commandline_parameters.py
+++ b/src/simtools/configuration/commandline_parameters.py
@@ -311,6 +311,7 @@ PARAMETER_DEFINITIONS = {
             ),
             "nargs": "+",
             "type": str,
+            "preserve_by_version": True,
         },
         "array_element_list": {
             "help": "list of array elements (e.g., LSTN-01, LSTN-02, MSTN).",

--- a/src/simtools/configuration/commandline_parameters.py
+++ b/src/simtools/configuration/commandline_parameters.py
@@ -17,10 +17,8 @@ def get_corsika_configuration_args():
     return {
         "primary": {
             "help": (
-                "Primary particle to simulate. "
-                "(choices for common names: "
-                f"{', '.join(PrimaryParticle.particle_names().keys())}; "
-                "use '--primary_id_type' to use other particle ID types)."
+                "Primary particle(s) to simulate. Common names: "
+                f"{', '.join(PrimaryParticle.particle_names().keys())}."
             ),
             "type": str.lower,
             "action": helpers.OneOrManyAction,
@@ -56,7 +54,7 @@ def get_corsika_configuration_args():
             "type": int,
         },
         "run_number_offset": {
-            "help": "Offset added to run number when executing a simulation.",
+            "help": "Offset added to each run number.",
             "type": int,
             "default": 0,
         },
@@ -91,33 +89,30 @@ PARAMETER_DEFINITIONS = {
             "default": -2.0,
         },
         "energy_range": {
-            "help": ("Energy range of the primary particle (min/max, e.g., '10 GeV 5 TeV')."),
+            "help": "Minimum and maximum primary energy, e.g. '10 GeV 5 TeV'.",
             "action": helpers.QuantityPairAction,
             "nargs": "+",
             "default": (3 * u.GeV, 330 * u.TeV),
         },
         "view_cone": {
-            "help": (
-                "View cone radius for primary arrival directions "
-                "(min/max value, e.g. '0 deg 10 deg')."
-            ),
+            "help": "Minimum and maximum view-cone radius, e.g. '0 deg 10 deg'.",
             "type": helpers.parse_quantity_pair,
             "default": ["0 deg 0 deg"],
         },
         "core_scatter": {
-            "help": "Scatter radius for shower cores (number of use; scatter radius).",
+            "help": "Core positions per shower and maximum scatter radius, e.g. '10 500 m'.",
             "type": helpers.parse_integer_and_quantity,
             "default": ["10 10000 m"],
         },
     },
     "CONFIGURATION_ARGS": {
         "config": {
-            "help": "simtools configuration file",
+            "help": "YAML application configuration file.",
             "default": None,
             "type": str,
         },
         "env_file": {
-            "help": "file with environment variables",
+            "help": "File containing environment variables.",
             "default": ".env",
             "type": str,
         },
@@ -129,7 +124,7 @@ PARAMETER_DEFINITIONS = {
             "default": "./data/",
         },
         "output_path": {
-            "help": "path pointing towards output directory",
+            "help": "Directory for output files.",
             "type": Path,
             "default": "./simtools-output/",
         },
@@ -156,7 +151,7 @@ PARAMETER_DEFINITIONS = {
     },
     "OUTPUT_ARGS": {
         "output_file": {
-            "help": "output data file",
+            "help": "Output data file.",
             "type": str,
         },
         "output_file_format": {
@@ -201,7 +196,7 @@ PARAMETER_DEFINITIONS = {
     },
     "EXECUTION_ARGS": {
         "activity_id": {
-            "help": "activity identifier",
+            "help": "Activity identifier.",
             "type": str,
             "default": None,
         },
@@ -210,19 +205,19 @@ PARAMETER_DEFINITIONS = {
             "action": "store_true",
         },
         "label": {
-            "help": "job label",
+            "help": "Application run label.",
         },
         "log_level": {
             "action": "store",
             "default": "info",
-            "help": "log level to print",
+            "help": "Logging level.",
         },
         "log_file": {
-            "help": "log file path",
+            "help": "Log file.",
             "type": Path,
         },
         "log_file_path": {
-            "help": "path pointing towards log directory",
+            "help": "Directory for the generated log file.",
             "type": Path,
         },
         "disable_log_file": {
@@ -236,7 +231,7 @@ PARAMETER_DEFINITIONS = {
             "default": ["png"],
         },
         "export_build_info": {
-            "help": "export build information to file",
+            "help": "Write build information to this file.",
             "type": str,
         },
         "ignore_existing_parameter_version": {
@@ -251,7 +246,7 @@ PARAMETER_DEFINITIONS = {
         "build_info": {
             "action": helpers.BuildInfoAction,
             "build_info": f"%(prog)s {simtools.version.__version__}",
-            "help": "show build information and exit",
+            "help": "Show build information and exit.",
         },
     },
     "USER_ARGS": {
@@ -261,23 +256,23 @@ PARAMETER_DEFINITIONS = {
         "user_orcid": {"help": "user ORCID", "type": str},
     },
     "DB_CONFIG_ARGS": {
-        "db_api_user": {"help": "database user", "type": str},
-        "db_api_pw": {"help": "database password", "type": str},
-        "db_api_port": {"help": "database port", "type": int},
-        "db_server": {"help": "database server address", "type": str},
+        "db_api_user": {"help": "Database username.", "type": str},
+        "db_api_pw": {"help": "Database password.", "type": str},
+        "db_api_port": {"help": "Database server port.", "type": int},
+        "db_server": {"help": "Database server address.", "type": str},
         "db_api_authentication_database": {
-            "help": "database with user info (optional)",
+            "help": "Authentication database name.",
             "type": str,
         },
-        "db_simulation_model": {"help": "name of simulation model database", "type": str.strip},
+        "db_simulation_model": {"help": "Simulation-model database name.", "type": str.strip},
         "db_simulation_model_version": {
-            "help": "version of simulation model database",
+            "help": "Simulation-model database version.",
             "type": str.strip,
         },
     },
     "SIMULATION_MODEL_ARGS": {
         "model_version": {
-            "help": "Simulation production model version",
+            "help": "Simulation production model version(s).",
             "type": str,
             "default": None,
             "nargs": "+",
@@ -370,7 +365,7 @@ PARAMETER_DEFINITIONS = {
     },
     "SIMULATION_SOFTWARE_ARGS": {
         "simulation_software": {
-            "help": "Simulation software steps.",
+            "help": "Simulation software workflow.",
             "type": str,
             "choices": list(defaults.SIMULATION_SOFTWARE_CHOICES),
             "default": defaults.SIMULATION_SOFTWARE_DEFAULT,

--- a/src/simtools/configuration/commandline_parameters.py
+++ b/src/simtools/configuration/commandline_parameters.py
@@ -311,7 +311,6 @@ PARAMETER_DEFINITIONS = {
             ),
             "nargs": "+",
             "type": str,
-            "preserve_by_version": True,
         },
         "array_element_list": {
             "help": "list of array elements (e.g., LSTN-01, LSTN-02, MSTN).",

--- a/src/simtools/configuration/commandline_parameters.py
+++ b/src/simtools/configuration/commandline_parameters.py
@@ -107,7 +107,7 @@ PARAMETER_DEFINITIONS = {
     },
     "CONFIGURATION_ARGS": {
         "config": {
-            "help": "YAML application configuration file.",
+            "help": "Application configuration file.",
             "default": None,
             "type": str,
         },

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -56,7 +56,6 @@ class CommandLineParser(argparse.ArgumentParser):
         """Initialize the command-line parser."""
         super().__init__(*args, **kwargs)
         self.argument_overrides = {}
-        self.preserve_by_version_keys = set()
 
     def initialize_default_arguments(
         self,
@@ -188,8 +187,6 @@ class CommandLineParser(argparse.ArgumentParser):
     def add_parameter_from_definition(self, container, name, definition):
         """Add one argument from a parameter-definition dictionary."""
         merged_definition = {**definition, **getattr(self, "argument_overrides", {}).get(name, {})}
-        if merged_definition.pop("preserve_by_version", False):
-            self.preserve_by_version_keys.add(name)
         return container.add_argument(f"--{name}", **merged_definition)
 
     def initialize_named_argument_group(self, group_name, selected_parameters=None):

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -52,6 +52,11 @@ class CommandLineParser(argparse.ArgumentParser):
         refer to argparse.ArgumentParser documentation.
     """
 
+    def __init__(self, *args, **kwargs):
+        """Initialize the command-line parser."""
+        super().__init__(*args, **kwargs)
+        self.argument_overrides = {}
+
     def initialize_default_arguments(
         self,
         paths=True,
@@ -59,16 +64,19 @@ class CommandLineParser(argparse.ArgumentParser):
         simulation_model=None,
         simulation_configuration=None,
         db_config=False,
+        common_arguments=None,
+        argument_overrides=None,
+        include_implicit_simulation_model_arguments=True,
     ):
         """
         Initialize default arguments used by all applications (e.g., log level or test flag).
 
         Parameters
         ----------
-        paths: bool
-            Add path configuration to list of args.
-        output: bool
-            Add output file configuration to list of args.
+        paths: bool or list
+            Add all path arguments, no path arguments, or the selected path arguments.
+        output: bool or list
+            Add all output arguments, no output arguments, or the selected output arguments.
         simulation_model: list
             List of simulation model configuration parameters to add to list of args
             (use: 'model_version', 'telescope', 'site')
@@ -76,31 +84,56 @@ class CommandLineParser(argparse.ArgumentParser):
             Dict of simulation software configuration parameters to add to list of args.
         db_config: bool
             Add database configuration parameters to list of args.
+        common_arguments: dict, optional
+            Mapping of common argument-group names to selected parameter names. If omitted,
+            all standard common groups and parameters are added.
+        argument_overrides: dict, optional
+            Per-parameter definition values overriding shared command-line definitions.
+        include_implicit_simulation_model_arguments: bool
+            Add the legacy implicit simulation-model arguments.
         """
-        self.initialize_simulation_model_arguments(simulation_model)
+        self.argument_overrides = argument_overrides or {}
+        self.initialize_simulation_model_arguments(
+            simulation_model,
+            include_implicit_arguments=include_implicit_simulation_model_arguments,
+        )
         self.initialize_simulation_configuration_arguments(simulation_configuration)
 
         if db_config:
             self.initialize_named_argument_group("database configuration")
-        if paths:
-            self.initialize_named_argument_group("paths")
-        if output:
-            self.initialize_named_argument_group("output")
+        self._initialize_optional_default_group("paths", paths)
+        self._initialize_optional_default_group("output", output)
 
-        for group_name in ("configuration", "execution", "run time", "user"):
-            self.initialize_named_argument_group(group_name)
+        default_common_groups = ("configuration", "execution", "run time", "user")
+        if common_arguments is None:
+            for group_name in default_common_groups:
+                self.initialize_named_argument_group(group_name)
+        else:
+            unknown_groups = set(common_arguments) - set(default_common_groups)
+            if unknown_groups:
+                names = ", ".join(sorted(unknown_groups))
+                raise ValueError(f"Unknown common argument group(s): {names}.")
+            for group_name, selected_parameters in common_arguments.items():
+                self._initialize_optional_default_group(group_name, selected_parameters)
 
-    def initialize_simulation_model_arguments(self, model_options):
+    def _initialize_optional_default_group(self, group_name, selection):
+        """Initialize a default group from a boolean or parameter-name selection."""
+        if not selection:
+            return
+        selected_parameters = ["all"] if selection is True else selection
+        self.initialize_named_argument_group(group_name, selected_parameters)
+
+    def initialize_simulation_model_arguments(self, model_options, include_implicit_arguments=True):
         """
         Initialize default arguments for simulation model definition.
-
-        Note that the model version is always required.
 
         Parameters
         ----------
         model_options: list
-            Options to be set: "telescope", "site", "layout", "layout_file",
-            "updated_parameter_version"
+            Simulation-model parameters or legacy layout selectors to add.
+        include_implicit_arguments: bool
+            Add ``overwrite_model_parameters`` and ``ignore_missing_design_model`` even when
+            they are not requested explicitly. This preserves the legacy parser behavior.
         """
         if model_options is None:
             return
@@ -111,14 +144,18 @@ class CommandLineParser(argparse.ArgumentParser):
 
         self._add_parameters(
             group,
-            self._simulation_model_direct_parameters(requested),
+            self._simulation_model_direct_parameters(requested, include_implicit_arguments),
             definitions,
         )
 
-        if requested & SIMULATION_MODEL_LAYOUT_OPTIONS:
+        layout_options = SIMULATION_MODEL_LAYOUT_OPTIONS | set(
+            SIMULATION_MODEL_LAYOUT_BASE_PARAMETERS
+        )
+        if requested & layout_options:
             self._add_simulation_model_layout_parameters(group, requested, definitions)
 
-        self._add_parameters(group, ["ignore_missing_design_model"], definitions)
+        if include_implicit_arguments or "ignore_missing_design_model" in requested:
+            self._add_parameters(group, ["ignore_missing_design_model"], definitions)
 
     def initialize_simulation_configuration_arguments(self, simulation_configuration):
         """
@@ -157,13 +194,14 @@ class CommandLineParser(argparse.ArgumentParser):
 
     def add_parameter_from_definition(self, container, name, definition):
         """Add one argument from a parameter-definition dictionary."""
-        return container.add_argument(f"--{name}", **definition)
+        merged_definition = {**definition, **getattr(self, "argument_overrides", {}).get(name, {})}
+        return container.add_argument(f"--{name}", **merged_definition)
 
-    def initialize_named_argument_group(self, group_name):
+    def initialize_named_argument_group(self, group_name, selected_parameters=None):
         """Initialize one predefined argument group by its display name."""
         self._initialize_named_parameters_group(
             group_name,
-            ["all"],
+            selected_parameters or ["all"],
             commandline_parameters.PARAMETER_DEFINITIONS[DEFAULT_ARGUMENT_GROUPS[group_name]],
         )
 
@@ -194,10 +232,11 @@ class CommandLineParser(argparse.ArgumentParser):
             if definition is not None:
                 self.add_parameter_from_definition(container, parameter_name, definition)
 
-    def _simulation_model_direct_parameters(self, requested):
+    def _simulation_model_direct_parameters(self, requested, include_implicit_arguments=True):
         """Return the ordered direct simulation-model parameters to add."""
         direct_parameters = [name for name in SIMULATION_MODEL_BASE_PARAMETERS if name in requested]
-        direct_parameters.append("overwrite_model_parameters")
+        if include_implicit_arguments or "overwrite_model_parameters" in requested:
+            direct_parameters.append("overwrite_model_parameters")
         if requested & SIMULATION_MODEL_SITE_DEPENDENCIES or "site" in requested:
             direct_parameters.append("site")
         if "telescope" in requested:
@@ -211,7 +250,11 @@ class CommandLineParser(argparse.ArgumentParser):
         layout_group = group.add_mutually_exclusive_group(
             required="--list_available_layouts" not in self._option_string_actions
         )
-        layout_parameters = list(SIMULATION_MODEL_LAYOUT_BASE_PARAMETERS)
+        layout_parameters = (
+            list(SIMULATION_MODEL_LAYOUT_BASE_PARAMETERS)
+            if "layout" in requested
+            else [name for name in SIMULATION_MODEL_LAYOUT_BASE_PARAMETERS if name in requested]
+        )
         for option_name, parameter_names in SIMULATION_MODEL_LAYOUT_OPTIONAL_PARAMETERS.items():
             if option_name in requested:
                 layout_parameters.extend(parameter_names)

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -124,8 +124,7 @@ class CommandLineParser(argparse.ArgumentParser):
         Parameters
         ----------
         model_options: list
-            Simulation-model parameters or legacy layout selectors to add. Model-aware
-            parsers always include ``overwrite_model_parameters``.
+            Simulation-model parameters or legacy layout selectors to add.
         """
         if model_options is None:
             return

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -56,6 +56,7 @@ class CommandLineParser(argparse.ArgumentParser):
         """Initialize the command-line parser."""
         super().__init__(*args, **kwargs)
         self.argument_overrides = {}
+        self.preserve_by_version_keys = set()
 
     def initialize_default_arguments(
         self,
@@ -66,7 +67,6 @@ class CommandLineParser(argparse.ArgumentParser):
         db_config=False,
         common_arguments=None,
         argument_overrides=None,
-        include_implicit_simulation_model_arguments=True,
     ):
         """
         Initialize default arguments used by all applications (e.g., log level or test flag).
@@ -89,14 +89,9 @@ class CommandLineParser(argparse.ArgumentParser):
             all standard common groups and parameters are added.
         argument_overrides: dict, optional
             Per-parameter definition values overriding shared command-line definitions.
-        include_implicit_simulation_model_arguments: bool
-            Add the legacy implicit simulation-model arguments.
         """
         self.argument_overrides = argument_overrides or {}
-        self.initialize_simulation_model_arguments(
-            simulation_model,
-            include_implicit_arguments=include_implicit_simulation_model_arguments,
-        )
+        self.initialize_simulation_model_arguments(simulation_model)
         self.initialize_simulation_configuration_arguments(simulation_configuration)
 
         if db_config:
@@ -123,17 +118,15 @@ class CommandLineParser(argparse.ArgumentParser):
         selected_parameters = ["all"] if selection is True else selection
         self.initialize_named_argument_group(group_name, selected_parameters)
 
-    def initialize_simulation_model_arguments(self, model_options, include_implicit_arguments=True):
+    def initialize_simulation_model_arguments(self, model_options):
         """
         Initialize default arguments for simulation model definition.
 
         Parameters
         ----------
         model_options: list
-            Simulation-model parameters or legacy layout selectors to add.
-        include_implicit_arguments: bool
-            Add ``overwrite_model_parameters`` and ``ignore_missing_design_model`` even when
-            they are not requested explicitly. This preserves the legacy parser behavior.
+            Simulation-model parameters or legacy layout selectors to add. Model-aware
+            parsers always include ``overwrite_model_parameters``.
         """
         if model_options is None:
             return
@@ -144,7 +137,7 @@ class CommandLineParser(argparse.ArgumentParser):
 
         self._add_parameters(
             group,
-            self._simulation_model_direct_parameters(requested, include_implicit_arguments),
+            self._simulation_model_direct_parameters(requested),
             definitions,
         )
 
@@ -154,7 +147,7 @@ class CommandLineParser(argparse.ArgumentParser):
         if requested & layout_options:
             self._add_simulation_model_layout_parameters(group, requested, definitions)
 
-        if include_implicit_arguments or "ignore_missing_design_model" in requested:
+        if "ignore_missing_design_model" in requested:
             self._add_parameters(group, ["ignore_missing_design_model"], definitions)
 
     def initialize_simulation_configuration_arguments(self, simulation_configuration):
@@ -195,6 +188,8 @@ class CommandLineParser(argparse.ArgumentParser):
     def add_parameter_from_definition(self, container, name, definition):
         """Add one argument from a parameter-definition dictionary."""
         merged_definition = {**definition, **getattr(self, "argument_overrides", {}).get(name, {})}
+        if merged_definition.pop("preserve_by_version", False):
+            self.preserve_by_version_keys.add(name)
         return container.add_argument(f"--{name}", **merged_definition)
 
     def initialize_named_argument_group(self, group_name, selected_parameters=None):
@@ -232,11 +227,10 @@ class CommandLineParser(argparse.ArgumentParser):
             if definition is not None:
                 self.add_parameter_from_definition(container, parameter_name, definition)
 
-    def _simulation_model_direct_parameters(self, requested, include_implicit_arguments=True):
+    def _simulation_model_direct_parameters(self, requested):
         """Return the ordered direct simulation-model parameters to add."""
         direct_parameters = [name for name in SIMULATION_MODEL_BASE_PARAMETERS if name in requested]
-        if include_implicit_arguments or "overwrite_model_parameters" in requested:
-            direct_parameters.append("overwrite_model_parameters")
+        direct_parameters.append("overwrite_model_parameters")
         if requested & SIMULATION_MODEL_SITE_DEPENDENCIES or "site" in requested:
             direct_parameters.append("site")
         if "telescope" in requested:

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -13,6 +13,8 @@ from simtools.db.mongo_db import jsonschema_db_dict
 from simtools.io import ascii_handler, io_handler
 from simtools.utils import general as gen
 
+PER_VERSION_CONFIGURATION_KEYS = {"array_layout_name"}
+
 
 class Configurator:
     """
@@ -167,12 +169,7 @@ class Configurator:
         }
         self.config.update(env_config)
         self.config.update(gen.change_dict_keys_case(self.config_class_init or {}))
-        self.config.update(
-            self._config_from_file(
-                _config_file,
-                preserve_by_version_keys=self.parser.preserve_by_version_keys,
-            )
-        )
+        self.config.update(self._config_from_file(_config_file))
         self._fill_config(_cli_arglist)
 
         if self.config.get("activity_id", None) is None:
@@ -240,7 +237,7 @@ class Configurator:
         for action in self.parser._actions:  # pylint: disable=protected-access
             action.required = False
 
-    def _config_from_file(self, config_file, preserve_by_version_keys=None):
+    def _config_from_file(self, config_file):
         """
         Read configuration from yaml file and return as dictionary.
 
@@ -248,8 +245,6 @@ class Configurator:
         ----------
         config_file: str
             Name of configuration file.
-        preserve_by_version_keys: list
-            Top-level configuration keys whose ``by_version`` dictionaries should be preserved.
 
         Returns
         -------
@@ -273,19 +268,11 @@ class Configurator:
             if _config_dict:
                 _config_dict = io_handler.resolve_test_resource_paths(_config_dict)
 
-            preserved_by_version = {}
-            for key in preserve_by_version_keys or []:
-                value = _config_dict.get(key)
-                if isinstance(value, dict) and list(value) == ["by_version"]:
-                    preserved_by_version[key] = value
-
-            for key in preserved_by_version:
-                _config_dict.pop(key)
-
             _config_dict = simtools_version.resolve_by_version(
-                _config_dict, _config_dict.get("model_version")
+                _config_dict,
+                _config_dict.get("model_version"),
+                preserve_version_dependent_keys=PER_VERSION_CONFIGURATION_KEYS,
             )
-            _config_dict.update(preserved_by_version)
             return gen.change_dict_keys_case(_config_dict)
         except (TypeError, AttributeError):
             self._logger.debug("No YAML configuration update applied to configuration dictionary.")

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -13,6 +13,7 @@ from simtools.db.mongo_db import jsonschema_db_dict
 from simtools.io import ascii_handler, io_handler
 from simtools.utils import general as gen
 
+# Allow to specify e.g., {"by_version:" "<7.0.0": beta, ">=7.0.0": CTAO-South-Beta}
 PER_VERSION_CONFIGURATION_KEYS = {"array_layout_name"}
 
 
@@ -23,7 +24,7 @@ class Configurator:
     Allow to set configuration parameters by
 
     - command line arguments
-    - configuration file (yml file)
+    - configuration file
     - configuration dict when calling the class
     - environmental variables
 

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -97,11 +97,9 @@ class Configurator:
         simulation_model=None,
         simulation_configuration=None,
         db_config=False,
-        preserve_by_version_keys=None,
         relax_required_options=None,
         common_arguments=None,
         argument_overrides=None,
-        include_implicit_simulation_model_arguments=True,
     ):
         """
         Initialize application configuration.
@@ -125,9 +123,6 @@ class Configurator:
             Dict of simulation software configuration parameters to add to list of args.
         db_config: bool
             Add database configuration parameters to list of args.
-        preserve_by_version_keys: list
-            Top-level configuration keys whose ``by_version`` dictionaries should be preserved
-            during initial YAML loading.
         relax_required_options: list
             CLI options that allow required parser arguments to be relaxed before reading
             full configuration. Defaults to ``["--config"]``.
@@ -135,8 +130,6 @@ class Configurator:
             Mapping of common argument-group names to selected parameter names.
         argument_overrides: dict, optional
             Per-parameter definition values overriding shared command-line definitions.
-        include_implicit_simulation_model_arguments: bool
-            Add legacy implicit simulation-model arguments.
 
         Returns
         -------
@@ -154,9 +147,6 @@ class Configurator:
             db_config=db_config,
             common_arguments=common_arguments,
             argument_overrides=argument_overrides,
-            include_implicit_simulation_model_arguments=(
-                include_implicit_simulation_model_arguments
-            ),
         )
 
         cli_arglist_kwargs = {"require_command_line": require_command_line}
@@ -177,15 +167,12 @@ class Configurator:
         }
         self.config.update(env_config)
         self.config.update(gen.change_dict_keys_case(self.config_class_init or {}))
-        if preserve_by_version_keys:
-            self.config.update(
-                self._config_from_file(
-                    _config_file,
-                    preserve_by_version_keys=preserve_by_version_keys,
-                )
+        self.config.update(
+            self._config_from_file(
+                _config_file,
+                preserve_by_version_keys=self.parser.preserve_by_version_keys,
             )
-        else:
-            self.config.update(self._config_from_file(_config_file))
+        )
         self._fill_config(_cli_arglist)
 
         if self.config.get("activity_id", None) is None:

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -99,6 +99,9 @@ class Configurator:
         db_config=False,
         preserve_by_version_keys=None,
         relax_required_options=None,
+        common_arguments=None,
+        argument_overrides=None,
+        include_implicit_simulation_model_arguments=True,
     ):
         """
         Initialize application configuration.
@@ -112,10 +115,10 @@ class Configurator:
         ----------
         require_command_line: bool
             Require at least one command line argument.
-        paths: bool
-            Add path configuration to list of args.
-        output: bool
-            Add output file configuration to list of args.
+        paths: bool or list
+            Add all path arguments, no path arguments, or selected path arguments.
+        output: bool or list
+            Add all output arguments, no output arguments, or selected output arguments.
         simulation_model: list
             List of simulation model configuration parameters to add to list of args
         simulation_configuration: dict
@@ -128,6 +131,12 @@ class Configurator:
         relax_required_options: list
             CLI options that allow required parser arguments to be relaxed before reading
             full configuration. Defaults to ``["--config"]``.
+        common_arguments: dict, optional
+            Mapping of common argument-group names to selected parameter names.
+        argument_overrides: dict, optional
+            Per-parameter definition values overriding shared command-line definitions.
+        include_implicit_simulation_model_arguments: bool
+            Add legacy implicit simulation-model arguments.
 
         Returns
         -------
@@ -143,6 +152,11 @@ class Configurator:
             simulation_model=simulation_model,
             simulation_configuration=simulation_configuration,
             db_config=db_config,
+            common_arguments=common_arguments,
+            argument_overrides=argument_overrides,
+            include_implicit_simulation_model_arguments=(
+                include_implicit_simulation_model_arguments
+            ),
         )
 
         cli_arglist_kwargs = {"require_command_line": require_command_line}

--- a/src/simtools/version.py
+++ b/src/simtools/version.py
@@ -269,7 +269,31 @@ def check_version_constraint(version_string, constraint):
     return False
 
 
-def resolve_by_version(config, model_version):
+def _resolve_single_version(by_version, parsed_version):
+    """Resolve one ``by_version`` mapping for one model version."""
+    for constraint, result in by_version.items():
+        if check_version_constraint(str(parsed_version), constraint):
+            return result
+    return None
+
+
+def _resolve_by_version_field(by_version, parsed_versions, key, versions, preserved_keys):
+    """Resolve one ``by_version`` field for the requested model versions."""
+    matched_values = [
+        _resolve_single_version(by_version, parsed_version) for parsed_version in parsed_versions
+    ]
+    first_match = matched_values[0]
+    if all(match == first_match for match in matched_values):
+        return first_match
+    if key in preserved_keys:
+        return {"by_version": by_version}
+    raise ValueError(
+        f"Inconsistent by_version resolution for key '{key}' and model versions "
+        f"{versions}: {matched_values}"
+    )
+
+
+def resolve_by_version(config, model_version, preserve_version_dependent_keys=None):
     """
     Resolve version-dependent values in a configuration dictionary.
 
@@ -283,6 +307,8 @@ def resolve_by_version(config, model_version):
     model_version : str or list
         Semantic version string or list of strings used to evaluate constraints
         (e.g. "6.0.2" or ["6.0.2", "6.1.1"]).
+    preserve_version_dependent_keys : set, optional
+        Keys whose ``by_version`` mappings are retained when they resolve to different values.
 
     Returns
     -------
@@ -295,28 +321,14 @@ def resolve_by_version(config, model_version):
 
     versions = model_version if isinstance(model_version, list) else [model_version]
     parsed_versions = [Version(str(version_item)) for version_item in versions]
-
-    def resolve_by_version_field(by_version_dict, parsed_versions, key):
-        """Resolve a single by_version field for all versions, enforcing consistency."""
-        matched_values = [resolve_single_version(by_version_dict, pv) for pv in parsed_versions]
-        first_match = matched_values[0]
-        if not all(match == first_match for match in matched_values):
-            raise ValueError(
-                f"Inconsistent by_version resolution for key '{key}' and model versions "
-                f"{versions}: {matched_values}"
-            )
-        return first_match
-
-    def resolve_single_version(by_version_dict, parsed_version):
-        for constraint, result in by_version_dict.items():
-            if check_version_constraint(str(parsed_version), constraint):
-                return result
-        return None
+    preserved_keys = set(preserve_version_dependent_keys or [])
 
     resolved = {}
     for key, value in config.items():
         if isinstance(value, dict) and list(value) == ["by_version"]:
-            resolved[key] = resolve_by_version_field(value["by_version"], parsed_versions, key)
+            resolved[key] = _resolve_by_version_field(
+                value["by_version"], parsed_versions, key, versions, preserved_keys
+            )
         else:
             resolved[key] = value
     return resolved

--- a/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
+++ b/tests/integration_tests/config/production_generate_grid_horizontal_explicit.yml
@@ -34,7 +34,6 @@ applications:
     primary:
     - gamma
     - proton
-    run_number: 10
     simulation_software: corsika_sim_telarray
     site: North
     view_cone: 0 deg 10 deg

--- a/tests/unit_tests/applications/test_production_generate_grid.py
+++ b/tests/unit_tests/applications/test_production_generate_grid.py
@@ -12,7 +12,16 @@ def _parser():
     return build_application_parser(
         application_path=app.__file__,
         description=app.__doc__,
-        application_argument_definitions=app._APPLICATION_ARG_DEFINITIONS,
+        add_arguments_function=app._add_arguments,
+    )
+
+
+def _full_parser():
+    return build_application_parser(
+        application_path=app.__file__,
+        description=app.__doc__,
+        add_arguments_function=app._add_arguments,
+        initialization_kwargs=app._INITIALIZATION_KWARGS,
     )
 
 
@@ -29,6 +38,74 @@ def test_main_generates_job_grid(mock_build_application, mock_generate_job_grid)
     app.main()
 
     mock_generate_job_grid.assert_called_once_with(args, Path("job_grid.ecsv"))
+    mock_build_application.assert_called_once_with(
+        add_arguments_function=app._add_arguments,
+        initialization_kwargs=app._INITIALIZATION_KWARGS,
+        startup_kwargs={"resolve_sim_software_executables": False},
+    )
+
+
+def test_full_parser_contains_only_relevant_shared_arguments():
+    parser = _full_parser()
+    actions = {action.dest: action for action in parser._actions}
+
+    expected = {
+        "array_layout_name",
+        "azimuth_angle",
+        "core_scatter",
+        "energy_range",
+        "model_version",
+        "output_file",
+        "output_path",
+        "primary",
+        "run_number_offset",
+        "showers_per_run",
+        "site",
+        "view_cone",
+        "zenith_angle",
+    }
+    assert expected <= set(actions)
+    assert actions["output_file"].default == "job_grid.ecsv"
+    assert actions["output_file"].help == "Output ECSV production job grid."
+
+    irrelevant = {
+        "array_element_list",
+        "correct_for_b_field_alignment",
+        "curved_atmosphere_min_zenith_angle",
+        "data_path",
+        "eslope",
+        "event_number_first_shower",
+        "figure_format",
+        "model_path",
+        "overwrite_model_parameters",
+        "primary_id_type",
+        "run_number",
+        "telescope",
+        "user_name",
+    }
+    assert irrelevant.isdisjoint(actions)
+
+
+def test_full_parser_accepts_minimum_direct_configuration():
+    args = _full_parser().parse_args(
+        [
+            "--model_version",
+            "7.0.0",
+            "--site",
+            "North",
+            "--array_layout_name",
+            "LSTN-01",
+            "--primary",
+            "gamma",
+            "--showers_per_run",
+            "1000",
+        ]
+    )
+
+    assert args.model_version == ["7.0.0"]
+    assert args.site == "North"
+    assert args.array_layout_name == ["LSTN-01"]
+    assert args.output_file == "job_grid.ecsv"
 
 
 def test_add_arguments_accepts_compact_axis_definitions():
@@ -66,6 +143,11 @@ def test_add_arguments_accepts_zenith_angle_scaling_factor():
     args = parser.parse_args(["--zenith_angle_scaling_factor", "2.5"])
 
     assert args.zenith_angle_scaling_factor == pytest.approx(2.5)
+
+
+def test_add_arguments_rejects_both_shower_count_modes():
+    with pytest.raises(SystemExit):
+        _parser().parse_args(["--number_of_runs", "2", "--total_showers", "1000"])
 
 
 def test_add_arguments_accepts_max_total_showers_rounding_warnings():

--- a/tests/unit_tests/applications/test_production_generate_grid.py
+++ b/tests/unit_tests/applications/test_production_generate_grid.py
@@ -7,12 +7,39 @@ import pytest
 import simtools.applications.production_generate_grid as app
 from simtools.application_control import build_application_parser
 
+INITIALIZATION_KWARGS = {
+    "argument_overrides": {
+        "model_version": {"required": True},
+        "showers_per_run": {"required": True},
+        "site": {"required": True},
+    },
+    "db_config": True,
+    "paths": ["output_path"],
+    "simulation_model": ["site", "array_layout_name", "model_version"],
+    "simulation_configuration": {
+        "software": None,
+        "corsika_configuration": [
+            "primary",
+            "primary_id_type",
+            "azimuth_angle",
+            "zenith_angle",
+            "showers_per_run",
+            "run_number_offset",
+            "energy_range",
+            "view_cone",
+            "core_scatter",
+            "corsika_he_interaction",
+            "corsika_le_interaction",
+        ],
+    },
+}
+
 
 def _parser():
     return build_application_parser(
         application_path=app.__file__,
         description=app.__doc__,
-        add_arguments_function=app._add_arguments,
+        application_argument_definitions=app._APPLICATION_ARG_DEFINITIONS,
     )
 
 
@@ -20,8 +47,8 @@ def _full_parser():
     return build_application_parser(
         application_path=app.__file__,
         description=app.__doc__,
-        add_arguments_function=app._add_arguments,
-        initialization_kwargs=app._INITIALIZATION_KWARGS,
+        application_argument_definitions=app._APPLICATION_ARG_DEFINITIONS,
+        initialization_kwargs=INITIALIZATION_KWARGS,
     )
 
 
@@ -39,8 +66,8 @@ def test_main_generates_job_grid(mock_build_application, mock_generate_job_grid)
 
     mock_generate_job_grid.assert_called_once_with(args, Path("job_grid.ecsv"))
     mock_build_application.assert_called_once_with(
-        add_arguments_function=app._add_arguments,
-        initialization_kwargs=app._INITIALIZATION_KWARGS,
+        application_argument_definitions=app._APPLICATION_ARG_DEFINITIONS,
+        initialization_kwargs=INITIALIZATION_KWARGS,
         startup_kwargs={"resolve_sim_software_executables": False},
     )
 
@@ -57,7 +84,9 @@ def test_full_parser_contains_only_relevant_shared_arguments():
         "model_version",
         "output_file",
         "output_path",
+        "overwrite_model_parameters",
         "primary",
+        "primary_id_type",
         "run_number_offset",
         "showers_per_run",
         "site",
@@ -75,13 +104,9 @@ def test_full_parser_contains_only_relevant_shared_arguments():
         "data_path",
         "eslope",
         "event_number_first_shower",
-        "figure_format",
         "model_path",
-        "overwrite_model_parameters",
-        "primary_id_type",
         "run_number",
         "telescope",
-        "user_name",
     }
     assert irrelevant.isdisjoint(actions)
 
@@ -143,11 +168,6 @@ def test_add_arguments_accepts_zenith_angle_scaling_factor():
     args = parser.parse_args(["--zenith_angle_scaling_factor", "2.5"])
 
     assert args.zenith_angle_scaling_factor == pytest.approx(2.5)
-
-
-def test_add_arguments_rejects_both_shower_count_modes():
-    with pytest.raises(SystemExit):
-        _parser().parse_args(["--number_of_runs", "2", "--total_showers", "1000"])
 
 
 def test_add_arguments_accepts_max_total_showers_rounding_warnings():

--- a/tests/unit_tests/configuration/test_commandline_parameters.py
+++ b/tests/unit_tests/configuration/test_commandline_parameters.py
@@ -34,7 +34,7 @@ def test_get_dictionary_with_corsika_configuration(mocker):
     corsika_config = get_corsika_configuration_args()
 
     assert "primary" in corsika_config
-    assert corsika_config["primary"]["help"].startswith("Primary particle to simulate.")
+    assert corsika_config["primary"]["help"].startswith("Primary particle(s) to simulate.")
     assert "proton" in corsika_config["primary"]["help"]
     assert "helium" in corsika_config["primary"]["help"]
     assert "iron" in corsika_config["primary"]["help"]
@@ -72,7 +72,7 @@ def test_get_dictionary_with_corsika_configuration(mocker):
     assert corsika_config["showers_per_run"]["type"] is int
 
     assert "run_number_offset" in corsika_config
-    assert "Offset added to run number" in corsika_config["run_number_offset"]["help"]
+    assert "Offset added to each run number" in corsika_config["run_number_offset"]["help"]
     assert corsika_config["run_number_offset"]["type"] is int
     assert corsika_config["run_number_offset"]["default"] == 0
 

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -279,7 +279,6 @@ def test_simulation_model_accepts_exact_layout_selection():
     assert "array_element_list" not in actions
     assert "overwrite_model_parameters" in actions
     assert "ignore_missing_design_model" not in actions
-    assert commandline_parser.preserve_by_version_keys == {"array_layout_name"}
 
 
 def test_simulation_model_adds_ignore_missing_design_model_when_requested():

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -46,6 +46,31 @@ def test_initialize_default_arguments():
     assert "output" in [str(group.title) for group in job_groups]
 
 
+def test_initialize_default_arguments_selects_shared_parameters_and_overrides():
+    commandline_parser = parser.CommandLineParser()
+    commandline_parser.initialize_default_arguments(
+        paths=["output_path"],
+        output=["output_file"],
+        common_arguments={"configuration": ["config"], "execution": ["log_level"]},
+        argument_overrides={"output_file": {"default": "grid.ecsv", "required": False}},
+    )
+
+    actions = {action.dest: action for action in commandline_parser._actions}
+    assert {"output_path", "output_file", "config", "log_level"} <= set(actions)
+    assert "data_path" not in actions
+    assert "output_file_format" not in actions
+    assert "env_file" not in actions
+    assert "activity_id" not in actions
+    assert commandline_parser.parse_args([]).output_file == "grid.ecsv"
+
+
+def test_initialize_default_arguments_rejects_unknown_common_group():
+    commandline_parser = parser.CommandLineParser()
+
+    with pytest.raises(ValueError, match=r"Unknown common argument group.*unknown"):
+        commandline_parser.initialize_default_arguments(common_arguments={"unknown": ["value"]})
+
+
 def test_initialize_default_arguments_accepts_activity_id():
     parser_with_defaults = parser.CommandLineParser()
     parser_with_defaults.initialize_default_arguments()
@@ -239,6 +264,22 @@ def test_layout_parsers():
     )
     assert args.array_layout_name == ["alpha"]
     assert args.array_layout_parameter_file == "array_layouts.json"
+
+
+def test_simulation_model_accepts_exact_layout_selection_without_implicit_arguments():
+    commandline_parser = parser.CommandLineParser()
+    commandline_parser.initialize_default_arguments(
+        simulation_model=["site", "model_version", "array_layout_name"],
+        include_implicit_simulation_model_arguments=False,
+        paths=False,
+        common_arguments={},
+    )
+
+    actions = {action.dest for action in commandline_parser._actions}
+    assert {"site", "model_version", "array_layout_name"} <= actions
+    assert "array_element_list" not in actions
+    assert "overwrite_model_parameters" not in actions
+    assert "ignore_missing_design_model" not in actions
 
 
 def test_simulation_configuration():

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -266,11 +266,10 @@ def test_layout_parsers():
     assert args.array_layout_parameter_file == "array_layouts.json"
 
 
-def test_simulation_model_accepts_exact_layout_selection_without_implicit_arguments():
+def test_simulation_model_accepts_exact_layout_selection():
     commandline_parser = parser.CommandLineParser()
     commandline_parser.initialize_default_arguments(
         simulation_model=["site", "model_version", "array_layout_name"],
-        include_implicit_simulation_model_arguments=False,
         paths=False,
         common_arguments={},
     )
@@ -278,8 +277,22 @@ def test_simulation_model_accepts_exact_layout_selection_without_implicit_argume
     actions = {action.dest for action in commandline_parser._actions}
     assert {"site", "model_version", "array_layout_name"} <= actions
     assert "array_element_list" not in actions
-    assert "overwrite_model_parameters" not in actions
+    assert "overwrite_model_parameters" in actions
     assert "ignore_missing_design_model" not in actions
+    assert commandline_parser.preserve_by_version_keys == {"array_layout_name"}
+
+
+def test_simulation_model_adds_ignore_missing_design_model_when_requested():
+    commandline_parser = parser.CommandLineParser()
+    commandline_parser.initialize_default_arguments(
+        simulation_model=["ignore_missing_design_model"],
+        paths=False,
+        common_arguments={},
+    )
+
+    actions = {action.dest for action in commandline_parser._actions}
+    assert "overwrite_model_parameters" in actions
+    assert "ignore_missing_design_model" in actions
 
 
 def test_simulation_configuration():

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -106,9 +106,12 @@ def test_config_from_file_preserves_selected_by_version_keys(tmp_test_directory)
         yaml.safe_dump(config_dict, output, sort_keys=False)
 
     config_builder = Configurator()
+    config_builder.parser.initialize_default_arguments(
+        simulation_model=["array_layout_name"], paths=False, common_arguments={}
+    )
     loaded_config = config_builder._config_from_file(
         config_file,
-        preserve_by_version_keys=["array_layout_name"],
+        preserve_by_version_keys=config_builder.parser.preserve_by_version_keys,
     )
 
     assert loaded_config["model_version"] == ["6.3.0", "7.0.0"]
@@ -423,7 +426,9 @@ def test_initialize(configurator):
     configurator.parser.initialize_default_arguments.assert_called_once()
     configurator._get_cli_arglist.assert_called_once_with(require_command_line=True)
     configurator._config_from_env.assert_called_once_with(".env")
-    configurator._config_from_file.assert_called_once_with(None)
+    configurator._config_from_file.assert_called_once_with(
+        None, preserve_by_version_keys=configurator.parser.preserve_by_version_keys
+    )
     configurator._fill_config.assert_called_once_with([])
     configurator._initialize_model_versions.assert_called_once()
     configurator._initialize_io_handler.assert_called_once()

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -106,13 +106,7 @@ def test_config_from_file_preserves_selected_by_version_keys(tmp_test_directory)
         yaml.safe_dump(config_dict, output, sort_keys=False)
 
     config_builder = Configurator()
-    config_builder.parser.initialize_default_arguments(
-        simulation_model=["array_layout_name"], paths=False, common_arguments={}
-    )
-    loaded_config = config_builder._config_from_file(
-        config_file,
-        preserve_by_version_keys=config_builder.parser.preserve_by_version_keys,
-    )
+    loaded_config = config_builder._config_from_file(config_file)
 
     assert loaded_config["model_version"] == ["6.3.0", "7.0.0"]
     assert loaded_config["array_layout_name"] == {
@@ -426,9 +420,7 @@ def test_initialize(configurator):
     configurator.parser.initialize_default_arguments.assert_called_once()
     configurator._get_cli_arglist.assert_called_once_with(require_command_line=True)
     configurator._config_from_env.assert_called_once_with(".env")
-    configurator._config_from_file.assert_called_once_with(
-        None, preserve_by_version_keys=configurator.parser.preserve_by_version_keys
-    )
+    configurator._config_from_file.assert_called_once_with(None)
     configurator._fill_config.assert_called_once_with([])
     configurator._initialize_model_versions.assert_called_once()
     configurator._initialize_io_handler.assert_called_once()

--- a/tests/unit_tests/test_application_control.py
+++ b/tests/unit_tests/test_application_control.py
@@ -316,7 +316,7 @@ def test_build_application_parser_uses_definition_help_for_default_arguments():
 
     actions = {action.dest: action for action in parser._actions}  # pylint: disable=protected-access
 
-    assert actions["config"].help == "YAML application configuration file."
+    assert actions["config"].help == "Application configuration file."
     assert not hasattr(actions["config"], "simtools_doc")
     assert not hasattr(actions["output_file"], "simtools_doc")
     assert not hasattr(actions["db_api_user"], "simtools_doc")
@@ -345,19 +345,14 @@ def test_startup_application_basic():
     mock_db_config = {"host": "localhost"}
     mock_parse_function = MagicMock(return_value=(mock_args_dict, mock_db_config))
 
-    # Call startup_application
     app_context = startup_application(mock_parse_function)
-
-    # Verify parse function was called
     mock_parse_function.assert_called_once()
 
-    # Verify returned values
     assert app_context.args == mock_args_dict
     assert app_context.db_config == mock_db_config
     assert isinstance(app_context.logger, logging.Logger)
     assert app_context.io_handler is not None
 
-    # Verify logger level was set
     assert app_context.logger.level == logging.INFO
 
 

--- a/tests/unit_tests/test_application_control.py
+++ b/tests/unit_tests/test_application_control.py
@@ -302,7 +302,6 @@ def test_build_application_parser(mocker, tmp_test_directory):
         db_config=True,
         common_arguments=None,
         argument_overrides=None,
-        include_implicit_simulation_model_arguments=True,
     )
 
 

--- a/tests/unit_tests/test_application_control.py
+++ b/tests/unit_tests/test_application_control.py
@@ -300,6 +300,9 @@ def test_build_application_parser(mocker, tmp_test_directory):
         simulation_model=None,
         simulation_configuration=None,
         db_config=True,
+        common_arguments=None,
+        argument_overrides=None,
+        include_implicit_simulation_model_arguments=True,
     )
 
 
@@ -314,7 +317,7 @@ def test_build_application_parser_uses_definition_help_for_default_arguments():
 
     actions = {action.dest: action for action in parser._actions}  # pylint: disable=protected-access
 
-    assert actions["config"].help == "simtools configuration file"
+    assert actions["config"].help == "YAML application configuration file."
     assert not hasattr(actions["config"], "simtools_doc")
     assert not hasattr(actions["output_file"], "simtools_doc")
     assert not hasattr(actions["db_api_user"], "simtools_doc")

--- a/tests/unit_tests/test_version.py
+++ b/tests/unit_tests/test_version.py
@@ -300,6 +300,15 @@ def test_resolve_by_version_list_inconsistent_raises():
     with pytest.raises(ValueError, match="Inconsistent by_version resolution"):
         version.resolve_by_version(config, ["6.0.2", "7.0.0"])
 
+    assert (
+        version.resolve_by_version(
+            config,
+            ["6.0.2", "7.0.0"],
+            preserve_version_dependent_keys={"array_layout_name"},
+        )
+        == config
+    )
+
 
 def test_is_valid_semantic_version():
     assert version.is_valid_semantic_version("1.0.0")


### PR DESCRIPTION
This is a first step towards a more consistent command line for the simtools applications, meaning that:

- remove irrelevant argument
- improve help messages
- remove duplicated arguments

Add functionality to build_application to:

- allow with `initialization_kwargs` to overwrite default arguments of common arguments (e.g., if an CL argument is needed for an application, but generally not)
- explicit list the arguments to be given (this can be a bit long; not clear if there is a better solution)

