### PR TITLE
Improve integration tests for HDF5 output; improve documentation of write-reduced-event-lists.

### DIFF
--- a/docs/changes/2402.feature.md
+++ b/docs/changes/2402.feature.md
@@ -1,0 +1,2 @@
+Improve integration tests for HDF5 output.
+Improve documentation of write-reduced-event-lists.

--- a/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
+++ b/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
@@ -1,0 +1,28 @@
+# simtools-write-reduced-event-lists
+
+```{eval-rst}
+.. automodule:: write_reduced_event_lists
+   :members:
+   :exclude-members: main
+```
+
+## Overview
+
+The application processes one or more sim_telarray output files (``*.simtel.zst``)
+and writes reduced event lists in HDF5 format. Input files can be given directly
+on the command line or read from a text file and processed in batches.
+
+## Command line arguments
+
+```{eval-rst}
+.. simtools-cli-help::
+   :application: write_reduced_event_lists
+   :no-heading:
+```
+
+## Examples
+
+```{eval-rst}
+.. simtools-integration-example::
+    :file: write_reduced_event_lists.yml
+```

--- a/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
+++ b/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
@@ -8,9 +8,28 @@
 
 ## Overview
 
-The application processes one or more sim_telarray output files (``*.simtel.zst``)
-and writes reduced event lists in HDF5 format. Input files can be given directly
-on the command line or read from a text file and processed in batches.
+The application converts sim_telarray event streams (``*.simtel.zst``) into a
+compact, analysis-oriented HDF5 product. It removes waveform- and pixel-level
+data while retaining the event-level quantities needed for trigger-rate,
+effective-area, and Monte Carlo statistics studies. Input files can be supplied
+directly or through a text file; several input files can be combined into one
+output file.
+
+Each output file contains the following root-level datasets:
+
+- ``SHOWERS``: simulated energy, core position, shower direction, event IDs, and
+  area weights for shower records.
+- ``TRIGGERS``: array pointing and the telescope lists for triggered records.
+- ``FILE_INFO``: one row per input file with file IDs and simulation settings,
+  including particle, energy, viewcone, core-scatter, pointing, and NSB values.
+- ``METADATA``: standard simtools product metadata.
+- ``SIMULATION_METADATA``: versioned provenance for the input files and simulation
+  software.
+
+The ``file_id`` column joins ``SHOWERS`` and ``TRIGGERS`` to ``FILE_INFO``;
+``TRIGGERS`` can contain fewer rows than ``SHOWERS`` because it records only
+triggered events. Tables are stored as HDF5 compound datasets, with physical
+columns carrying their Astropy units.
 
 ## Command line arguments
 

--- a/docs/source/user-guide/applications/simtools-write-reduced-event-lists.rst
+++ b/docs/source/user-guide/applications/simtools-write-reduced-event-lists.rst
@@ -1,6 +1,0 @@
-simtools-write-reduced-event-lists
-==================================
-
-.. automodule:: write_reduced_event_lists
-   :members:
-   :exclude-members: main

--- a/src/simtools/applications/write_reduced_event_lists.py
+++ b/src/simtools/applications/write_reduced_event_lists.py
@@ -1,36 +1,6 @@
 #!/usr/bin/python3
 
-r"""
-Write reduced event lists from sim_telarray output files.
-
-Processes one or more sim_telarray output files and writes reduced event
-lists (HDF5). Input files can be given directly or read from a text file and
-processed in batches.
-
-Command line arguments
-----------------------
-input_files (list of str, optional)
-    One or more sim_telarray output files (e.g., ``*.simtel.zst``).
-input_file_list (str, optional)
-    Text file containing one sim_telarray output file per line.
-files_per_reduced_event_file (int, optional)
-    Number of input files combined into each reduced event file. Defaults to 1.
-max_workers (int, optional)
-    Maximum number of parallel output-file workers.
-output_path (str, optional)
-    Directory for the output files. Defaults to './simtools-output/'.
-
-Example
--------
-Write reduced event lists for a set of sim_telarray output files:
-
-.. code-block:: console
-
-    simtools-write-reduced-event-lists \\
-        --input_files run000001.simtel.zst run000002.simtel.zst \\
-        --output_path /path/to/output/
-
-"""
+"""Write reduced event lists from sim_telarray output files."""
 
 from simtools.application.definition import ApplicationDefinition
 from simtools.configuration import arguments as cli

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -150,6 +150,14 @@ definitions:
               description: |
                 "Expected output of integration test."
               type: object
+            expected_hdf5_datasets:
+              description: "Root-level HDF5 datasets required in the output file."
+              type: array
+              minItems: 1
+              uniqueItems: true
+              items:
+                type: string
+                minLength: 1
           required: ["path_descriptor", "file"]
       file_type:
         description: |

--- a/src/simtools/testing/assertions.py
+++ b/src/simtools/testing/assertions.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 
+import h5py
 import yaml
 
 from simtools.simtel import simtel_output_validator
@@ -44,6 +45,51 @@ def assert_file_type(file_type, file_name):
     # no dedicated tests for other file types, checking suffix only
     _logger.info(f"File type test is checking suffix only for {file_name} (suffix: {file_type}))")
     return Path(file_name).suffix[1:] == file_type
+
+
+def assert_hdf5_datasets(file_name, expected_datasets):
+    """Assert that an HDF5 file contains the requested root datasets.
+
+    Parameters
+    ----------
+    file_name : str or pathlib.Path
+        HDF5 file to inspect.
+    expected_datasets : sequence of str
+        Names of root-level HDF5 datasets that must be present.
+
+    Returns
+    -------
+    bool
+        ``True`` when all requested datasets are present.
+
+    Raises
+    ------
+    AssertionError
+        If a requested item is missing or is not an HDF5 dataset.
+    OSError
+        If ``file_name`` is not a readable HDF5 file.
+    """
+    with h5py.File(file_name, "r") as hdf5_file:
+        missing = []
+        invalid = []
+        for dataset_name in expected_datasets:
+            if dataset_name not in hdf5_file:
+                missing.append(dataset_name)
+            elif not isinstance(hdf5_file[dataset_name], h5py.Dataset):
+                invalid.append(dataset_name)
+
+        if missing or invalid:
+            details = []
+            if missing:
+                details.append(f"missing {missing}")
+            if invalid:
+                details.append(f"not datasets {invalid}")
+            raise AssertionError(
+                f"HDF5 file {file_name} has invalid output structure: "
+                f"{'; '.join(details)}. Available root items: {list(hdf5_file)}"
+            )
+
+    return True
 
 
 def check_output_from_sim_telarray(file, file_test):

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -370,6 +370,10 @@ def _validate_output_path_and_file(config, integration_file_tests):
         ):
             assert assertions.check_log_files(output_file_path, file_test)
         if "expected_hdf5_datasets" in file_test:
+            if output_file_path.suffix.lower() not in (".hdf5", ".h5"):
+                raise AssertionError(
+                    f"expected_hdf5_datasets requires an HDF5 output file, got {output_file_path}."
+                )
             assert assertions.assert_hdf5_datasets(
                 output_file_path, file_test["expected_hdf5_datasets"]
             )

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -369,6 +369,10 @@ def _validate_output_path_and_file(config, integration_file_tests):
             ".log"
         ):
             assert assertions.check_log_files(output_file_path, file_test)
+        if "expected_hdf5_datasets" in file_test:
+            assert assertions.assert_hdf5_datasets(
+                output_file_path, file_test["expected_hdf5_datasets"]
+            )
 
 
 def _validate_model_parameter_json_file(config, model_parameter_validation):

--- a/tests/integration_tests/config/write_reduced_event_lists.yml
+++ b/tests/integration_tests/config/write_reduced_event_lists.yml
@@ -1,12 +1,22 @@
 ---
 applications:
 - application: simtools-write-reduced-event-lists
+  docs:
+    title: Read event data from sim_telarray files and writes reduced event list data.
   configuration:
     input_files:
     - ${generated:proton_run000001_za20deg_azm180deg_North_CTAO-North-Alpha_7.0.0_test.simtel.zst}
     output_path: simtools-output
   integration_tests:
-  - output_file: proton_run000001_za20deg_azm180deg_North_CTAO-North-Alpha_7.0.0_test.reduced_event_data.hdf5
+  - test_output_files:
+    - path_descriptor: output_path
+      file: proton_run000001_za20deg_azm180deg_North_CTAO-North-Alpha_7.0.0_test.reduced_event_data.hdf5
+      expected_hdf5_datasets:
+      - FILE_INFO
+      - METADATA
+      - SHOWERS
+      - SIMULATION_METADATA
+      - TRIGGERS
   test_name: write_reduced_event_lists
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/config/write_reduced_event_lists.yml
+++ b/tests/integration_tests/config/write_reduced_event_lists.yml
@@ -2,7 +2,7 @@
 applications:
 - application: simtools-write-reduced-event-lists
   docs:
-    title: Read event data from sim_telarray files and writes reduced event list data.
+    title: Read event data from sim_telarray files and write reduced event list data.
   configuration:
     input_files:
     - ${generated:proton_run000001_za20deg_azm180deg_North_CTAO-North-Alpha_7.0.0_test.simtel.zst}

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -2,6 +2,7 @@ import gzip
 import logging
 from pathlib import Path
 
+import h5py
 import pytest
 
 from simtools.constants import MODEL_PARAMETER_SCHEMA_PATH
@@ -59,6 +60,30 @@ def test_assert_file_type_others(caplog):
         "File type test is checking suffix only for tests/resources/"
         "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
     )
+
+
+def test_assert_hdf5_datasets(tmp_test_directory):
+    """Require the configured root datasets and allow additional datasets."""
+    output_file = tmp_test_directory / "output.hdf5"
+    with h5py.File(output_file, "w") as hdf5_file:
+        for name in ("FILE_INFO", "METADATA", "SHOWERS"):
+            hdf5_file.create_dataset(name, data=[1])
+        hdf5_file.create_dataset("additional", data=[1])
+
+    assert assertions.assert_hdf5_datasets(output_file, ["FILE_INFO", "METADATA", "SHOWERS"])
+
+    with pytest.raises(AssertionError, match="missing \\['TRIGGERS'\\]"):
+        assertions.assert_hdf5_datasets(output_file, ["TRIGGERS"])
+
+
+def test_assert_hdf5_datasets_rejects_groups(tmp_test_directory):
+    """Reject an HDF5 group when a dataset is required."""
+    output_file = tmp_test_directory / "output.hdf5"
+    with h5py.File(output_file, "w") as hdf5_file:
+        hdf5_file.create_group("METADATA")
+
+    with pytest.raises(AssertionError, match="not datasets \\['METADATA'\\]"):
+        assertions.assert_hdf5_datasets(output_file, ["METADATA"])
 
 
 def test_assert_no_suffix():

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -538,6 +538,25 @@ def test_validate_output_path_and_file_checks_hdf5_datasets(tmp_test_directory, 
     mock_check_hdf5.assert_called_once_with(output_file, file_test["expected_hdf5_datasets"])
 
 
+def test_validate_output_path_and_file_rejects_non_hdf5_dataset_check(tmp_test_directory):
+    """Reject HDF5 dataset checks for outputs with a non-HDF5 suffix."""
+    output_file = Path(str(tmp_test_directory)) / "output.simtel.zst"
+    output_file.touch()
+    file_test = {
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "expected_hdf5_datasets": ["FILE_INFO"],
+    }
+
+    with pytest.raises(
+        AssertionError,
+        match="expected_hdf5_datasets requires an HDF5 output file",
+    ):
+        validate_output._validate_output_path_and_file(
+            {"configuration": {"output_path": str(tmp_test_directory)}}, [file_test]
+        )
+
+
 def test_compare_simtel_cfg_files(tmp_test_directory):
     file1 = Path(f"{TEST_RESOURCES_GENERATED}/sim_telarray_configurations/7.0.0/CTAO-LSTN-01.cfg")
     file2 = Path(f"{TEST_RESOURCES_GENERATED}/sim_telarray_configurations/7.0.0/CTAO-LSTN-01.cfg")

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -518,6 +518,26 @@ def test_validate_application_output_with_file_type(
     )
 
 
+def test_validate_output_path_and_file_checks_hdf5_datasets(tmp_test_directory, mocker):
+    """Run declarative HDF5 dataset checks for a configured output file."""
+    output_file = Path(str(tmp_test_directory)) / "output.hdf5"
+    output_file.touch()
+    mock_check_hdf5 = mocker.patch(
+        "simtools.testing.assertions.assert_hdf5_datasets", return_value=True
+    )
+    file_test = {
+        "path_descriptor": "output_path",
+        "file": output_file.name,
+        "expected_hdf5_datasets": ["FILE_INFO", "METADATA"],
+    }
+
+    validate_output._validate_output_path_and_file(
+        {"configuration": {"output_path": str(tmp_test_directory)}}, [file_test]
+    )
+
+    mock_check_hdf5.assert_called_once_with(output_file, file_test["expected_hdf5_datasets"])
+
+
 def test_compare_simtel_cfg_files(tmp_test_directory):
     file1 = Path(f"{TEST_RESOURCES_GENERATED}/sim_telarray_configurations/7.0.0/CTAO-LSTN-01.cfg")
     file2 = Path(f"{TEST_RESOURCES_GENERATED}/sim_telarray_configurations/7.0.0/CTAO-LSTN-01.cfg")


### PR DESCRIPTION
Improves `simtools-write-reduced-event-lists`:

- documentation improvement
- add tests of on HDF5 file to ensure that expected root entries are available when running integration tests.