### PR TITLE
SonarQ maintenance

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -146,7 +146,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Download coverage report
         uses: actions/download-artifact@v8
@@ -173,8 +172,6 @@ jobs:
 
       - name: Run Sonar scanner
         id: sonar_scan
-        # Soft fail for draft PRs (unstable network connections)
-        continue-on-error: ${{ github.event.pull_request.draft == true }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -236,22 +233,24 @@ jobs:
             fi
           done
 
-          echo "Sonar scanner failed after 3 attempts."
-          exit 1
+          echo "Sonar scanner failed after 3 attempts due to transient network errors."
+          echo "soft_failed=true" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Report soft-failed Sonar scan
-        if: always() && github.event.pull_request.draft == true && steps.sonar_scan.outcome == 'failure'
+        if: steps.sonar_scan.outputs.soft_failed == 'true'
         run: |
-          echo "::warning::Sonar scan failed but was allowed to continue because this is a draft PR."
+          echo "::warning::Sonar scan could not complete after 3 attempts due to transient network errors."
           {
             echo "## Sonar scan soft failure"
             echo
-            echo "The Sonar scan failed, but the workflow continued because this is a draft PR."
+            echo "The Sonar scan could not complete after 3 attempts because of transient network errors."
+            echo "Quality-gate and non-transient scanner failures still fail the workflow."
             echo "Open the \`Run Sonar scanner\` step logs for details."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload soft-failed Sonar logs
-        if: always() && github.event.pull_request.draft == true && steps.sonar_scan.outcome == 'failure'
+        if: steps.sonar_scan.outputs.soft_failed == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: sonar-scanner-logs

--- a/docs/changes/2372.maintenance.md
+++ b/docs/changes/2372.maintenance.md
@@ -1,0 +1,1 @@
+Improve SonarQube response and indicate soft fails for network errors.


### PR DESCRIPTION
Two items related to SonarQu:

- introduce a 'soft fail' in case of network errors to distinguish between failed Sonar runs and not reachable
- fix mismatch between merge commits and sonar analysis: Unit tests use the default checkout (PR merge commit), 
Sonar explicitly checks out github.event.pull_request.head.sha