### PR TITLE
Run sonarqube on pull request event only

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -130,6 +130,7 @@ jobs:
 
   sonarqube:
     needs: unit_tests
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     env:
       SONAR_SCANNER_VERSION: 8.1.0.6389


### PR DESCRIPTION
Sonarqube fails almost every night when running on main - mostly due to network access issue to DESY.

Disable therefore Sonarqube for anything other than `pull_request` events.